### PR TITLE
Improved evaluateGraphQLResolver

### DIFF
--- a/src/test-utils/package.json
+++ b/src/test-utils/package.json
@@ -4,11 +4,14 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/test-utils",
   "license": "MIT",
   "private": false,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "src/index",
   "sideEffects": false,
   "dependencies": {
     "@adeira/js": "^1.2.0",
     "@babel/runtime": "^7.9.2"
+  },
+  "devDependencies": {
+    "graphql": "^14.6.0"
   }
 }

--- a/src/test-utils/src/__tests__/evaluateGraphQLResolver.test.js
+++ b/src/test-utils/src/__tests__/evaluateGraphQLResolver.test.js
@@ -1,0 +1,37 @@
+// @flow
+
+/* eslint-disable adeira/graphql-require-object-description */
+
+import { GraphQLObjectType, GraphQLFloat } from 'graphql';
+
+import evaluateGraphQLResolver from '../evaluateGraphQLResolver';
+
+function createType(type: any): GraphQLObjectType {
+  return new GraphQLObjectType({
+    name: 'SomeType',
+    fields: {
+      value: {
+        type,
+      },
+    },
+  });
+}
+
+describe('evaluateGraphQLResolver', () => {
+  it('works with default graphql scalar', () => {
+    const { value } = createType(GraphQLFloat).getFields();
+
+    expect(evaluateGraphQLResolver(value, { value: 3.14 })).toBe(3.14);
+    expect(evaluateGraphQLResolver(value, { value: '3.14' })).toBe(3.14);
+    expect(() => evaluateGraphQLResolver(value, { value: 'abc' })).toThrowError(
+      'Float cannot represent non numeric value: "abc"',
+    );
+  });
+
+  it('just returns the input on complex type', () => {
+    const { value } = createType('ComplexType').getFields();
+    const input = { foo: 'bar' };
+
+    expect(evaluateGraphQLResolver(value, { value: input })).toStrictEqual(input);
+  });
+});

--- a/src/test-utils/src/evaluateGraphQLResolver.js
+++ b/src/test-utils/src/evaluateGraphQLResolver.js
@@ -1,0 +1,34 @@
+// @flow
+
+/**
+ * Use this function to evaluate resolvers in test files. Usage:
+ *
+ * ```js
+ * const fields = Location.getFields();
+ * expect(
+ *   evaluateGraphQLResolver(fields.countryFlagURL, {
+ *     country: ' ... ', // test value
+ *   }),
+ * ).toBe(' ... ');
+ * ```
+ */
+export default function evaluateGraphQLResolver(
+  field: { [key: string]: any, name: string, ... },
+  testValue: { [key: string]: any, ... },
+  argsValue?: { [key: string]: any, ... },
+  contextValue?: { [key: string]: any, ... },
+): any {
+  const resolveFn =
+    field.resolve ||
+    function resolveMock(): string {
+      return testValue[field.name];
+    };
+  const resolvedValue = resolveFn(testValue, argsValue, contextValue, {
+    path: { key: 'mocked' },
+  });
+
+  if (typeof field.type.serialize === 'function') {
+    return field.type.serialize(resolvedValue);
+  }
+  return resolvedValue;
+}

--- a/src/test-utils/src/index.js
+++ b/src/test-utils/src/index.js
@@ -1,29 +1,6 @@
 // @flow
 
 import generateTestsFromFixtures from './generateTestsFromFixtures';
-
-/**
- * Use this function to evaluate resolvers in test files. Usage:
- *
- * ```js
- * const fields = Location.getFields();
- * expect(
- *   evaluateGraphQLResolver(fields.countryFlagURL, {
- *     country: ' ... ', // test value
- *   }),
- * ).toBe(' ... ');
- * ```
- */
-function evaluateGraphQLResolver(
-  field: { [key: string]: any, ... },
-  testValue: mixed,
-  argsValue?: { [key: string]: any, ... },
-  contextValue?: { [key: string]: any, ... },
-): any {
-  const resolveFn = field.resolve || function resolveMock() {};
-  return resolveFn(testValue, argsValue, contextValue, {
-    path: { key: 'mocked' },
-  });
-}
+import evaluateGraphQLResolver from './evaluateGraphQLResolver';
 
 export { evaluateGraphQLResolver, generateTestsFromFixtures };


### PR DESCRIPTION
Fields without explicit resolver are supported now.
It also calls `serialize` method if the field has one (scalars does) so invalid inputs can be tested.