### PR TITLE
shipit: Remove non-existing ".github" dir from "relay-example" config

### DIFF
--- a/src/monorepo-shipit/config/__tests__/example-relay.test.js
+++ b/src/monorepo-shipit/config/__tests__/example-relay.test.js
@@ -12,10 +12,6 @@ testExportedPaths(path.join(__dirname, '..', 'example-relay.js'), [
   ['src/example-relay/__github__/.flowconfig', '.flowconfig'],
   ['src/example-relay/__github__/babel.config.js', 'babel.config.js'],
   ['src/example-relay/__github__/flow-typed/globals.js', 'flow-typed/globals.js'],
-  [
-    'src/example-relay/__github__/.github/workflows/continuous-integration.yml',
-    '.github/workflows/continuous-integration.yml',
-  ],
   ['src/example-relay/.babelrc.js', undefined], // correctly deleted
 
   // invalid cases:

--- a/src/monorepo-shipit/config/example-relay.js
+++ b/src/monorepo-shipit/config/example-relay.js
@@ -12,7 +12,6 @@ module.exports = {
       ['src/example-relay/__github__/babel.config.js', 'babel.config.js'],
       ['src/example-relay/__github__/jest.config.js', 'jest.config.js'],
       ['src/example-relay/__github__/flow-typed', 'flow-typed'],
-      ['src/example-relay/__github__/.github/', '.github/'],
       ['src/example-relay/', ''],
     ]);
   },


### PR DESCRIPTION
Relay-example is not updated for last weeks because `.github` dir does not exist yet. 

We can always put it back but now it's better to keep repositories in sync.