### PR TITLE
utils: Handle output from yarn workspaces info --json

### DIFF
--- a/src/babel-preset-adeira/package.json
+++ b/src/babel-preset-adeira/package.json
@@ -18,7 +18,7 @@
     "@babel/runtime": "^7.8.4"
   },
   "devDependencies": {
-    "@adeira/monorepo-utils": "^0.2.0",
+    "@adeira/monorepo-utils": "^0.3.0",
     "@adeira/test-utils": "^0.1.0",
     "strip-ansi": "^6.0.0"
   },

--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -8,7 +8,7 @@
   "main": "index",
   "sideEffects": false,
   "dependencies": {
-    "@adeira/monorepo-utils": "^0.2.0",
+    "@adeira/monorepo-utils": "^0.3.0",
     "@babel/register": "^7.8.3",
     "@babel/runtime": "^7.8.4",
     "chalk": "^3.0.0",

--- a/src/flow-bin/package.json
+++ b/src/flow-bin/package.json
@@ -15,7 +15,7 @@
     "@babel/register": "^7.8.3",
     "@adeira/js": "^1.0.0",
     "@adeira/logger": "^0.1.0",
-    "@adeira/monorepo-utils": "^0.2.0",
+    "@adeira/monorepo-utils": "^0.3.0",
     "chalk": "^3.0.0",
     "is-ci": "^2.0.0"
   },

--- a/src/monorepo-builder/package.json
+++ b/src/monorepo-builder/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@adeira/js": "^1.0.0",
     "@adeira/logger": "^0.1.0",
-    "@adeira/monorepo-utils": "^0.2.0",
+    "@adeira/monorepo-utils": "^0.3.0",
     "rimraf": "^3.0.1"
   },
   "peerDependencies": {

--- a/src/monorepo-npm-publisher/package.json
+++ b/src/monorepo-npm-publisher/package.json
@@ -9,7 +9,7 @@
   "sideEffects": false,
   "dependencies": {
     "@adeira/babel-preset-adeira": "^0.3.0",
-    "@adeira/monorepo-utils": "^0.2.0",
+    "@adeira/monorepo-utils": "^0.3.0",
     "@adeira/test-utils": "^0.1.0",
     "chalk": "^3.0.0",
     "is-ci": "^2.0.0",

--- a/src/monorepo-scanner/package.json
+++ b/src/monorepo-scanner/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "dependencies": {
     "@adeira/js": "^1.0.0",
-    "@adeira/monorepo-utils": "^0.2.0",
+    "@adeira/monorepo-utils": "^0.3.0",
     "semver": "^7.1.2"
   },
   "devDependencies": {

--- a/src/monorepo-shipit/package.json
+++ b/src/monorepo-shipit/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@adeira/js": "^1.0.0",
     "@adeira/logger": "^0.1.0",
-    "@adeira/monorepo-utils": "^0.2.0",
+    "@adeira/monorepo-utils": "^0.3.0",
     "@adeira/test-utils": "^0.1.0",
     "fast-levenshtein": "^2.0.6"
   }

--- a/src/monorepo-utils/package.json
+++ b/src/monorepo-utils/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/monorepo-utils",
   "license": "MIT",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "src/index",
   "sideEffects": false,
   "engines": {

--- a/src/monorepo-utils/src/getWorkspaceDependencies.js
+++ b/src/monorepo-utils/src/getWorkspaceDependencies.js
@@ -12,5 +12,15 @@ export default function getWorkspaceDependencies(): WorkspaceDependencies {
     .runSynchronously()
     .getStdout();
 
-  return sanitizeWorkspaces(JSON.parse(JSON.parse(stdout).data));
+  const sanitizeStdout = () => {
+    const data = JSON.parse(stdout);
+    if (data.data === undefined) {
+      // yarn upated how they return data from yarn workspaces info --json, this is to support 1.22.0
+      return data;
+    }
+    // This is how the data has to be parsed prior to 1.22.0
+    return JSON.parse(data.data);
+  };
+
+  return sanitizeWorkspaces(sanitizeStdout());
 }

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -20,7 +20,7 @@
     "@adeira/fetch": "^1.0.0",
     "@adeira/js": "^1.0.0",
     "@adeira/logger": "^0.1.0",
-    "@adeira/monorepo-utils": "^0.2.0",
+    "@adeira/monorepo-utils": "^0.3.0",
     "@adeira/relay-runtime": "^0.5.0",
     "@adeira/signed-source": "^0.1.0",
     "@babel/register": "^7.8.3",


### PR DESCRIPTION
The output of this call was changed in 1.22.0.
This change will make it work with new format and older formats