### PR TITLE
Docs: Fix config

### DIFF
--- a/src/docs/docusaurus.config.js
+++ b/src/docs/docusaurus.config.js
@@ -24,7 +24,7 @@ module.exports = {
         src: 'img/logo-transparent.png',
         alt: 'Adeira.dev',
       },
-      links: [
+      items: [
         { to: 'docs/general/introduction', label: 'Docs', position: 'left' },
         {
           href: 'https://github.com/adeira/universe',


### PR DESCRIPTION
`themeConfig.navbar.links` has been renamed as `themeConfig.navbar.items`