### PR TITLE
graphql-global-id: toGlobalId function added

### DIFF
--- a/src/graphql-global-id/package.json
+++ b/src/graphql-global-id/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/graphql-global-id",
   "license": "MIT",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "src/GlobalID",
   "sideEffects": false,
   "dependencies": {

--- a/src/graphql-global-id/src/GlobalID.d.ts
+++ b/src/graphql-global-id/src/GlobalID.d.ts
@@ -2,6 +2,8 @@ import { GraphQLFieldConfig, GraphQLResolveInfo } from 'graphql';
 
 export function fromGlobalId(opaqueID: string): string;
 
+export function toGlobalId(type: string, id: string | number): string;
+
 export function __isTypeOf(type: string, opaqueID: string): boolean;
 
 type FetchFnType = (object: any, context: any, info: GraphQLResolveInfo) => string | number;

--- a/src/graphql-global-id/src/GlobalID.js
+++ b/src/graphql-global-id/src/GlobalID.js
@@ -32,6 +32,10 @@ export function fromGlobalId(opaqueID: string): string {
   return unbasedGlobalID.substring(delimiterPos + 1);
 }
 
+export function toGlobalId(type: string, id: string | number): string {
+  return base64(`${type}:${id}`);
+}
+
 // TODO: find out better way how to do it (type should be just an internal detail - see evaluateGlobalIdField)
 export function __isTypeOf(type: string, opaqueID: string): boolean {
   const unbasedGlobalID = unbase64(opaqueID);
@@ -119,7 +123,7 @@ export default function globalIdField(
 
       if (args.opaque === true) {
         // this should always be the default in our system
-        return base64([info.parentType.name, id].join(':'));
+        return toGlobalId(info.parentType.name, id);
       }
 
       return unmaskedIdFetcher ? unmaskedIdFetcher(obj, context, info) : id;

--- a/src/graphql-global-id/src/__tests__/GlobalID.test.js
+++ b/src/graphql-global-id/src/__tests__/GlobalID.test.js
@@ -3,7 +3,7 @@
 import { GraphQLObjectType, GraphQLID } from 'graphql';
 import { nullthrows } from '@adeira/js';
 
-import GlobalID, { fromGlobalId, evaluateGlobalIdField, __isTypeOf } from '../GlobalID';
+import GlobalID, { fromGlobalId, evaluateGlobalIdField, __isTypeOf, toGlobalId } from '../GlobalID';
 
 function base64(text) {
   return Buffer.from(text).toString('base64');
@@ -138,6 +138,18 @@ describe('fromGlobalId', () => {
     expect(() => fromGlobalId('aW52YWxpZC12YWx1ZQ==')).toThrow(
       "ID 'aW52YWxpZC12YWx1ZQ==' is not valid opaque value.",
     );
+  });
+});
+
+describe('toGlobalId', () => {
+  it.each([
+    ['SomeType', 'abc'],
+    ['AnotherType', 123],
+  ])('works with string or numeric id', (type, id) => {
+    const globalId = toGlobalId(type, id);
+
+    expect(fromGlobalId(globalId)).toBe(id.toString());
+    expect(__isTypeOf(type, globalId)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Added `toGlobalId` to it's possible to create global ID not only in `GraphQLObjectType` field.