### PR TITLE
Release @adeira/eslint-config 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {},
   "devDependencies": {
     "@adeira/babel-preset-adeira": "^0.3.0",
-    "@adeira/eslint-config": "^1.0.0",
+    "@adeira/eslint-config": "^1.1.0",
     "@adeira/flow-bin": "^0.1.0",
     "@babel/core": "^7.8.0",
     "babel-eslint": "^10.0.3",

--- a/src/eslint-config-adeira/CHANGELOG.md
+++ b/src/eslint-config-adeira/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 1.1.0
+
+- New CLI option `--no-warnings`
+
 # 1.0.0
 
 - Add new rule `adeira/no-duplicate-import-type-import`;

--- a/src/eslint-config-adeira/README.md
+++ b/src/eslint-config-adeira/README.md
@@ -80,6 +80,8 @@ It tries to detect files to lint because it's highly inefficient to test all the
 
 Please note: this Eslint runner not only runs all the tests much faster but it also performs automatic fixes. This is currently no-opt.
 
+You can also suppress warnings in report by `--no-warnings` option. This is not to make you ignore warnings, rather an utility to easily filter out problems in changed code while you are in process of updating your legacy codebase with a lot of warnings. 
+
 ## Tip
 
 You can benefit from the main Jest executor much more. You can for example use watch mode to watch changes in one directory:

--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/eslint-config-adeira",
   "license": "MIT",
   "private": false,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index",
   "sideEffects": false,
   "dependencies": {


### PR DESCRIPTION
- update readme
- release `@adeira/eslint-config` 1.1.0 with `--no-warnings`