### PR TITLE
Eslint-config: Allow to disable automatic fixes

### DIFF
--- a/src/eslint-config-adeira/README.md
+++ b/src/eslint-config-adeira/README.md
@@ -78,7 +78,7 @@ It is of course possible to run this lint as yet another Jest project (using `op
 
 It tries to detect files to lint because it's highly inefficient to test all the files everytime. However, you can do so by using `--all` flag like so: `yarn run lint --all`.
 
-Please note: this Eslint runner not only runs all the tests much faster but it also performs automatic fixes. This is currently no-opt.
+Please note: this Eslint runner not only runs all the tests much faster but if it's not executed in CI environment, it also performs automatic fixes by default. You can opt-out by `--no-fix` flag: `yarn run lint --no-fix`.
 
 ## Tip
 

--- a/src/eslint-config-adeira/runner/index.js
+++ b/src/eslint-config-adeira/runner/index.js
@@ -12,6 +12,7 @@ module.exports = (createJestRunner(require.resolve('./run'), {
   getExtraOptions: () => {
     return {
       runAll: externalConfig.includes('--all'),
+      noFixes: externalConfig.includes('--no-fix'),
     };
   },
 }) /*: any */);

--- a/src/eslint-config-adeira/runner/run.js
+++ b/src/eslint-config-adeira/runner/run.js
@@ -10,12 +10,6 @@ const { Git } = require('@adeira/monorepo-utils');
 const formatter = require('./stylish');
 const shouldLintAll = require('./shouldLintAll').default;
 
-const PERFORM_FIXES = isCI === false;
-const cliEngine = new CLIEngine({
-  fix: PERFORM_FIXES,
-  reportUnusedDisableDirectives: true,
-});
-
 /*::
 
 type Options = {|
@@ -24,6 +18,7 @@ type Options = {|
   +globalConfig: { [key: string]: any, ... },
   +extraOptions: {|
     +runAll: boolean,
+    +noFixes: boolean,
   |}
 |}
 
@@ -36,6 +31,12 @@ const changedFiles = Git.getChangesToTest();
 
 module.exports = ({ testPath, extraOptions } /*: Options */) /*: { +[string]: mixed, ... } */ => {
   const start = Date.now();
+
+  const performFixes = (isCI || extraOptions.noFixes) === false;
+  const cliEngine = new CLIEngine({
+    fix: performFixes,
+    reportUnusedDisableDirectives: true,
+  });
 
   let runAll = extraOptions.runAll;
   for (const changedFile of changedFiles) {
@@ -69,7 +70,7 @@ module.exports = ({ testPath, extraOptions } /*: Options */) /*: { +[string]: mi
   }
 
   const report = cliEngine.executeOnFiles([testPath]);
-  if (PERFORM_FIXES) {
+  if (performFixes) {
     CLIEngine.outputFixes(report);
   }
 


### PR DESCRIPTION
Reasoning:

I like the way how eslint runner is opinionated yet I would like to have an option to change default behavior e.g. when adopting this tool on a large codebase which is too broken.