### PR TITLE
relay: Use disposable type from relay-runtime

### DIFF
--- a/src/relay-runtime/index.js
+++ b/src/relay-runtime/index.js
@@ -1,5 +1,6 @@
 // @flow
 
+export type { GraphQLTaggedNode, Disposable } from 'relay-runtime';
 export { default as RelayLogger } from './src/RelayLogger';
 
 export type { Variables, RecordProxy } from './src/RelayRuntimeTypes';

--- a/src/relay/src/LocalQueryRenderer.js
+++ b/src/relay/src/LocalQueryRenderer.js
@@ -3,10 +3,9 @@
 import * as React from 'react';
 import { LocalQueryRenderer as RelayLocalQueryRenderer, ReactRelayContext } from 'react-relay';
 import { invariant } from '@adeira/js';
-import type { Variables } from '@adeira/relay-runtime';
+import type { Variables, GraphQLTaggedNode } from '@adeira/relay-runtime';
 
 import createLocalEnvironment from './createLocalEnvironment';
-import type { GraphQLTaggedNode } from './types.flow';
 import type { Environment } from './runtimeTypes.flow';
 
 type RendererProps = {| +[key: string]: any |}; // it can be anything, really

--- a/src/relay/src/QueryRenderer.js
+++ b/src/relay/src/QueryRenderer.js
@@ -4,9 +4,8 @@ import * as React from 'react';
 import { QueryRenderer as RelayQueryRenderer, ReactRelayContext } from 'react-relay';
 import { invariant, sprintf } from '@adeira/js';
 import { TimeoutError, ResponseError } from '@adeira/fetch';
-import type { Variables } from '@adeira/relay-runtime';
+import type { Variables, GraphQLTaggedNode } from '@adeira/relay-runtime';
 
-import type { GraphQLTaggedNode } from './types.flow';
 import type { Environment } from './runtimeTypes.flow';
 
 type RendererProps = {| +[key: string]: any |}; // it can be anything, really

--- a/src/relay/src/__flowtests__/CustomQueryRenderer.js
+++ b/src/relay/src/__flowtests__/CustomQueryRenderer.js
@@ -1,8 +1,9 @@
 // @flow
 
 import * as React from 'react';
+import type { GraphQLTaggedNode } from '@adeira/relay-runtime';
 
