### PR TITLE
Release eslint-plugin-adeira

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {},
   "devDependencies": {
     "@adeira/babel-preset-adeira": "^0.1.0",
-    "@adeira/eslint-config": "^0.1.0",
+    "@adeira/eslint-config": "^0.2.0",
     "@adeira/flow-bin": "^0.1.0",
     "@babel/core": "^7.7.2",
     "babel-eslint": "^10.0.3",

--- a/scripts/publishNPMPackages.js
+++ b/scripts/publishNPMPackages.js
@@ -33,6 +33,7 @@ import { invariant } from '@adeira/js';
       '@adeira/eslint-config',
       '@adeira/graphql-global-id',
       '@adeira/graphql-bc-checker',
+      'eslint-plugin-adeira',
     ]),
   });
 })();

--- a/src/eslint-config-adeira/CHANGELOG.md
+++ b/src/eslint-config-adeira/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
 
+# 0.2.0
+
 - Remove `eslint-plugin-react-native`
-- Move rules from `eslint-plugin-relay-imports` under this package
+
 ---
 
 Changelog before our fork:

--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/eslint-config-adeira",
   "license": "MIT",
   "private": false,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "index",
   "sideEffects": false,
   "dependencies": {

--- a/src/eslint-plugin-adeira/package.json
+++ b/src/eslint-plugin-adeira/package.json
@@ -1,9 +1,9 @@
 {
   "name": "eslint-plugin-adeira",
   "description": "Additional Eslint rules for Adeira projects. Do not use directly - use @adeira/eslint-config instead.",
-  "homepage": "https://github.com/adeira/universe/tree/master/src/eslint-plugin-adeira-incubator",
+  "homepage": "https://github.com/adeira/universe/tree/master/src/eslint-plugin-adeira",
   "license": "MIT",
-  "private": true,
+  "private": false,
   "version": "0.1.0",
   "main": "src/index",
   "sideEffects": false,

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@adeira/babel-preset-adeira": "^0.1.0",
-    "@adeira/eslint-config": "^0.1.0",
+    "@adeira/eslint-config": "^0.2.0",
     "@adeira/test-utils": "^0.1.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.6.0",


### PR DESCRIPTION
These packages are needed by `@adeira/eslint-config`

Release `@adeira/eslint-config` version `0.2.0`