### PR TITLE
relay-utils: Add "getDataByTypename" for convenient work with unions

### DIFF
--- a/src/relay-utils/README.md
+++ b/src/relay-utils/README.md
@@ -2,7 +2,9 @@ This package contains relay utility functions used in the Adeira ecosystem.
 
 ## Install
 
-- yarn add @adeira/relay-utils
+```
+yarn add @adeira/relay-utils
+```
 
 ## Usage
 

--- a/src/relay-utils/src/__flowtests__/getDataByTypename.js
+++ b/src/relay-utils/src/__flowtests__/getDataByTypename.js
@@ -1,0 +1,32 @@
+// @flow strict
+
+import getDataByTypename from '../getDataByTypename';
+
+module.exports = {
+  validUsage() {
+    type Data = ?(
+      | {|
+          +__typename: 'Error',
+          +code: number,
+        |}
+      | {|
+          +__typename: 'Person',
+          +name: string,
+        |}
+      | {|
+          +__typename: '%other',
+        |}
+    );
+    const personOrError: Data = { name: 'Joe', __typename: 'Person' };
+
+    const { Error, Person } = getDataByTypename(personOrError);
+
+    if (Person) {
+      // eslint-disable-next-line no-unused-vars
+      const hello = `Hello ${Person.name}`;
+    } else if (Error) {
+      // eslint-disable-next-line no-unused-vars
+      const error = `Error: ${Error.code}`;
+    }
+  },
+};

--- a/src/relay-utils/src/getDataByTypename.js
+++ b/src/relay-utils/src/getDataByTypename.js
@@ -1,0 +1,5 @@
+// @flow strict
+
+const getDataByTypename = data => (data?.__typename != null ? { [data.__typename]: data } : {});
+
+export default getDataByTypename;

--- a/src/relay-utils/src/index.js
+++ b/src/relay-utils/src/index.js
@@ -1,3 +1,4 @@
 // @flow
 
+export { default as getDataByTypename } from './getDataByTypename';
 export { default as getDataFromRequest } from './getDataFromRequest';


### PR DESCRIPTION
`getDataByTypename` to "destructure" union types

Inspiration here: https://github.com/artsy/artsy.github.io/issues/495#issuecomment-509697859