### PR TITLE
Relay: partially revert abort controller

### DIFF
--- a/src/relay/CHANGELOG.md
+++ b/src/relay/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Unreleased
 
-- Automatically cancel stale requests via fetch `AbortController` (https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
-
 # 2.0.2
 
 - Upgrade relay to 10.0.1

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -25,7 +25,6 @@
     "@adeira/signed-source": "^1.0.0",
     "@babel/register": "^7.10.5",
     "@babel/runtime": "^7.11.2",
-    "abort-controller": "^3.0.0",
     "babel-plugin-relay": "^10.0.1",
     "commander": "^6.0.0",
     "is-ci": "^2.0.0",

--- a/src/relay/src/createRequestHandler.js
+++ b/src/relay/src/createRequestHandler.js
@@ -2,7 +2,6 @@
 
 import { Observable, type CacheConfig } from 'relay-runtime';
 import type { Variables, GraphQLResponse } from '@adeira/relay-runtime';
-import AbortController from 'abort-controller';
 
 import type { RequestNode, Uploadables } from './types.flow';
 
@@ -25,11 +24,8 @@ export default function createRequestHandler(customFetcher: (...args: $ReadOnlyA
     cacheConfig: CacheConfig,
     uploadables: ?Uploadables,
   ) {
-    const controller = new AbortController();
-    const signal = controller.signal;
-
     return Observable.create((sink: Sink) => {
-      customFetcher(requestNode, variables, uploadables, signal)
+      customFetcher(requestNode, variables, uploadables)
         .then((response) => {
           if (response.errors) {
             // Relay is currently quite opinionated and recommends to either try to render the data
@@ -50,8 +46,7 @@ export default function createRequestHandler(customFetcher: (...args: $ReadOnlyA
         });
 
       return function cleanup() {
-        // called after sink.complete or when Relay unsubscribes
-        controller.abort();
+        // noop, do anything here (called after sink.complete or when Relay unsubscribes)
       };
     });
   };

--- a/src/relay/src/fetchers/createNetworkFetcher.js
+++ b/src/relay/src/fetchers/createNetworkFetcher.js
@@ -28,7 +28,6 @@ export default function createNetworkFetcher(
     request: RequestNode,
     variables: Variables,
     uploadables: ?Uploadables,
-    signal: ?AbortSignal,
   ) {
     const body = getRequestBody(request, variables, uploadables);
 
@@ -52,7 +51,6 @@ export default function createNetworkFetcher(
       method: 'POST',
       headers,
       body,
-      signal,
       ...refetchConfig,
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2925,7 +2925,7 @@ abab@^2.0.3:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.4.tgz#6dfa57b417ca06d21b2478f0e638302f99c2405c"
   integrity sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==
 
-abort-controller@3.0.0, abort-controller@^3.0.0:
+abort-controller@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
   integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==


### PR DESCRIPTION
This partially reverts 5acc6c1d5a5eb0eb8e09c902b5d3ba3b92b28ec7 - turned out it's a bit tricky to implement it properly to support even IE 11. Will try again somewhere down the road.