### PR TITLE
Require @babel/runtime for public NPM packages

### DIFF
--- a/src/eslint-plugin-adeira/package.json
+++ b/src/eslint-plugin-adeira/package.json
@@ -7,6 +7,9 @@
   "version": "0.8.0",
   "main": "src/index",
   "sideEffects": false,
+  "dependencies": {
+    "@babel/runtime": "^7.9.0"
+  },
   "devDependencies": {
     "eslint": "^6.7.2"
   }

--- a/src/fetch/package.json
+++ b/src/fetch/package.json
@@ -10,6 +10,7 @@
   "description": "Production ready fetch function with advanced capabilities like retries with delay and request cancellation after timeout.",
   "dependencies": {
     "@adeira/js": "^1.2.0",
+    "@babel/runtime": "^7.9.0",
     "cross-fetch": "^3.0.4"
   },
   "devDependencies": {

--- a/src/flow-bin/package.json
+++ b/src/flow-bin/package.json
@@ -16,10 +16,11 @@
     "@adeira/logger": "^0.2.0",
     "@adeira/monorepo-utils": "^0.6.0",
     "@babel/register": "^7.9.0",
+    "@babel/runtime": "^7.9.0",
     "chalk": "^3.0.0",
     "is-ci": "^2.0.0"
   },
   "peerDependencies": {
-    "flow-bin": "^0.119.1"
+    "flow-bin": "^0.121.0"
   }
 }

--- a/src/graphql-bc-checker/package.json
+++ b/src/graphql-bc-checker/package.json
@@ -9,6 +9,7 @@
   "sideEffects": false,
   "dependencies": {
     "@adeira/signed-source": "^0.1.0",
+    "@babel/runtime": "^7.9.0",
     "chalk": "^3.0.0"
   },
   "devDependencies": {

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -7,5 +7,7 @@
   "version": "1.2.2",
   "main": "src/index",
   "sideEffects": false,
-  "dependencies": {}
+  "dependencies": {
+    "@babel/runtime": "^7.9.0"
+  }
 }

--- a/src/logger/package.json
+++ b/src/logger/package.json
@@ -8,6 +8,7 @@
   "main": "src/index",
   "dependencies": {
     "@adeira/js": "^1.2.0",
+    "@babel/runtime": "^7.9.0",
     "triple-beam": "^1.3.0",
     "winston": "^3.2.1"
   }

--- a/src/monorepo-npm-publisher/package.json
+++ b/src/monorepo-npm-publisher/package.json
@@ -11,6 +11,7 @@
     "@adeira/babel-preset-adeira": "^0.3.0",
     "@adeira/monorepo-utils": "^0.6.0",
     "@adeira/test-utils": "^0.2.0",
+    "@babel/runtime": "^7.9.0",
     "chalk": "^3.0.0",
     "is-ci": "^2.0.0",
     "npm-packlist": "^2.1.1",

--- a/src/monorepo-scanner/src/scans/NpmPackages.scan.js
+++ b/src/monorepo-scanner/src/scans/NpmPackages.scan.js
@@ -23,5 +23,10 @@ for (const npmPackage of npmPackages) {
       'You are trying to release a non existing package',
     );
     expect(packageJson?.private).toBe(false);
+
+    const packageName = packageJson?.name ?? 'unknown';
+    expect(packageJson?.dependencies?.['@babel/runtime'] !== undefined).toGiveHelp(
+      `Package '${packageName}' is being transpiled via Babel for NPM and it requires '@babel/runtime' to be in dependencies.`,
+    );
   });
 }

--- a/src/monorepo-utils/package.json
+++ b/src/monorepo-utils/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@babel/register": "^7.9.0",
+    "@babel/runtime": "^7.9.0",
     "@adeira/js": "^1.2.0",
     "glob": "^7.1.6",
     "is-ci": "^2.0.0"

--- a/src/relay-runtime/package.json
+++ b/src/relay-runtime/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@adeira/js": "^1.2.0",
+    "@babel/runtime": "^7.9.0",
     "relay-runtime": "^9.0.0"
   }
 }

--- a/src/relay-utils/package.json
+++ b/src/relay-utils/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "dependencies": {
     "@adeira/relay": "^1.1.3",
-    "@adeira/relay-runtime": "^0.8.0"
+    "@adeira/relay-runtime": "^0.8.0",
+    "@babel/runtime": "^7.9.0"
   },
   "peerDependencies": {
     "relay-runtime": "^9.0.0"

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -24,6 +24,7 @@
     "@adeira/relay-runtime": "^0.8.0",
     "@adeira/signed-source": "^0.1.0",
     "@babel/register": "^7.9.0",
+    "@babel/runtime": "^7.9.0",
     "babel-plugin-relay": "^9.0.0",
     "commander": "^5.0.0",
     "is-ci": "^2.0.0",

--- a/src/signed-source/package.json
+++ b/src/signed-source/package.json
@@ -7,5 +7,7 @@
   "version": "0.1.0",
   "main": "src/SignedSource",
   "sideEffects": false,
-  "dependencies": {}
+  "dependencies": {
+    "@babel/runtime": "^7.9.0"
+  }
 }

--- a/src/test-utils/package.json
+++ b/src/test-utils/package.json
@@ -8,6 +8,7 @@
   "main": "src/index",
   "sideEffects": false,
   "dependencies": {
-    "@adeira/js": "^1.2.0"
+    "@adeira/js": "^1.2.0",
+    "@babel/runtime": "^7.9.0"
   }
 }


### PR DESCRIPTION
I was considering to stop using it but that would blow up the NPM size significantly. Moreover it's not that simple to opt-out from it. So instead, we should require it everywhere for public NPM packages (via our Scanner).

Closes: https://github.com/adeira/universe/issues/526