### PR TITLE
@adeira/graphql-global-id: add @babel/runtime into dependencies

### DIFF
--- a/src/graphql-global-id/package.json
+++ b/src/graphql-global-id/package.json
@@ -4,11 +4,12 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/graphql-global-id",
   "license": "MIT",
   "private": false,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "src/GlobalID",
   "sideEffects": false,
   "dependencies": {
-    "@adeira/js": "^1.2.0"
+    "@adeira/js": "^1.2.0",
+    "@babel/runtime": "^7.8.7"
   },
   "peerDependencies": {
     "graphql": "^14.5.8"


### PR DESCRIPTION
Closes: https://github.com/adeira/universe/issues/485