### PR TITLE
Improve relay types

### DIFF
--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -10,7 +10,7 @@
     "@adeira/graphql-relay": "^0.2.0",
     "@adeira/js": "^1.2.4",
     "@adeira/monorepo-utils": "^0.8.0",
-    "@adeira/relay": "^2.0.2",
+    "@adeira/relay": "^2.0.3",
     "@adeira/relay-runtime": "^0.14.0",
     "@adeira/relay-utils": "0.11.0",
     "@adeira/test-utils": "^0.5.0",

--- a/src/relay-utils/package.json
+++ b/src/relay-utils/package.json
@@ -9,7 +9,7 @@
   "description": "Relay utils used at Adeira ecosystem",
   "license": "MIT",
   "dependencies": {
-    "@adeira/relay": "^2.0.2",
+    "@adeira/relay": "^2.0.3",
     "@adeira/relay-runtime": "^0.14.0",
     "@babel/runtime": "^7.10.5"
   },

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adeira/relay",
   "private": false,
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "src/index",
   "module": false,
   "sideEffects": false,

--- a/src/relay/src/fetchQuery.js
+++ b/src/relay/src/fetchQuery.js
@@ -1,16 +1,17 @@
 // @flow
 
 import { fetchQuery as relayFetchQuery } from 'react-relay';
-import type { Variables, GraphQLTaggedNode } from '@adeira/relay-runtime';
+import type { OperationType } from 'relay-runtime';
+import type { GraphQLTaggedNode } from '@adeira/relay-runtime';
 
 import type { Environment } from './runtimeTypes.flow';
 
 // https://relay.dev/docs/en/fetch-query
-export default function fetchQuery(
+export default function fetchQuery<T: OperationType>(
   environment: Environment,
   query: GraphQLTaggedNode,
-  variables: Variables,
+  variables: $PropertyType<T, 'variables'>,
   // TODO: cacheConfig (?)
-): Promise<mixed> {
+): Promise<$PropertyType<T, 'response'>> {
   return relayFetchQuery(environment, query, variables);
 }


### PR DESCRIPTION
This should enable passing generated types which are now incompatible with mixed, e.g.:

```
export type fetchCreditsQuery = {|
  variables: fetchCreditsQueryVariables,
  response: fetchCreditsQueryResponse,
|};

// ... later:
const response = await fetchQuery<fetchCreditsQuery>(env, query, variables);
```