### PR TITLE
Dependencies: remove Eslint resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,5 @@
     "test": "yarn run typecheck && yarn run lint && yarn run test-only --ci --colors",
     "test-only": "BABEL_TYPES_8_BREAKING=true yarn run monorepo-babel-node src/monorepo-utils/bin/monorepo-run-tests.js",
     "typecheck": "yarn run adeira-flow-bin"
-  },
-  "resolutions": {
-    "eslint": "~7.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6335,7 +6335,7 @@ eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
-eslint@^7.6.0, eslint@~7.6.0:
+eslint@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.6.0.tgz#522d67cfaea09724d96949c70e7a0550614d64d6"
   integrity sha512-QlAManNtqr7sozWm5TF4wIH9gmUm2hE3vNRUvyoYAa4y1l5/jxD/PQStEjBMQtCqZmSep8UxrcecI60hOpe61w==


### PR DESCRIPTION
I tested it without it and it seems to be working fine. I don't even remember why was it there. Seems like we no longer have this problem (?).