### PR TITLE
Relay example: use '@adeira/sx'

### DIFF
--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "@adeira/fetch": "^1.0.3",
+    "@adeira/sx": "^0.3.0",
     "@adeira/graphql-bc-checker": "^0.2.0",
     "@adeira/graphql-global-id": "^1.0.0",
     "@adeira/graphql-relay": "^0.2.0",

--- a/src/example-relay/src/pages/_app.js
+++ b/src/example-relay/src/pages/_app.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react';
+import * as sx from '@adeira/sx';
 import App from 'next/app';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -93,13 +94,17 @@ export default class MyApp extends App {
           </Header>
           <Box pad="medium">
             {__DEV__ ? (
-              <Box background="neutral-3" pad="small">
+              <div className={styles('box')}>
                 TIP: Open a console to see what&apos;s going on behind the scenes.
-              </Box>
+              </div>
             ) : (
-              <Box background="status-warning" pad="small">
-                It&apos;s better to clone this repository and try it in development mode.
-              </Box>
+              <div className={styles('box', 'boxWarning')}>
+                It&apos;s better to clone this repository and try it in development mode so you can
+                see what&apos;s going on behind the scenes:{' '}
+                <a href="https://github.com/adeira/relay-example">
+                  https://github.com/adeira/relay-example
+                </a>
+              </div>
             )}
             <Box margin={{ top: 'small' }}>
               <Component {...pageProps} />
@@ -110,3 +115,14 @@ export default class MyApp extends App {
     );
   }
 }
+
+const styles = sx.create({
+  box: {
+    backgroundColor: '#FFF8E1',
+    maxWidth: '100%',
+    padding: 12,
+  },
+  boxWarning: {
+    backgroundColor: '#FFCA28',
+  },
+});

--- a/src/example-relay/src/pages/_document.js
+++ b/src/example-relay/src/pages/_document.js
@@ -3,11 +3,13 @@
 import React, { type Element } from 'react';
 import Document, { Head, Main, NextScript, type DocumentContext } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
+import * as sx from '@adeira/sx';
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext): Promise<any> {
     const sheet = new ServerStyleSheet();
     const originalRenderPage = ctx.renderPage;
+    const { html, css } = sx.renderStatic(originalRenderPage);
 
     try {
       ctx.renderPage = () =>
@@ -17,6 +19,7 @@ export default class MyDocument extends Document {
 
       const initialProps = await Document.getInitialProps(ctx);
       return {
+        ...html, // @adeira/sx
         ...initialProps,
         styles: (
           <>
@@ -24,6 +27,7 @@ export default class MyDocument extends Document {
             {sheet.getStyleElement()}
           </>
         ),
+        css, // @adeira/sx
       };
     } finally {
       sheet.seal();
@@ -38,6 +42,7 @@ export default class MyDocument extends Document {
             href="https://fonts.googleapis.com/css?family=Roboto:400,400i,500,500i,700"
             rel="stylesheet"
           />
+          <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
           <link rel="stylesheet" type="text/css" href="/nprogress.css" />
         </Head>
         <body>

--- a/src/sx/README.md
+++ b/src/sx/README.md
@@ -20,7 +20,7 @@ Create a stylesheet and use it to generate `className` props for React:
 
 ```jsx
 import * as React from 'react';
-import sx from '@adeira/sx';
+import * as sx from '@adeira/sx';
 
 export default function Example() {
   return <div className={styles('example')}>example</div>;
@@ -52,7 +52,7 @@ The example above will generate something like this:
 Finally, render somewhere the styles and HTML. Example for Next.js with [custom document](https://nextjs.org/docs/advanced-features/custom-document) would be:
 
 ```jsx
-import sx from '@adeira/sx';
+import * as sx from '@adeira/sx';
 
 export default class MyDocument extends Document {
   static getInitialProps({ renderPage }) {

--- a/src/sx/__flowtests__/css-properties.js
+++ b/src/sx/__flowtests__/css-properties.js
@@ -1,6 +1,6 @@
 // @flow
 
-import sx from '../index';
+import * as sx from '../index';
 
 sx.create({
   NoIssues: {

--- a/src/sx/__flowtests__/sx.js
+++ b/src/sx/__flowtests__/sx.js
@@ -2,7 +2,7 @@
 
 import React, { type Node } from 'react';
 
-import sx from '../index';
+import * as sx from '../index';
 
 export function NoErrors(): Node {
   const styles = sx.create({

--- a/src/sx/index.js
+++ b/src/sx/index.js
@@ -3,7 +3,4 @@
 import create from './src/create';
 import renderStatic from './src/renderStatic';
 
-export default {
-  create,
-  renderStatic,
-};
+export { create, renderStatic };

--- a/src/sx/package.json
+++ b/src/sx/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/sx",
   "license": "MIT",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "index",
   "sideEffects": false,
   "dependencies": {

--- a/src/sx/src/__tests__/renderStatic.test.js
+++ b/src/sx/src/__tests__/renderStatic.test.js
@@ -2,7 +2,7 @@
 
 import prettier from 'prettier';
 
-import sx from '../../index';
+import * as sx from '../../index';
 import { styleBuffer, mediaStyleBuffer } from '../styleBuffer';
 
 beforeEach(() => {


### PR DESCRIPTION
Eventually, I'd like to completely replace `grommet` there and use only atomic CSS-in-JS. It will also help us developing `@adeira/sx` since we can try it directly in Universe.