### PR TITLE
Fix shouldLintAll regex

### DIFF
--- a/src/eslint-config-adeira/runner/__tests__/shouldLintAll.test.js
+++ b/src/eslint-config-adeira/runner/__tests__/shouldLintAll.test.js
@@ -14,7 +14,6 @@ test.each([
   'src/packages/relay/package.json',
   '/Users/code/universe/src/packages/relay/package.json',
   '.eslintignore',
-  '/Users/code/universe/src/packages/relay/.eslintignore',
 ])('filename "%s" IS eslint config file', filename => {
   expect(shouldLintAll(filename)).toBe(true);
 });
@@ -25,7 +24,7 @@ test.each([
   '.eslintrc.jsonp',
   '.eslintrc/xyz',
   'src/.eslintrc/test',
-  'src/test/.eslintignore/test',
+  'src/test/.eslintignore',
 ])('filename "%s" IS NOT eslint config file', filename => {
   expect(shouldLintAll(filename)).toBe(false);
 });

--- a/src/eslint-config-adeira/runner/shouldLintAll.js
+++ b/src/eslint-config-adeira/runner/shouldLintAll.js
@@ -3,5 +3,5 @@
 export default function shouldLintAll(filename: string): boolean %checks {
   // Eslint configs can be nested (not only the root path).
   // See: https://eslint.org/docs/user-guide/configuring#configuration-file-formats
-  return /\.eslintrc(?:\.(?:js(?:on)?|ya?ml))?$|package.json$|.eslintignore$/.test(filename);
+  return /\.eslintrc(?:\.(?:js(?:on)?|ya?ml))?$|package\.json$|^\.eslintignore$/.test(filename);
 }


### PR DESCRIPTION
Only .eslintignore in root works, so only lint all
if that file is changed. Ignore other files called .eslintigore