### PR TITLE
Relay CLI: remove include/exclude options

### DIFF
--- a/src/relay/bin/relay-compiler.js
+++ b/src/relay/bin/relay-compiler.js
@@ -16,25 +16,11 @@ const RelayConfig = require('relay-config');
 
 const compiler = require('../src/compiler').default;
 
-const collectPaths = value => {
-  return value.split(',');
-};
-
-// Please note: try not to extend this CLI if possible. Always prefer "relay.config.js" file.
 program
+  // Please note: try not to extend this CLI if possible. Always prefer "relay.config.js" file.
   .option('--src <src>')
   .option('--schema <schema>')
   .option('--persist-mode <fs|remote>')
-  .option('--include <include>', 'Comma separated list of directories to include.', collectPaths, [
-    '**',
-  ])
-  .option('--exclude <exclude>', 'Comma separated list of directories to ignore.', collectPaths, [
-    // allowed in __tests__
-    '**/__flowtests__/**',
-    '**/__generated__/**',
-    '**/__mocks__/**',
-    '**/node_modules/**',
-  ])
   .option('--validate', 'Activates validate only mode', false)
   .option(
     '--watch',
@@ -49,8 +35,6 @@ const config = {
   persistMode: program.persistMode,
   validate: program.validate,
   watch: program.watch,
-  include: program.include,
-  exclude: program.exclude,
   ...RelayConfig.loadConfig(),
 };
 

--- a/src/relay/src/compiler/index.js
+++ b/src/relay/src/compiler/index.js
@@ -19,8 +19,6 @@ type ExternalOptions = {|
   +src: string,
   +schema: string,
   +persistMode: 'fs', // TODO consider more generic: +persistFunction?: ?(query: string) => Promise<string>,
-  +include: $ReadOnlyArray<string>,
-  +exclude: $ReadOnlyArray<string>,
   +validate: boolean,
   +watch: boolean,
   +language: 'javascript' | 'typescript', // TODO: detect this automatically based on tsconfig.json file?
@@ -40,6 +38,14 @@ export default async function compiler(externalOptions: ExternalOptions) {
     // defaults
     noFutureProofEnums: false,
     artifactDirectory: null,
+    exclude: [
+      // allowed in __tests__
+      '**/__flowtests__/**',
+      '**/__generated__/**',
+      '**/__mocks__/**',
+      '**/node_modules/**',
+    ],
+    include: ['**'],
     language: 'javascript',
     ...externalOptions,
   };


### PR DESCRIPTION
These options were added because of one legacy project which we don't have under control anymore. It was to enable multiple schemas in the same repository which is highly discouraged.