### PR TITLE
WIP: relay-compiler: Add transform fn to warn against usage of deprecated fields

### DIFF
--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -39,13 +39,15 @@
     "babel-eslint": "^10.0.3",
     "eslint": "^6.8.0",
     "flow-bin": "^0.114.0",
+    "graphql": "^14.5.8",
     "jest": "^24.9.0",
     "react": "^16.12.0",
     "react-test-renderer": "^16.12.0",
-    "relay-test-utils": "^8.0.0"
+    "relay-test-utils": "^8.0.0",
+    "relay-test-utils-internal": "^8.0.0"
   },
   "peerDependencies": {
-    "graphql": "^14.5.6",
+    "graphql": "^14.5.8",
     "react": "^16.9.0"
   }
 }

--- a/src/relay/src/compiler/transforms/__tests__/__fixtures__/TestSchema.graphql
+++ b/src/relay/src/compiler/transforms/__tests__/__fixtures__/TestSchema.graphql
@@ -1,0 +1,14 @@
+schema {
+  query: Query
+}
+
+type Query {
+  me: User
+  node(id: ID): Node
+}
+
+type User implements Node {
+  firstName: String
+  lastName: String
+  surname: String @deprecated(reason: "Use \"lastName\" field instead.")
+}

--- a/src/relay/src/compiler/transforms/__tests__/__fixtures__/TestSchema.js
+++ b/src/relay/src/compiler/transforms/__tests__/__fixtures__/TestSchema.js
@@ -1,0 +1,10 @@
+// @flow
+
+import fs from 'fs';
+import { Source, type SchemaDefinitionNode } from 'graphql';
+import { Schema } from 'relay-compiler';
+
+const testSchemaPath = `${__dirname}/TestSchema.graphql`;
+const TestSchema: SchemaDefinitionNode = Schema.create(new Source(fs.readFileSync(testSchemaPath, 'utf8')));
+
+export default TestSchema;

--- a/src/relay/src/compiler/transforms/__tests__/__fixtures__/disallowDeprecatedFields/ExampleQuery.invalid.graphql
+++ b/src/relay/src/compiler/transforms/__tests__/__fixtures__/disallowDeprecatedFields/ExampleQuery.invalid.graphql
@@ -1,0 +1,6 @@
+query ExampleQueryInvalid {
+  me {
+    firstName
+    surname
+  }
+}

--- a/src/relay/src/compiler/transforms/__tests__/__fixtures__/disallowDeprecatedFields/ExampleQuery.valid.graphql
+++ b/src/relay/src/compiler/transforms/__tests__/__fixtures__/disallowDeprecatedFields/ExampleQuery.valid.graphql
@@ -1,0 +1,6 @@
+query ExampleQueryValid {
+  me {
+    firstName
+    lastName
+  }
+}

--- a/src/relay/src/compiler/transforms/__tests__/__snapshots__/disallowDeprecatedFields.test.js.snap
+++ b/src/relay/src/compiler/transforms/__tests__/__snapshots__/disallowDeprecatedFields.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`matches expected output: ExampleQuery.invalid.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+query ExampleQueryInvalid {
+  me {
+    firstName
+    surname
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+query ExampleQueryInvalid {
+  me {
+    firstName
+    surname
+  }
+}
+
+`;
+
+exports[`matches expected output: ExampleQuery.valid.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+query ExampleQueryValid {
+  me {
+    firstName
+    lastName
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+query ExampleQueryValid {
+  me {
+    firstName
+    lastName
+  }
+}
+
+`;

--- a/src/relay/src/compiler/transforms/__tests__/disallowDeprecatedFields.test.js
+++ b/src/relay/src/compiler/transforms/__tests__/disallowDeprecatedFields.test.js
@@ -1,0 +1,18 @@
+// @flow
+
+import { generateTestsFromFixtures } from '@adeira/test-utils';
+import { CompilerContext, Printer } from 'relay-compiler';
+import { parseGraphQLText } from 'relay-test-utils-internal';
+
+import disallowDeprecatedFields from '../disallowDeprecatedFields';
+import TestSchema from './__fixtures__/TestSchema';
+
+generateTestsFromFixtures(`${__dirname}/__fixtures__/disallowDeprecatedFields`, text => {
+  const {definitions} = parseGraphQLText(TestSchema, text);
+  return new CompilerContext(TestSchema)
+    .addAll(definitions)
+    .applyTransforms([disallowDeprecatedFields.transform])
+    .documents()
+    .map(doc => Printer.print(TestSchema, doc))
+    .join('\n');
+});

--- a/src/relay/src/compiler/transforms/disallowDeprecatedFields.js
+++ b/src/relay/src/compiler/transforms/disallowDeprecatedFields.js
@@ -1,0 +1,30 @@
+// @flow
+
+import { IRTransformer } from 'relay-compiler';
+
+function getFieldVisitor(schema) {
+  function visitField(field) {
+    // todo: implement this -> warn by default, throw error when "--no-deprecated-fields" is passed
+    // How can I know whether field is deprecated?
+
+    return this.traverse(field);
+  }
+
+  return visitField;
+}
+
+/**
+ * This is not an actual transform but more a validation
+ */
+function disallowDeprecatedFields(context) {
+  return IRTransformer.transform(context, {
+    // todo: is this correct visitor type where to detect this?
+    LinkedField: getFieldVisitor(context.getSchema()),
+  });
+}
+
+const transform = {
+  transform: disallowDeprecatedFields,
+};
+
+export default transform;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4558,7 +4558,7 @@ eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.7.2, eslint@^6.8.0, eslint@~6.8.0:
+eslint@^6.7.2, eslint@^6.8.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
   integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
@@ -10260,7 +10260,7 @@ relay-compiler-language-typescript@^10.1.3:
     immutable "^4.0.0-rc.12"
     invariant "^2.2.4"
 
-relay-compiler@^8.0.0:
+relay-compiler@8.0.0, relay-compiler@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-8.0.0.tgz#567edebc857db5748142b57a78d197f976b5e3ac"
   integrity sha512-JrS3Bv6+6S0KloHmXUyTcrdFRpI3NxWdiVQC146vD5jgay9EM464lyf9bEUsCol3na4JUrad4aQ/r+4wWxG1kw==
@@ -10296,6 +10296,16 @@ relay-runtime@8.0.0, relay-runtime@^8.0.0:
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
+
+relay-test-utils-internal@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/relay-test-utils-internal/-/relay-test-utils-internal-8.0.0.tgz#5e9509680ddd187eace12c565dec07906275841a"
+  integrity sha512-C8vgAcs7RVxIqXnOz93Kd7FEVrU6rlBgRaoF+KNIsPm4RJRdjvLMPqGhuWZPNaP4DRYK5c4lD9SqmfRJWOgLxg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    fbjs "^1.0.0"
+    relay-compiler "8.0.0"
+    relay-runtime "8.0.0"
 
 relay-test-utils@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
**WIP**

When running relay-compiler, warn when a deprecated field is used in a fragment.

By default, it should just log a warning into the console, e.g.

```
User.surname is deprecated (./path/to/component/User.js): Use "lastName" field instead
```
