### PR TITLE
Relay logger: show partial responses with errors

### DIFF
--- a/src/relay-runtime/package.json
+++ b/src/relay-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adeira/relay-runtime",
   "private": false,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "main": "index",
   "module": false,
   "sideEffects": false,

--- a/src/relay-runtime/src/RelayNetworkTypes.js
+++ b/src/relay-runtime/src/RelayNetworkTypes.js
@@ -1,0 +1,59 @@
+// @flow strict
+
+// https://github.com/facebook/relay/blob/master/packages/relay-runtime/network/RelayNetworkTypes.js
+
+export type PayloadData = { [key: string]: mixed, ... };
+
+export type PayloadError = {
+  message: string,
+  locations?: Array<{
+    line: number,
+    column: number,
+    ...
+  }>,
+  // Not officially part of the spec, but used at Facebook
+  severity?: 'CRITICAL' | 'ERROR' | 'WARNING',
+  ...
+};
+
+export type PayloadExtensions = { [key: string]: mixed, ... };
+
+/**
+ * The shape of a GraphQL response as dictated by the
+ * [spec](https://graphql.github.io/graphql-spec/June2018/#sec-Response-Format)
+ */
+export type GraphQLResponseWithData = {|
+  +data: PayloadData,
+  +errors?: Array<PayloadError>,
+  +extensions?: PayloadExtensions,
+  +label?: string,
+  +path?: Array<string | number>,
+|};
+
+export type GraphQLResponseWithoutData = {|
+  +data?: ?PayloadData,
+  +errors: Array<PayloadError>,
+  +extensions?: PayloadExtensions,
+  +label?: string,
+  +path?: Array<string | number>,
+|};
+
+export type GraphQLResponseWithExtensionsOnly = {|
+  // Per https://spec.graphql.org/June2018/#sec-Errors
+  // > If the data entry in the response is not present, the errors entry
+  // > in the response must not be empty. It must contain at least one error
+  // This means a payload has to have either a data key or an errors key:
+  // but the spec leaves room for the combination of data: null plus extensions
+  // since `data: null` is a *required* output if there was an error during
+  // execution, but the inverse is not described in the sepc: `data: null`
+  // does not necessarily indicate that there was an error.
+  +data: null,
+  +extensions: PayloadExtensions,
+|};
+
+export type GraphQLSingularResponse =
+  | GraphQLResponseWithData
+  | GraphQLResponseWithExtensionsOnly
+  | GraphQLResponseWithoutData;
+
+export type GraphQLResponse = GraphQLSingularResponse | $ReadOnlyArray<GraphQLSingularResponse>;

--- a/src/relay-runtime/src/__tests__/RelayLogger.node.test.js
+++ b/src/relay-runtime/src/__tests__/RelayLogger.node.test.js
@@ -1,7 +1,7 @@
 /**
- * @jest-environment  node
+ * @flow
+ * @jest-environment node
  */
-// @flow
 
 import Logger from '../RelayLogger';
 
@@ -15,7 +15,7 @@ afterEach(() => {
   spy.mockRestore();
 });
 
