### PR TITLE
Typescript support for graphql-global-id

### DIFF
--- a/src/graphql-global-id/README.md
+++ b/src/graphql-global-id/README.md
@@ -78,3 +78,7 @@ It is possible to fetch both ID versions at the same time in GraphQL:
 ```
 
 This is handy especially when you are migrating old code to this new type. Just change something like deprecated `databaseID` to `databaseID: id(opaque: false)` and that's it.
+
+# Types support
+
+This package includes types for Flow and Typescript.

--- a/src/graphql-global-id/package.json
+++ b/src/graphql-global-id/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/graphql-global-id",
   "license": "MIT",
   "private": false,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/GlobalID",
   "sideEffects": false,
   "dependencies": {

--- a/src/graphql-global-id/src/GlobalID.d.ts
+++ b/src/graphql-global-id/src/GlobalID.d.ts
@@ -1,0 +1,12 @@
+import { GraphQLFieldConfig, GraphQLResolveInfo } from 'graphql';
+
+export function fromGlobalId(opaqueID: string): string;
+
+export function __isTypeOf(type: string, opaqueID: string): boolean;
+
+type FetchFnType = (object: any, context: any, info: GraphQLResolveInfo) => string | number;
+
+export default function globalIdField(
+  idFetcher: FetchFnType,
+  unmaskedIdFetcher?: FetchFnType,
+): GraphQLFieldConfig<any, any>;


### PR DESCRIPTION
First steps forward TS support. I just hope NPM publisher includes `.d.ts` file automatically :-) 