### PR TITLE
Add option to pass logger when creating environment

### DIFF
--- a/src/example-relay/next.config.js
+++ b/src/example-relay/next.config.js
@@ -11,6 +11,7 @@ module.exports = withCustomBabelConfigFile(
       // @x-shipit-enable: 'babel.config.js',
       '.babelrc', // @x-shipit-disable
     ),
-    transpileModules: ['@adeira'],
+    // @kiwicom/orbit-components is using `@adeira/js`, and needs to be  tranpiled as well because of this
+    transpileModules: ['@adeira', '@kiwicom'],
   }),
 );

--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@adeira/fetch": "^1.0.0",
-    "@adeira/relay": "^0.5.0",
+    "@adeira/relay": "^0.6.0",
     "@kiwicom/orbit-components": "^0.68.0",
     "date-fns": "^2.8.1",
     "next": "^9.1.4",

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adeira/relay",
   "private": false,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "src/index",
   "module": false,
   "sideEffects": false,

--- a/src/relay/src/createEnvironment.js
+++ b/src/relay/src/createEnvironment.js
@@ -2,7 +2,7 @@
 
 import { Network, Environment as RelayEnvironment, ConnectionHandler } from 'relay-runtime';
 
-import RelayLogger from './RelayLogger';
+import RelayLogger, { type LogEvent } from './RelayLogger';
 import createRequestHandler from './createRequestHandler';
 import createRelayStore from './createRelayStore';
 import type { Environment, RecordMap } from './runtimeTypes.flow';
@@ -17,6 +17,7 @@ type Options = {|
     load: string => Promise<?NormalizationSplitOperation>,
   |},
   +records?: ?RecordMap,
+  +logger?: (LogEvent => void) | null,
 |};
 
 type NormalizationSplitOperation = {|
@@ -43,11 +44,11 @@ function handlerProvider(handle) {
 }
 
 export default function createEnvironment(options: Options): Environment {
-  const { fetchFn, subscribeFn, records, ...rest } = options;
+  const { fetchFn, subscribeFn, records, logger, ...rest } = options;
   return new RelayEnvironment({
     handlerProvider,
     network: createNetwork(fetchFn, subscribeFn),
-    log: RelayLogger,
+    log: logger === undefined ? RelayLogger : logger, // Use default if no option is sent, but allow user to overwrite it
     store: createRelayStore(records),
     ...rest,
   });


### PR DESCRIPTION
Especially when debugging things on the server, the logging of the fragments and response is just noise. It would be nice to easily deactivate the logger in these cases by passing null. 