-import { QueryRenderer, graphql, type GraphQLTaggedNode, createLocalEnvironment } from '../index';
+import { QueryRenderer, graphql, createLocalEnvironment } from '../index';
 
 function placeholder() {
   return null;

--- a/src/relay/src/__flowtests__/Disposable.js
+++ b/src/relay/src/__flowtests__/Disposable.js
@@ -1,6 +1,8 @@
 // @flow
 
-import { graphql, requestSubscription, type Disposable, type RelayProp } from '../index';
+import type { Disposable } from '@adeira/relay-runtime';
+
+import { graphql, requestSubscription, type RelayProp } from '../index';
 
 type Props = {| +relay: RelayProp |};
 

--- a/src/relay/src/createRefetchContainer.js
+++ b/src/relay/src/createRefetchContainer.js
@@ -3,8 +3,9 @@
 import * as React from 'react';
 import { createRefetchContainer as _createRefetchContainer } from 'react-relay';
 import { invariant, isObjectEmpty } from '@adeira/js';
+import type { GraphQLTaggedNode, Disposable } from '@adeira/relay-runtime';
 
-import type { $RelayProps, FragmentSpec, GraphQLTaggedNode, Disposable } from './types.flow';
+import type { $RelayProps, FragmentSpec } from './types.flow';
 import type { Environment } from './runtimeTypes.flow';
 
 type RefetchOptions = {

--- a/src/relay/src/fetchQuery.js
+++ b/src/relay/src/fetchQuery.js
@@ -1,9 +1,8 @@
 // @flow
 
 import { fetchQuery as relayFetchQuery } from 'react-relay';
-import type { Variables } from '@adeira/relay-runtime';
+import type { Variables, GraphQLTaggedNode } from '@adeira/relay-runtime';
 
-import type { GraphQLTaggedNode } from './types.flow';
 import type { Environment } from './runtimeTypes.flow';
 
 // https://relay.dev/docs/en/fetch-query

--- a/src/relay/src/hooks/__flowtests__/useMutation.js
+++ b/src/relay/src/hooks/__flowtests__/useMutation.js
@@ -1,7 +1,8 @@
 // @flow
 
+import type { Disposable } from '@adeira/relay-runtime';
+
 import { useMutation, graphql } from '../index';
-import type { Disposable } from '../../types.flow';
 
 const mutation = graphql`
   mutation useMutation {

--- a/src/relay/src/hooks/useMutation.js
+++ b/src/relay/src/hooks/useMutation.js
@@ -1,16 +1,12 @@
 // @flow
 
 import { useState, useRef, useCallback, useEffect } from 'react';
+import type { GraphQLTaggedNode, Disposable } from '@adeira/relay-runtime';
 
 import useIsMountedRef from './useIsMountedRef';
 import useRelayEnvironment from './useRelayEnvironment';
 import { commitMutation, type MutationParameters } from '../mutations';
-import type {
-  DeclarativeMutationConfig,
-  GraphQLTaggedNode,
-  Disposable,
-  Uploadables,
-} from '../types.flow';
+import type { DeclarativeMutationConfig, Uploadables } from '../types.flow';
 import type { RecordSourceSelectorProxy } from '../runtimeTypes.flow';
 
 type HookMutationConfig<T: MutationParameters> = {|
@@ -97,6 +93,5 @@ export default function useMutation<T: MutationParameters>(
     [cleanup, environment, isMountedRef, mutation],
   );
 
-  // $FlowFixMe errors after upgrading to relay 9.1.0
   return [commit, isMutationInFlight];
 }

--- a/src/relay/src/index.js
+++ b/src/relay/src/index.js
@@ -53,5 +53,7 @@ module.exports = {
 export type { RelayProp } from './createFragmentContainer';
 export type { PaginationRelayProp } from './createPaginationContainer';
 export type { RefetchRelayProp } from './createRefetchContainer';
-export type { DeclarativeMutationConfig, Disposable, GraphQLTaggedNode } from './types.flow';
+export type { DeclarativeMutationConfig } from './types.flow';
 export type { Environment, Snapshot, RecordMap } from './runtimeTypes.flow';
+// TODO: Remove from here, and only export from @adeira/relay-runtime
+export type { Disposable, GraphQLTaggedNode } from '@adeira/relay-runtime';

--- a/src/relay/src/mutations.js
+++ b/src/relay/src/mutations.js
@@ -1,9 +1,9 @@
 // @flow
 
-import type { Variables } from '@adeira/relay-runtime';
+import type { GraphQLTaggedNode, Variables } from '@adeira/relay-runtime';
 import { commitMutation as _commitMutation } from 'react-relay';
 
-import type { GraphQLTaggedNode, DeclarativeMutationConfig, Uploadables } from './types.flow';
+import type { DeclarativeMutationConfig, Uploadables } from './types.flow';
 import type { Environment, RecordSourceSelectorProxy } from './runtimeTypes.flow';
 
 opaque type SelectorData = $FlowFixMe;

--- a/src/relay/src/readInlineData.js
+++ b/src/relay/src/readInlineData.js
@@ -1,8 +1,7 @@
 // @flow
 
 import { readInlineData as _readInlineData } from 'react-relay';
-
-import type { GraphQLTaggedNode } from './types.flow';
+import type { GraphQLTaggedNode } from '@adeira/relay-runtime';
 
 opaque type FragmentReference = empty;
 

--- a/src/relay/src/requestSubscription.js
+++ b/src/relay/src/requestSubscription.js
@@ -1,9 +1,9 @@
 // @flow
 
-import type { Variables } from '@adeira/relay-runtime';
+import type { Variables, Disposable, GraphQLTaggedNode } from '@adeira/relay-runtime';
 import { requestSubscription as _requestSubscription } from 'react-relay';
 
-import type { DeclarativeMutationConfig, Disposable, GraphQLTaggedNode } from './types.flow';
+import type { DeclarativeMutationConfig } from './types.flow';
 import type { Environment, RecordSourceSelectorProxy } from './runtimeTypes.flow';
 
 opaque type SelectorData = $FlowFixMe;

--- a/src/relay/src/types.flow.js
+++ b/src/relay/src/types.flow.js
@@ -1,15 +1,9 @@
 // @flow
 
-import type { Variables } from '@adeira/relay-runtime';
-import type { GraphQLTaggedNode as _GraphQLTaggedNode } from 'relay-runtime';
+import type { Variables, GraphQLTaggedNode } from '@adeira/relay-runtime';
 
-export type GraphQLTaggedNode = _GraphQLTaggedNode;
 export type RequestNode = $FlowFixMe;
 export type Uploadables = { +[key: string]: File | Blob, ... };
-
-export type Disposable = {|
-  +dispose: () => void,
-|};
 
 // The type of a graphql`...` tagged template expression.
 


### PR DESCRIPTION
Move disposable and GraphQLTaggedNode types to @adeira/relay-runtime