### PR TITLE
eslint-config: change "no-constant-condition" from warning to error

### DIFF
--- a/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
+++ b/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
@@ -924,6 +924,11 @@ Snapshot Diff:
 +     "jest/valid-title": 2,
       "jsx-a11y/accessible-emoji": 2,
 @@ --- --- @@
+      "no-constant-condition": Array [
+-       1,
++       2,
+        Object {
+@@ --- --- @@
       ],
 -     "no-constructor-return": 1,
 +     "no-constructor-return": 2,

--- a/src/eslint-config-adeira/ourRules.js
+++ b/src/eslint-config-adeira/ourRules.js
@@ -18,7 +18,7 @@ module.exports = {
   'no-compare-neg-zero': ERROR,
   'no-cond-assign': ERROR,
   'no-console': ERROR,
-  'no-constant-condition': [WARN, { checkLoops: false }],
+  'no-constant-condition': [NEXT_VERSION_ERROR, { checkLoops: false }],
   'no-control-regex': ERROR,
   'no-debugger': ERROR,
   'no-dupe-args': ERROR,


### PR DESCRIPTION
I would like to propose making `no-constant-condition` an error. There shouldn't be an use case for the following code:

```
if (true) {
  stuff();
}
```

and constant conditions will remain allowed in loops thanks to `{ checkLoops: false }`.

This type of mistake can occur in code when a developer wants to quickly enable/disable particular branch of code, e.g.:

```
if (isTurnedOn() && false) {
  doStuff();
}
```

Such a practice should be discouraged, leading me to this suggestion.