### PR TITLE
monorepo-utils: Correctly log timezone

### DIFF
--- a/src/monorepo-utils/src/TestsRunner.js
+++ b/src/monorepo-utils/src/TestsRunner.js
@@ -26,7 +26,7 @@ function _runJest(config, timezone = 'UTC') {
     }
   });
 
-  console.warn(`Running tests in timezone: ${timezone}`); // eslint-disable-line no-console
+  console.warn(`Running tests in timezone: ${process.env.TZ ?? timezone}`); // eslint-disable-line no-console
   return new ShellCommand(
     null,
     'node',


### PR DESCRIPTION
Currenlty it was logging UTC, even if you had another
timezone in process.env.TZ