### PR TITLE
npm-publisher: Use projects babel config

### DIFF
--- a/src/monorepo-npm-publisher/CHANGELOG.md
+++ b/src/monorepo-npm-publisher/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Set root mode to upwards to apply consumer projects babel config
+
 ---
 
 Changelog before our fork:

--- a/src/monorepo-npm-publisher/src/transformFileVariants.js
+++ b/src/monorepo-npm-publisher/src/transformFileVariants.js
@@ -11,9 +11,8 @@ export default function transformFileVariants(
   transpileESM: boolean,
 ): void {
   const getBabelConfig = (target: 'js' | 'js-esm' | 'flow') => {
-    // TODO: load Babel config from the packages instead (if exists)
     return {
-      root: __dirname, // do not lookup any other Babel config
+      rootMode: 'upward',
       presets: [
         [
           '@adeira/babel-preset-adeira',


### PR DESCRIPTION
Use rootMode upwards to apply the babel config from the project
using this package, rather than force the @adeira/babel-preset

closes #196