### PR TITLE
Relay example: remove `dynamic-export` from .flowconfig

### DIFF
--- a/src/example-relay/__github__/.flowconfig
+++ b/src/example-relay/__github__/.flowconfig
@@ -13,7 +13,6 @@
 [lints]
 all=error
 ambiguous-object-type=off
-dynamic-export=off
 sketchy-null-bool=off
 unclear-type=off
 untyped-import=off


### PR DESCRIPTION
This option has been removed from Flow, see: 93d01d89c8337dbd85c09a677a613e435180513f