### PR TITLE
Flow: fix types-first migration command

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -66,7 +66,6 @@ sharedmemory.hash_table_pow=21
 ; This option lets you alias 'any' with a given string - useful for explaining why you’re using 'any'.
 suppress_type=$FlowFixMe
 
-
 esproposal.optional_chaining=enable
 esproposal.nullish_coalescing=enable
 

--- a/src/flow-bin/bin/migrate/types-first.js
+++ b/src/flow-bin/bin/migrate/types-first.js
@@ -1,26 +1,19 @@
 // @flow
 
-/* eslint-disable no-console */
-
 import { ShellCommand } from '@adeira/monorepo-utils';
-
-import walk from './utils/walk';
 
 // https://flow.org/en/docs/cli/annotate-exports/
 export default function typesFirst(flowPath: string, typesFirstPath: string) {
-  walk(typesFirstPath, (file) => {
-    console.log('🔷 %s', file);
-    new ShellCommand(
-      null,
-      flowPath,
-      'codemod',
-      'annotate-exports',
-      '--write',
-      '--repeat',
-      '--log-level=info',
-      file,
-    )
-      .setOutputToScreen()
-      .runSynchronously();
-  });
+  new ShellCommand(
+    null,
+    flowPath,
+    'codemod',
+    'annotate-exports',
+    '--write',
+    '--repeat',
+    '--log-level=info',
+    typesFirstPath,
+  )
+    .setOutputToScreen()
+    .runSynchronously();
 }


### PR DESCRIPTION
I incorrectly changed the command in af7c259283d1d1cc2aa16ceeb69ced2f485300c9 (it accepts the whole folders and not files). It worked as well but it was too slow.