### PR TITLE
Flow: move the whole 'node_modules' under declarations

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -11,10 +11,7 @@
 
 ; https://flow.org/en/docs/config/declarations/
 [declarations]
-.+/node_modules/dataloader/.+
-.+/node_modules/graphql-iso-date/dist/.+
-.+/node_modules/graphql-relay/lib/connection/connection.js
-.+/node_modules/graphql/utilities/extendSchema.js
+.+/node_modules/.+
 
 
 ; https://flow.org/en/docs/config/libs/
@@ -99,7 +96,6 @@ experimental.well_formed_exports.whitelist=<PROJECT_ROOT>/src/babel-preset-adeir
 experimental.well_formed_exports.whitelist=<PROJECT_ROOT>/src/eslint-config-adeira
 experimental.well_formed_exports.whitelist=<PROJECT_ROOT>/src/eslint-plugin-adeira
 experimental.well_formed_exports.whitelist=<PROJECT_ROOT>/src/eslint-plugin-graphql-fragments
-experimental.well_formed_exports.whitelist=<PROJECT_ROOT>/src/eslint-plugin-relay-imports
 experimental.well_formed_exports.whitelist=<PROJECT_ROOT>/src/fetch
 experimental.well_formed_exports.whitelist=<PROJECT_ROOT>/src/flow-bin
 experimental.well_formed_exports.whitelist=<PROJECT_ROOT>/src/graphql-bc-checker


### PR DESCRIPTION
I asked about this directly Flow developers from FB and they responded like this:

> We do that internally, and I would recommend you do it too!

Other developers also confirmed it works fine. Source: https://discordapp.com/channels/539606376339734558/539915538550226954/643493126035603496