### PR TITLE
SX: add failing test for nested media queries

### DIFF
--- a/src/sx/src/__tests__/__snapshots__/renderStatic.test.js.snap
+++ b/src/sx/src/__tests__/__snapshots__/renderStatic.test.js.snap
@@ -129,6 +129,33 @@ class="wUqnh _4rAdwD"
 
 `;
 
+exports[`matches expected output: media-queries-nested.json 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+{
+  "test": {
+    "@media print": {
+      "color": "red",
+      "@media (max-width: 12cm)": {
+        "color": "blue"
+      }
+    }
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+@media print {
+  .wUqnh {
+    color: #f00;
+  }
+  @media (max-width: 12cm) {
+    ._4fo5TC {
+      color: #00f;
+    }
+  }
+}
+
+`;
+
 exports[`matches expected output: pseudo-classes.json 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 {

--- a/src/sx/src/__tests__/fixtures/media-queries-nested.json
+++ b/src/sx/src/__tests__/fixtures/media-queries-nested.json
@@ -1,0 +1,10 @@
+{
+  "test": {
+    "@media print": {
+      "color": "red",
+      "@media (max-width: 12cm)": {
+        "color": "blue"
+      }
+    }
+  }
+}


### PR DESCRIPTION
We are currently generating media queries on a global level but they should stay nested. See: https://www.w3.org/TR/css3-conditional/#processing