### PR TITLE
SX: fix `change-case` import

### DIFF
--- a/src/sx/README.md
+++ b/src/sx/README.md
@@ -3,7 +3,7 @@ In conventional applications, CSS rules are duplicated throughout the stylesheet
 ```text
 TODOs and Ideas:
  - media queries (?)
- - autoprefixer via browserlist
+ - autoprefixer via browserlist (https://github.com/robinweser/inline-style-prefixer?)
  - babel transpilation (compile time instead of runtime)
  - support for `marginEnd`, `marginVertical` and so on like in RN (for LRT/RTL layouts)
 ```

--- a/src/sx/package.json
+++ b/src/sx/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/sx",
   "license": "MIT",
   "private": false,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "index",
   "sideEffects": false,
   "dependencies": {

--- a/src/sx/src/transformStyleName.js
+++ b/src/sx/src/transformStyleName.js
@@ -1,7 +1,7 @@
 // @flow
 
-import { paramCase } from 'change-case';
+import * as changeCase from 'change-case';
 
 export default function transformStyleName(styleName: string): string {
-  return paramCase(styleName);
+  return changeCase.paramCase(styleName);
 }


### PR DESCRIPTION
As suggested here: https://github.com/blakeembrey/change-case/blob/c19866744e0ea07bb167602a81a664162d59618e/README.md

The library uses some weird export system and it stops working when transpiled with the following error:

```
Can't import the named export 'paramCase' from non EcmaScript module (only default export is available)
```