### PR TITLE
Hard-code all values in prettier & Release @adeira/eslint-config 2.2.1 

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {},
   "devDependencies": {
     "@adeira/babel-preset-adeira": "^0.4.0",
-    "@adeira/eslint-config": "^2.2.0",
+    "@adeira/eslint-config": "^2.2.1",
     "@adeira/flow-bin": "^0.2.0",
     "@babel/core": "^7.10.2",
     "babel-eslint": "^10.1.0",

--- a/src/eslint-config-adeira/getCommonConfig.js
+++ b/src/eslint-config-adeira/getCommonConfig.js
@@ -38,12 +38,17 @@ module.exports = function getCommonConfig(rules /*: EslintConfigRules */) /*: Es
       'prettier/prettier': [
         ERROR,
         {
-          // see: prettier.config.js
-          bracketSpacing: true,
-          printWidth: 100, // see: https://prettier.io/docs/en/options.html#print-width
-          singleQuote: true,
+          printWidth: 100, // Default: 80 ; See https://prettier.io/docs/en/options.html#print-width
           tabWidth: 2,
+          tabs: false,
+          semi: true,
+          singleQuote: true,
+          quoteProps: 'as-needed',
+          jsxSingleQuote: false,
           trailingComma: 'all',
+          bracketSpacing: true,
+          jsxBracketSameLine: false,
+          arrowParens: 'avoid', // Keep 'avoid' from prettier@1 ; See https://prettier.io/docs/en/options.html#arrow-function-parentheses
         },
       ],
     },

--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/eslint-config-adeira",
   "license": "MIT",
   "private": false,
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "index",
   "sideEffects": false,
   "dependencies": {


### PR DESCRIPTION
- Hard-code all values in prettier
  - to make it clear, these are the DEFAULT values that `@adeira/eslint-config` was using in `v2.1.0`
  - `arrowParens` changed its default value in `prettier@2`, so we should hard-code all values to make sure there are no conflicts going forward.
- Release @adeira/eslint-config 2.2.1