### PR TITLE
Relay example: fix misconfigured Shipit

### DIFF
--- a/src/example-relay/__github__/jest.config.js
+++ b/src/example-relay/__github__/jest.config.js
@@ -1,6 +1,0 @@
-// @flow strict
-
-module.exports = {
-  rootDir: __dirname,
-  testMatch: ['<rootDir>/**/__tests__/**/?(*.)+(spec|test).js?(x)'],
-};

--- a/src/example-relay/jest.config.js
+++ b/src/example-relay/jest.config.js
@@ -4,7 +4,6 @@
 // in this monorepo root.
 module.exports = {
   rootDir: __dirname,
-  transform: {
-    '^.+\\.js$': '<rootDir>/scripts/jest/custom-transformer.js',
-  },
+  // @x-shipit-enable: testMatch: ['<rootDir>/**/__tests__/**/?(*.)+(spec|test).js?(x)'],
+  transform: { '^.+\\.js$': '<rootDir>/scripts/jest/custom-transformer.js' }, // @x-shipit-disable
 };

--- a/src/monorepo-shipit/config/__tests__/example-relay.test.js
+++ b/src/monorepo-shipit/config/__tests__/example-relay.test.js
@@ -19,7 +19,6 @@ testExportedPaths(path.join(__dirname, '..', 'example-relay.js'), [
 
   // invalid cases:
   ['src/example-relay/.babelrc.js', undefined], // correctly deleted
-  ['src/example-relay/jest.config.js', undefined], // correctly deleted
   ['src/example-relay/__github__/unknown.js', undefined], // correctly deleted
   ['src/packages/monorepo/outsideScope.js', undefined], // correctly deleted
   ['package.json', undefined], // correctly deleted

--- a/src/monorepo-shipit/config/example-relay.js
+++ b/src/monorepo-shipit/config/example-relay.js
@@ -10,13 +10,12 @@ module.exports = {
     return new Map([
       ['src/example-relay/__github__/.flowconfig', '.flowconfig'],
       ['src/example-relay/__github__/babel.config.js', 'babel.config.js'],
-      ['src/example-relay/__github__/jest.config.js', 'jest.config.js'],
       ['src/example-relay/__github__/flow-typed', 'flow-typed'],
       ['src/example-relay/__github__/.github', '.github'],
       ['src/example-relay/', ''],
     ]);
   },
   getStrippedFiles(): Set<RegExp> {
-    return new Set([/__github__/, /^\.babelrc\.js$/, /^jest\.config\.js$/, /scripts/]);
+    return new Set([/__github__/, /^\.babelrc\.js$/, /scripts/]);
   },
 };


### PR DESCRIPTION
There was a logical error: you cannot try to ship some file and then strip it from the shipping process. I am not sure we actually support such file replacement. This could be (in theory) fairly simple to fix by reordering the filters.