### PR TITLE
Relay: expose language plugins interface

### DIFF
--- a/src/relay/CHANGELOG.md
+++ b/src/relay/CHANGELOG.md
@@ -1,18 +1,12 @@
 # Unreleased
 
-# 0.3.0
-
-- Use `console.warn` instead of `console.error` in `createRequestHandler`, since the first causes crash on `react-native`
-
-# 0.2.0
-- rename `kiwicom-fetch-schema` -> `adeira-fetch-schema`
-- rename `kiwicom-relay-compiler` -> `adeira-relay-compiler`
+TODO: release stable versions
 
 ---
 
 Changelog before our fork:
 
-```text
+````text
 # Unreleased
 
 This is a **breaking** release!
@@ -156,4 +150,4 @@ module.exports = {
 
 - `Disposable` Flow type exposed publicly
 - `Environment` (incomplete) Flow type exposed publicly
-```
+````

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adeira/relay",
   "private": false,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "src/index",
   "module": false,
   "sideEffects": false,
@@ -28,6 +28,7 @@
     "is-ci": "^2.0.0",
     "react-relay": "^7.1.0",
     "relay-compiler": "^7.1.0",
+    "relay-compiler-language-typescript": "^10.1.1",
     "relay-config": "^7.1.0",
     "relay-runtime": "^7.1.0"
   },

--- a/src/relay/src/compiler/buildLanguagePlugin.js
+++ b/src/relay/src/compiler/buildLanguagePlugin.js
@@ -2,15 +2,22 @@
 
 import { FlowGenerator } from 'relay-compiler';
 import { find } from 'relay-compiler/lib/language/javascript/FindGraphQLTags'; // TODO: better (?)
+import TypescriptPluginFactory from 'relay-compiler-language-typescript';
 
 import formatGeneratedModule from './formatGeneratedModule';
 
-export default function buildLanguagePlugin() {
-  return {
-    inputExtensions: ['js', 'jsx'],
-    outputExtension: 'js',
-    typeGenerator: FlowGenerator,
-    formatModule: formatGeneratedModule,
-    findGraphQLTags: find,
-  };
+export default function buildLanguagePlugin(language: 'javascript' | 'typescript') {
+  if (language === 'typescript') {
+    return TypescriptPluginFactory();
+  } else if (language === 'javascript') {
+    return {
+      inputExtensions: ['js', 'jsx'],
+      outputExtension: 'js',
+      typeGenerator: FlowGenerator,
+      formatModule: formatGeneratedModule,
+      findGraphQLTags: find,
+    };
+  }
+
+  throw new Error(`Language '${(language: empty)}' is not supported.`);
 }

--- a/src/relay/src/compiler/index.js
+++ b/src/relay/src/compiler/index.js
@@ -23,6 +23,7 @@ type ExternalOptions = {|
   +exclude: $ReadOnlyArray<string>,
   +validate: boolean,
   +watch: boolean,
+  +language: 'javascript' | 'typescript', // TODO: detect this automatically based on tsconfig.json file?
 |};
 
 const {
@@ -36,13 +37,15 @@ const {
 
 export default async function compiler(externalOptions: ExternalOptions) {
   const options = {
+    // defaults
     noFutureProofEnums: false,
     artifactDirectory: null,
+    language: 'javascript',
     ...externalOptions,
   };
 
   const reporter = new ConsoleReporter({ verbose: true });
-  const languagePlugin = buildLanguagePlugin();
+  const languagePlugin = buildLanguagePlugin(options.language);
   const srcDir = path.resolve(process.cwd(), options.src);
   const schemaPath = path.resolve(process.cwd(), options.schema);
   const schema = getSchemaSource(schemaPath);
@@ -89,7 +92,8 @@ export default async function compiler(externalOptions: ExternalOptions) {
         options.persistMode,
       ),
       isGeneratedFile: (filePath: string) =>
-        filePath.endsWith('.graphql.js') && filePath.includes('__generated__'),
+        filePath.endsWith(`.graphql.${languagePlugin.outputExtension}`) &&
+        filePath.includes('__generated__'),
       parser: sourceParserName,
       baseParsers: ['graphql'],
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6017,6 +6017,11 @@ immer@1.10.0:
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
   integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
 
+immutable@^4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
+  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
+
 immutable@~3.7.6:
   version "3.7.6"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
@@ -10242,6 +10247,14 @@ regjsparser@^0.6.0:
   integrity sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==
   dependencies:
     jsesc "~0.5.0"
+
+relay-compiler-language-typescript@^10.1.1:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/relay-compiler-language-typescript/-/relay-compiler-language-typescript-10.1.1.tgz#64dda4328964854bf0f9bd790531e2d94ed51871"
+  integrity sha512-M8VP+Yv/CPX2CPI0ZRYgFe/zoP4zryoA9RAqmcHfhMS04qfs4ZOCXDuEZzVBooWcuO/MQ9Ufy9Fyxpv9U54kXA==
+  dependencies:
+    immutable "^4.0.0-rc.12"
+    invariant "^2.2.4"
 
 relay-compiler@^7.1.0:
   version "7.1.0"


### PR DESCRIPTION
This exposes public interface for changing the language plugin. Currently, people are mostly interested in 'javascript' or 'typescript' languages so I added support only for these two. Javascript is and will stay as a default.