### PR TITLE
Upgrade Flow to the latest version ^0.121.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "babel-jest": "^25.1.0",
     "babel-loader": "^8.0.6",
     "eslint": "^6.8.0",
-    "flow-bin": "^0.120.1",
+    "flow-bin": "^0.121.0",
     "flow-typed": "^3.1.0",
     "glob": "^7.1.6",
     "jest": "^25.1.0"

--- a/src/__flowtests__/lints/sketchy-null.js
+++ b/src/__flowtests__/lints/sketchy-null.js
@@ -1,25 +1,25 @@
 // @flow strict
 
-// $FlowExpectedError: sketchy-null-bool
 const a: ?boolean = true;
+// $FlowExpectedError: sketchy-null-bool
 if (a) {
   // sketchy because "a" could be either null or false
 }
 
-// $FlowExpectedError: sketchy-null-number
 const b: ?number = 5;
+// $FlowExpectedError: sketchy-null-number
 if (b) {
   // sketchy because "b" could be either null or 0
 }
 
-// $FlowExpectedError: sketchy-null-string
 const c: ?string = 'ok';
+// $FlowExpectedError: sketchy-null-string
 if (c) {
   // sketchy because "c" could be either null or ""
 }
 
-// $FlowExpectedError: sketchy-null-mixed
 const d: ?mixed = new Date();
+// $FlowExpectedError: sketchy-null-mixed
 if (d) {
   // sketchy because "d" could be either null or falsey
 }

--- a/src/__flowtests__/lints/sketchy-number.js
+++ b/src/__flowtests__/lints/sketchy-number.js
@@ -1,11 +1,10 @@
 // @flow strict
 
-// $FlowExpectedError: just a React mock
 const React = { createElement: () => {} };
 
-// $FlowExpectedError: sketchy-number-and
 const showBr: number = 42;
 
 export function Component() {
+  // $FlowExpectedError: sketchy-number-and
   return <div>{showBr && <br />}</div>;
 }

--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@adeira/babel-preset-adeira": "^0.3.0",
     "babel-jest": "^25.1.0",
-    "flow-bin": "^0.120.1",
+    "flow-bin": "^0.121.0",
     "graphql": "^14.6.0",
     "jest": "^25.1.0",
     "react-test-renderer": "^16.13.0",