-it('does not log in node', () => {
+it('does not log in Node.js', () => {
   Logger({
     name: 'execute.start',
     transactionID: 1,

--- a/src/relay-runtime/src/__tests__/RelayLogger.test.js
+++ b/src/relay-runtime/src/__tests__/RelayLogger.test.js
@@ -1,24 +1,27 @@
 /**
  * @flow
- * @jest-environment  jsdom
+ * @jest-environment jsdom
  */
 
 import Logger from '../RelayLogger';
 
-let log;
+let consoleLogSpy;
+let consoleErrorSpy;
 let groupCollapsed;
 
 beforeEach(() => {
-  log = jest.spyOn(console, 'log').mockImplementation(jest.fn());
+  consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(jest.fn());
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn());
   groupCollapsed = jest.spyOn(console, 'groupCollapsed').mockImplementation(jest.fn());
 });
 
 afterEach(() => {
-  log.mockRestore();
+  consoleLogSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
   groupCollapsed.mockRestore();
 });
 
-it('logs in browser', () => {
+it("calls event 'execute.start' as expected", () => {
   Logger({
     name: 'execute.start',
     transactionID: 100_000,
@@ -30,9 +33,9 @@ it('logs in browser', () => {
     variables: {},
   });
 
-  expect(log).toHaveBeenCalledTimes(2);
-  expect(log).toHaveBeenCalledWith('Variables: %o', {});
-  expect(log).toHaveBeenCalledWith('query Lol{id}');
+  expect(consoleLogSpy).toHaveBeenCalledTimes(2);
+  expect(consoleLogSpy).toHaveBeenCalledWith('Variables: %o', {});
+  expect(consoleLogSpy).toHaveBeenCalledWith('query Lol{id}');
   expect(groupCollapsed).toHaveBeenCalledTimes(1);
   expect(groupCollapsed).toHaveBeenCalledWith(
     '%c%s%c%s',
@@ -42,3 +45,80 @@ it('logs in browser', () => {
     ' - test 🔍 (13)',
   );
 });
+
+test.each([
+  // response => groupCollapsedArgs
+  [{ data: null, extensions: {} }, ['%c%s', 'font-weight:bold;', '[Relay 1] execute.next']],
+  [{ data: 'mock' }, ['%c%s', 'font-weight:bold;', '[Relay 1] execute.next']],
+  [
+    { errors: 'oops' },
+    [
+      '%c%s%c%s',
+      'font-weight:bold;color:orange',
+      '[Relay 1] execute.next',
+      'font-weight:normal',
+      ' - partial response with errors',
+    ],
+  ],
+  [
+    { data: null, errors: 'oops' },
+    [
+      '%c%s%c%s',
+      'font-weight:bold;color:orange',
+      '[Relay 1] execute.next',
+      'font-weight:normal',
+      ' - partial response with errors',
+    ],
+  ],
+  [
+    { data: 'mock', errors: 'oops' },
+    [
+      '%c%s%c%s',
+      'font-weight:bold;color:orange',
+      '[Relay 1] execute.next',
+      'font-weight:normal',
+      ' - partial response with errors',
+    ],
+  ],
+])("%#) calls event 'execute.next' as expected", (response, groupCollapsedArgs) => {
+  Logger({
+    name: 'execute.next',
+    transactionID: 100_000,
+    response,
+  });
+
+  expect(groupCollapsed).toHaveBeenCalledWith(...groupCollapsedArgs);
+});
+
+it("calls event 'execute.error' as expected", () => {
+  Logger({
+    name: 'execute.error',
+    transactionID: 100_000,
+    error: new Error('oops'),
+  });
+
+  expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  expect(consoleErrorSpy).toHaveBeenCalledWith(new Error('oops'));
+  expect(groupCollapsed).toHaveBeenCalledWith(
+    '%c%s',
+    'font-weight:bold;color:red',
+    '[Relay 1] execute.error',
+  );
+});
+
+test.each(['execute.info', 'execute.complete', 'execute.unsubscribe'])(
+  "calls event '%s' as expected",
+  eventName => {
+    // $FlowExpectedError: OK for testing purposes - additional props are being ignored for these events
+    Logger({
+      name: eventName,
+      transactionID: 100_001,
+    });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '%c%s',
+      'font-weight:bold',
+      `[Relay 2] ${eventName}`,
+    );
+  },
+);

--- a/src/relay-utils/package.json
+++ b/src/relay-utils/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@adeira/relay": "^1.2.0",
-    "@adeira/relay-runtime": "^0.9.0",
+    "@adeira/relay-runtime": "^0.10.0",
     "@babel/runtime": "^7.9.2"
   },
   "peerDependencies": {

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -21,7 +21,7 @@
     "@adeira/js": "^1.2.0",
     "@adeira/logger": "^0.2.0",
     "@adeira/monorepo-utils": "^0.6.0",
-    "@adeira/relay-runtime": "^0.9.0",
+    "@adeira/relay-runtime": "^0.10.0",
     "@adeira/signed-source": "^0.1.0",
     "@babel/register": "^7.9.0",
     "@babel/runtime": "^7.9.2",


### PR DESCRIPTION
This change better displays responses which are successful only partially. Otherwise, these errors can be really well hidden and it's easy to overlook them.