### PR TITLE
GraphQL ID: rename `__isTypeOf` to `isTypeOf`

### DIFF
--- a/src/graphql-global-id/CHANGELOG.md
+++ b/src/graphql-global-id/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Unreleased
+
+# 0.8.0
+
+- rename `evaluateGlobalIdField` to `DEPRECATED_evaluateGlobalIdField` (will be removed in next major version)
+- rename `__isTypeOf` to `isTypeOf` (old version will be removed in the next major version)

--- a/src/graphql-global-id/README.md
+++ b/src/graphql-global-id/README.md
@@ -50,7 +50,11 @@ const fields = {
 };
 ```
 
-# Restoring original ID
+# `toGlobalId`
+
+TKTK
+
+# Restoring original ID (`fromGlobalId``)
 
 `GlobalID` used in previous examples accepts readable (unmasked ID) and returns opaque ID. You can revert this process in case you need to access the original unmasked ID. Check the following test to get the idea:
 
@@ -63,6 +67,10 @@ it('returns correct original ID', () => {
 ```
 
 You should always use this function because the way how this utility works with masking and unmasking is just an internal detail.
+
+# `isTypeOf`
+
+TKTK
 
 # Tips
 

--- a/src/graphql-global-id/package.json
+++ b/src/graphql-global-id/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/graphql-global-id",
   "license": "MIT",
   "private": false,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "src/GlobalID",
   "sideEffects": false,
   "dependencies": {

--- a/src/graphql-global-id/src/GlobalID.d.ts
+++ b/src/graphql-global-id/src/GlobalID.d.ts
@@ -4,9 +4,8 @@ export function fromGlobalId(opaqueID: string): string;
 
 export function toGlobalId(type: string, id: string | number): string;
 
-export function __isTypeOf(type: string, opaqueID: unknown): boolean;
-
-// TODO: evaluateGlobalIdField (?)
+export function isTypeOf(type: string, opaqueID: unknown): boolean;
+export function __isTypeOf(type: string, opaqueID: unknown): boolean; // TODO: deprecated, remove
 
 type FetchFnType = (object: any, context: any, info: GraphQLResolveInfo) => string | number;
 

--- a/src/graphql-global-id/src/GlobalID.js
+++ b/src/graphql-global-id/src/GlobalID.js
@@ -27,8 +27,15 @@ export function toGlobalId(type: string, id: string | number): OpaqueIDString {
   return encode(`${type}:${id}`);
 }
 
-// TODO: find out better way how to do it (type should be just an internal detail - see evaluateGlobalIdField)
+/**
+ * TODO: remove in 1.0.0
+ * @deprecated
+ */
 export function __isTypeOf(type: string, opaqueID: mixed): boolean {
+  return isTypeOf(type, opaqueID);
+}
+
+export function isTypeOf(type: string, opaqueID: mixed): boolean {
   if (typeof opaqueID !== 'string') {
     return false;
   }
@@ -48,7 +55,7 @@ export function __isTypeOf(type: string, opaqueID: mixed): boolean {
  * @deprecated This functions should be used mainly in tests. It doesn't feel
  * right in production code (it's currently used only in hotels).
  */
-export function evaluateGlobalIdField(
+export function DEPRECATED_evaluateGlobalIdField( // eslint-disable-line babel/camelcase
   outputObject: GraphQLObjectType,
   parent?: { [key: string]: any, ... },
   args?: { ... },

--- a/src/graphql-global-id/src/__tests__/GlobalID.test.js
+++ b/src/graphql-global-id/src/__tests__/GlobalID.test.js
@@ -3,7 +3,13 @@
 import { GraphQLObjectType, GraphQLID } from 'graphql';
 import { nullthrows } from '@adeira/js';
 
-import GlobalID, { fromGlobalId, evaluateGlobalIdField, __isTypeOf, toGlobalId } from '../GlobalID';
+import GlobalID, {
+  fromGlobalId,
+  DEPRECATED_evaluateGlobalIdField, // eslint-disable-line babel/camelcase
+  __isTypeOf,
+  isTypeOf,
+  toGlobalId,
+} from '../GlobalID';
 import type { OpaqueIDString } from '../Encoder';
 
 // This typecast is necessary only for testing purposes. In normal scenarios, you'd create the
@@ -172,13 +178,17 @@ describe('toGlobalId', () => {
     const globalId = toGlobalId(type, id);
 
     expect(fromGlobalId(globalId)).toBe(id.toString());
-    expect(__isTypeOf(type, globalId)).toBe(true);
+    expect(isTypeOf(type, globalId)).toBe(true);
   });
 });
 
-describe('__isTypeOf', () => {
+describe('isTypeOf', () => {
   const ID = GlobalID(() => 42);
   it('resolves the type correctly', () => {
+    expect(isTypeOf('WrongTypeName', resolveField(ID))).toBe(false);
+    expect(isTypeOf('TypeName', resolveField(ID))).toBe(true);
+
+    // deprecated:
     expect(__isTypeOf('WrongTypeName', resolveField(ID))).toBe(false);
     expect(__isTypeOf('TypeName', resolveField(ID))).toBe(true);
   });
@@ -198,6 +208,9 @@ describe('__isTypeOf', () => {
   it.each([null, undefined, 42, [], new Date()])(
     'handles incorrect usages gracefully - opaqueID=%p',
     input => {
+      expect(isTypeOf('TypeName', input)).toBe(false);
+
+      // deprecated:
       expect(__isTypeOf('TypeName', input)).toBe(false);
     },
   );
@@ -206,7 +219,7 @@ describe('__isTypeOf', () => {
 describe('evaluateGlobalIdField', () => {
   it('works with standard output object', () => {
     expect(
-      evaluateGlobalIdField(
+      DEPRECATED_evaluateGlobalIdField(
         new GraphQLObjectType({
           name: 'Test',
           description: 'Test',
@@ -220,7 +233,7 @@ describe('evaluateGlobalIdField', () => {
 
   it('throws when trying to use incompatible output type', () => {
     const error = catchError(() =>
-      evaluateGlobalIdField(
+      DEPRECATED_evaluateGlobalIdField(
         new GraphQLObjectType({
           name: 'Test',
           description: 'Test',
@@ -241,7 +254,7 @@ describe('evaluateGlobalIdField', () => {
 
   it('throws when id filed is missing', () => {
     const error = catchError(() =>
-      evaluateGlobalIdField(
+      DEPRECATED_evaluateGlobalIdField(
         new GraphQLObjectType({
           name: 'Test',
           description: 'Test',
@@ -260,7 +273,7 @@ describe('evaluateGlobalIdField', () => {
 
   it('calls resolver with correct arguments', () => {
     const resolveMock = jest.fn();
-    evaluateGlobalIdField(
+    DEPRECATED_evaluateGlobalIdField(
       new GraphQLObjectType({
         name: 'Test',
         description: 'Test',
@@ -284,7 +297,7 @@ describe('evaluateGlobalIdField', () => {
 
   it('calls resolver with correct additional arguments', () => {
     const resolveMock = jest.fn();
-    evaluateGlobalIdField(
+    DEPRECATED_evaluateGlobalIdField(
       new GraphQLObjectType({
         name: 'Test',
         description: 'Test',


### PR DESCRIPTION
Preparation for stable release.