--- a/src/fetch/src/ResponseError.js
+++ b/src/fetch/src/ResponseError.js
@@ -12,14 +12,16 @@ type ResponseErrorType = {
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types
  */
 function ResponseError(response: Response, message?: string): ResponseErrorType {
-  // property 'error.response' is unknown in Error (but that's fine, we are extending here)
-  // $FlowExpectedError: ^^
   const instance = new Error(message);
+
+  // $FlowExpectedError: property 'error.response' is unknown in Error (but that's fine, we are extending here)
   instance.response = response;
   setPrototypeOf(instance, Object.getPrototypeOf(this));
   if (Error.captureStackTrace) {
     Error.captureStackTrace(instance, ResponseError);
   }
+
+  // $FlowExpectedError: property 'error.response' is unknown in Error (but that's fine, we are extending here)
   return instance;
 }
 

--- a/src/fetch/src/__tests__/ResponseError.test.js
+++ b/src/fetch/src/__tests__/ResponseError.test.js
@@ -2,12 +2,12 @@
 
 import { ResponseError } from '../fetchWithRetries';
 
-// $FlowExpectedError: incomplete Response object for testing purposes only
 const fetchResponse = {
   status: 403,
 };
 
 it('is instance of Error and TimeoutError', () => {
+  // $FlowExpectedError: incomplete Response object for testing purposes only
   const error = new ResponseError(fetchResponse, 'ups');
   expect(error).toBeInstanceOf(Error);
   // $FlowExpectedError: function is incompatible with statics of existential (?)
@@ -15,6 +15,7 @@ it('is instance of Error and TimeoutError', () => {
 });
 
 it('contains response', () => {
+  // $FlowExpectedError: incomplete Response object for testing purposes only
   const error = new ResponseError(fetchResponse, 'ups');
   expect(error.response).toBe(fetchResponse);
   expect(error.message).toBe('ups');
@@ -22,6 +23,7 @@ it('contains response', () => {
 
 it('is throwable', () => {
   expect(() => {
+    // $FlowExpectedError: incomplete Response object for testing purposes only
     throw new ResponseError(fetchResponse, 'ups');
   }).toThrowError('ups');
 });

--- a/src/graphql-global-id/src/__tests__/GlobalID.test.js
+++ b/src/graphql-global-id/src/__tests__/GlobalID.test.js
@@ -28,6 +28,7 @@ function resolveField(
       undefined, // context
       // $FlowExpectedError: this is incomplete info only for test purposes
       {
+        // $FlowExpectedError: this is incomplete info only for test purposes
         parentType: {
           name: typename,
         },
@@ -118,8 +119,8 @@ Object {
   });
 
   it('throws error for original ID being "null"', () => {
-    // $FlowExpectedError: ID fetcher result should not be null
     const idFetcher = () => null;
+    // $FlowExpectedError: ID fetcher should not return null (testing purposes only)
     const field = GlobalID(idFetcher);
     const error = catchError(() => resolveField(field));
     expect(error).toBeInstanceOf(Error);
@@ -128,8 +129,8 @@ Object {
   });
 
   it('throws error for original ID being "undefined"', () => {
-    // $FlowExpectedError: ID fetcher result should nto be undefined
     const idFetcher = () => undefined;
+    // $FlowExpectedError: ID fetcher should not return undefined (testing purposes only)
     const field = GlobalID(idFetcher);
     const error = catchError(() => resolveField(field));
     expect(error).toBeInstanceOf(Error);

--- a/src/monorepo-utils/src/__flowtests__/glob.js
+++ b/src/monorepo-utils/src/__flowtests__/glob.js
@@ -31,10 +31,10 @@ module.exports = {
     return glob('pattern', {}, () => {}, 'additional');
   },
   invalidConfig_1(): empty {
+    // $FlowExpectedError: root option must be string
     return glob(
       'pattern',
       {
-        // $FlowExpectedError: root option must be string
         root: true,
       },
       () => {},

--- a/src/relay/src/__flowtests__/LocalQueryRenderer.js
+++ b/src/relay/src/__flowtests__/LocalQueryRenderer.js
@@ -53,11 +53,11 @@ module.exports = {
   },
   invalidVariablesValue() {
     return (
+      // $FlowExpectedError: Cannot create LocalQueryRenderer element because null is incompatible with Variables.
       <LocalQueryRenderer
         environment={environment}
         query={query}
         render={placeholder}
-        // $FlowExpectedError: Cannot create LocalQueryRenderer element because null is incompatible with Variables.
         variables={null}
       />
     );

--- a/src/relay/src/__flowtests__/QueryRenderer.js
+++ b/src/relay/src/__flowtests__/QueryRenderer.js
@@ -140,6 +140,7 @@ module.exports = {
   },
   invalidCacheConfig() {
     return (
+      // $FlowExpectedError: this cache config is not valid
       <QueryRenderer
         query={graphql`
           query QueryRenderer {
@@ -147,13 +148,13 @@ module.exports = {
           }
         `}
         onResponse={placeholder}
-        // $FlowExpectedError: this cache config is not valid
         cacheConfig={{ invalid: 'ups' }}
       />
     );
   },
   invalidVariablesValue() {
     return (
+      // $FlowExpectedError: variables can be object or undefined but nothing else
       <QueryRenderer
         query={graphql`
           query QueryRenderer {
@@ -161,7 +162,6 @@ module.exports = {
           }
         `}
         onResponse={placeholder}
-        // $FlowExpectedError: variables can be object or undefined but nothing else
         variables={null}
       />
     );

--- a/src/relay/src/__flowtests__/mutations.js
+++ b/src/relay/src/__flowtests__/mutations.js
@@ -68,19 +68,18 @@ module.exports = {
     });
   },
   invalidVariables() {
-    // $FlowExpectedError: passed variables are incorrect
     return commitMutation<NamedMutation>(environment, {
       mutation,
+      // $FlowExpectedError: passed variables are incorrect
       variables: { someNumber: '123' },
     });
   },
   invalidOnCompletedType() {
-    // $FlowExpectedError: response type differs from onCompleted declaration
     return commitMutation<NamedMutation>(environment, {
       mutation,
       variables,
-      // eslint-disable-next-line no-unused-vars
-      onCompleted: (response: {||}) => {},
+      // $FlowExpectedError: response type differs from onCompleted declaration
+      onCompleted: (response: {||}) => {}, // eslint-disable-line no-unused-vars
     });
   },
   invalidAsyncMutation() {

--- a/src/relay/src/__tests__/createPaginationContainer.test.js
+++ b/src/relay/src/__tests__/createPaginationContainer.test.js
@@ -5,13 +5,12 @@ import * as React from 'react';
 import createPaginationContainer from '../createPaginationContainer';
 
 class MockComponent extends React.Component<{||}> {}
-// $FlowExpectedError: we do not need the connection config here
-const connectionConfig = {};
 
 it('throws when used with empty fragment spec', () => {
   let error = new Error();
   try {
-    createPaginationContainer(MockComponent, {}, connectionConfig);
+    // $FlowExpectedError: we do not need the connection config here
+    createPaginationContainer(MockComponent, {}, {});
   } catch (_error) {
     error = _error;
   }

--- a/src/relay/src/__tests__/createRefetchContainer.test.js
+++ b/src/relay/src/__tests__/createRefetchContainer.test.js
@@ -5,13 +5,12 @@ import * as React from 'react';
 import createRefetchContainer from '../createRefetchContainer';
 
 class MockComponent extends React.Component<{||}> {}
-// $FlowExpectedError: we do not need the refetch query here
-const refetchQueryMock = null;
 
 it('throws when used with empty fragment spec', () => {
   let error = new Error();
   try {
-    createRefetchContainer(MockComponent, {}, refetchQueryMock);
+    // $FlowExpectedError: we do not need the refetch query here
+    createRefetchContainer(MockComponent, {}, null);
   } catch (_error) {
     error = _error;
   }

--- a/src/relay/src/__tests__/helpers.handleData.test.js
+++ b/src/relay/src/__tests__/helpers.handleData.test.js
@@ -5,7 +5,6 @@ import { handleData } from '../helpers';
 const jsonMock = jest.fn();
 const textMock = jest.fn();
 
-// $FlowExpectedError: incomplete Response object for testing purposes only
 const createResponse = getMockFunction => ({
   headers: {
     get: getMockFunction,
@@ -22,6 +21,7 @@ it('calls "text" method by default', () => {
   const headersGetMock = jest.fn();
   const response = createResponse(headersGetMock);
 
+  // $FlowExpectedError: incomplete Response object for testing purposes only
   handleData(response);
 
   expect(headersGetMock).toHaveBeenCalledWith('content-type');
@@ -33,6 +33,7 @@ it('calls "json" method when header "content-type" with value "application/json"
   const headersGetMock = jest.fn().mockImplementation(() => 'application/json');
   const response = createResponse(headersGetMock);
 
+  // $FlowExpectedError: incomplete Response object for testing purposes only
   handleData(response);
 
   expect(headersGetMock).toHaveBeenCalledWith('content-type');

--- a/src/relay/src/fetchers/__flowtests__/createNetworkFetcher.js
+++ b/src/relay/src/fetchers/__flowtests__/createNetworkFetcher.js
@@ -27,8 +27,8 @@ module.exports = {
     };
   },
   invalidXClient: () => {
+    // $FlowExpectedError: X-Client header should be string, not number
     return createNetworkFetcher('//localhost', {
-      // $FlowExpectedError: X-Client header should be string, not number
       'X-Client': 1,
     });
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6063,10 +6063,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-flow-bin@^0.120.1:
-  version "0.120.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.120.1.tgz#ab051d6df71829b70a26a2c90bb81f9d43797cae"
-  integrity sha512-KgE+d+rKzdXzhweYVJty1QIOOZTTbtnXZf+4SLnmArLvmdfeLreQOZpeLbtq5h79m7HhDzX/HkUkoyu/fmSC2A==
+flow-bin@^0.121.0:
+  version "0.121.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.121.0.tgz#e206bdc3d510277f9a847920540f72c49e87c130"
+  integrity sha512-QYRMs+AoMLj/OTaSo9+8c3kzM/u8YgvfrInp0qzhtzC02Sc2jb3BV/QZWZGjPo+XK3twyyqXrcI3s8MuL1UQRg==
 
 flow-typed@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
This change also relocates error suppression comments to the primary locations which is a first step towards new and more specific suppressions, see: https://medium.com/flow-type/making-flow-error-suppressions-more-specific-280aa4e3c95c