### PR TITLE
relay: Mock "console.groupCollapsed" in unit tests

### DIFF
--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -47,7 +47,7 @@ const isSpy = (spy: MaybeSpy): boolean %checks => {
 };
 
 // TODO: .toWarnDev() ?
-['error', 'warn', 'log'].forEach(methodName => {
+['error', 'warn', 'log', 'info', 'groupCollapsed'].forEach(methodName => {
   const unexpectedConsoleCallStacks = [];
   const newMethod = function(format, ...args) {
     const stack = new Error().stack;

--- a/src/relay/src/__tests__/RelayLogger.test.js
+++ b/src/relay/src/__tests__/RelayLogger.test.js
@@ -5,14 +5,17 @@
 
 import Logger from '../RelayLogger';
 
-let spy;
+let log;
+let groupCollapsed;
 
 beforeEach(() => {
-  spy = jest.spyOn(console, 'log').mockImplementation(jest.fn());
+  log = jest.spyOn(console, 'log').mockImplementation(jest.fn());
+  groupCollapsed = jest.spyOn(console, 'groupCollapsed').mockImplementation(jest.fn());
 });
 
 afterEach(() => {
-  spy.mockRestore();
+  log.mockRestore();
+  groupCollapsed.mockRestore();
 });
 
 it('logs in browser', () => {
@@ -27,5 +30,6 @@ it('logs in browser', () => {
     variables: {},
   });
 
-  expect(spy).toHaveBeenCalledTimes(2);
+  expect(log).toHaveBeenCalledTimes(2);
+  expect(groupCollapsed).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
do not accidentally output calls to `console.groupCollapsed` when running unit tests:

<img width="796" alt="Screenshot 2019-12-26 22 57 28" src="https://user-images.githubusercontent.com/2174629/71491970-2f962180-2834-11ea-9617-550bc8f25046.png">
