### PR TITLE
Relay: do not enforce project wide configuration

### DIFF
--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@adeira/fetch": "^1.0.0",
-    "@adeira/relay": "^0.5.0",
+    "@adeira/relay": "^0.6.0",
     "@adeira/js": "^0.2.0",
     "@kiwicom/orbit-components": "^0.68.0",
     "date-fns": "^2.8.1",

--- a/src/relay/bin/fetch-schema.js
+++ b/src/relay/bin/fetch-schema.js
@@ -6,7 +6,7 @@
 // This is here to make this `bin` available directly from our monorepo without transpiling it.
 require('@babel/register')({
   ignore: [/node_modules\/(?!@adeira)/],
-  rootMode: 'upward',
+  rootMode: 'upward-optional',
 });
 
 const fs = require('fs');

--- a/src/relay/bin/relay-compiler.js
+++ b/src/relay/bin/relay-compiler.js
@@ -6,7 +6,7 @@
 // This is here to make this `bin` available directly from our monorepo without transpiling it.
 require('@babel/register')({
   ignore: [/node_modules\/(?!@adeira)/],
-  rootMode: 'upward',
+  rootMode: 'upward-optional',
 });
 
 const program = require('commander');

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adeira/relay",
   "private": false,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "src/index",
   "module": false,
   "sideEffects": false,


### PR DESCRIPTION
This feature was requested here https://github.com/adeira/universe/issues/189 and was greatly improved in Babel itself here https://github.com/babel/babel/pull/10778. It can however be annoying and sometimes difficult to do such modification so I changed my mind and I'd like to allow it after all. It's because this code where we require "upward" mode is necessary only for Universe development and should not affect users of our NPM package.