### PR TITLE
Global ID: Export Encoder

### DIFF
--- a/src/graphql-global-id/CHANGELOG.md
+++ b/src/graphql-global-id/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 1.1.0
+
+- export Encoder
+
 # 1.0.0
 
 - removed deprecated functions `DEPRECATED_evaluateGlobalIdField` and `__isTypeOf`

--- a/src/graphql-global-id/package.json
+++ b/src/graphql-global-id/package.json
@@ -4,8 +4,8 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/graphql-global-id",
   "license": "MIT",
   "private": false,
-  "version": "1.0.1",
-  "main": "src/GlobalID",
+  "version": "1.1.0",
+  "main": "src/index",
   "sideEffects": false,
   "dependencies": {
     "@adeira/js": "^1.2.2",

--- a/src/graphql-global-id/src/index.js
+++ b/src/graphql-global-id/src/index.js
@@ -1,0 +1,8 @@
+// @flow strict-local
+
+import globalIdField from './GlobalID';
+
+export * from './Encoder';
+export * from './GlobalID';
+
+export default globalIdField;


### PR DESCRIPTION
I'm gonna need it for `graphql-relay-fauna` package