### PR TITLE
example: Replace grommet with sx styled components

### DIFF
--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -19,7 +19,6 @@
     "cors": "^2.8.5",
     "date-fns": "^2.16.0",
     "graphql": "^15.3.0",
-    "grommet": "^2.15.0",
     "grommet-icons": "^4.4.0",
     "next": "^9.5.2",
     "next-plugin-custom-babel-config": "^1.0.4",

--- a/src/example-relay/src/Homepage/index.js
+++ b/src/example-relay/src/Homepage/index.js
@@ -2,22 +2,24 @@
 
 import * as React from 'react';
 import { graphql, QueryRenderer } from '@adeira/relay';
-import { Heading, Text } from 'grommet';
 import * as sx from '@adeira/sx';
 
 import LocationsPaginatedBidirectional from './locations/LocationsPaginatedBidirectional';
 import LocationsPaginatedRefetch from './locations/LocationsPaginatedRefetch';
 import LocationsPaginated from './locations/LocationsPaginated';
 import type { HomepageQueryResponse } from './__generated__/HomepageQuery.graphql';
+import Heading from '../components/Heading';
+import Text from '../components/Text';
 
 function Demo(props) {
   return (
     <>
-      <Heading level={2} size="small">
-        {props.title}
-      </Heading>
+      <Heading level={2}>{props.title}</Heading>
       <Text size="small">
-        See: <a href={props.link}>{props.linkTitle}</a>
+        See:{' '}
+        <a rel="noreferrer" target="_blank" href={props.link}>
+          {props.linkTitle}
+        </a>
       </Text>
       {props.component}
     </>

--- a/src/example-relay/src/Homepage/locations/Location.js
+++ b/src/example-relay/src/Homepage/locations/Location.js
@@ -2,9 +2,10 @@
 
 import React from 'react';
 import { createFragmentContainer, graphql, type FragmentContainerType } from '@adeira/relay';
-import { Text, Box } from 'grommet';
+import * as sx from '@adeira/sx';
 
 import type { Location_location as LocationDataType } from './__generated__/Location_location.graphql';
+import Text from '../../components/Text';
 
 type Props = {|
   +location: ?LocationDataType,
@@ -19,12 +20,12 @@ function Location({ location }: Props) {
   const countryName = location.country?.name ?? '';
   return (
     <li>
-      <Box align="center" direction="row" gap="small">
+      <div className={styles('box')}>
         <img src={location.countryFlagURL} alt={`${countryName} flag`} height="24" width="24" />
         <Text dataTest={`location-${name}`} size="small">
           {name}
         </Text>
-      </Box>
+      </div>
     </li>
   );
 }
@@ -40,3 +41,11 @@ export default (createFragmentContainer(Location, {
     }
   `,
 }): FragmentContainerType<Props>);
+
+const styles = sx.create({
+  box: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px', // Works in edge, chrome and firefox, but should be ok for this app
+  },
+});

--- a/src/example-relay/src/Homepage/locations/LocationsPaginated.js
+++ b/src/example-relay/src/Homepage/locations/LocationsPaginated.js
@@ -7,10 +7,10 @@ import {
   type PaginationRelayProp,
   type PaginationContainerType,
 } from '@adeira/relay';
-import { Button } from 'grommet';
 
 import Location from './Location';
 import type { LocationsPaginated_data as LocationsDataType } from './__generated__/LocationsPaginated_data.graphql';
+import Button from '../../components/Button';
 
 type Props = {|
   +data: LocationsDataType,
@@ -37,7 +37,7 @@ function LocationsPaginated(props: Props) {
           <Location key={edge?.node?.id} location={edge?.node} />
         ))}
       </ol>
-      <Button label="Load more!" onClick={loadMore} size="small" primary />
+      <Button onClick={loadMore}>Load more!</Button>
     </>
   );
 }

--- a/src/example-relay/src/Homepage/locations/LocationsPaginatedBidirectional.js
+++ b/src/example-relay/src/Homepage/locations/LocationsPaginatedBidirectional.js
@@ -7,11 +7,12 @@ import {
   type RefetchRelayProp,
   type RefetchContainerType,
 } from '@adeira/relay';
-import { Button, Box } from 'grommet';
 import { Next, Previous } from 'grommet-icons';
+import * as sx from '@adeira/sx';
 
 import Location from './Location';
 import type { LocationsPaginatedBidirectional_data as LocationsDataType } from './__generated__/LocationsPaginatedBidirectional_data.graphql';
+import Button from '../../components/Button';
 
 type Props = {|
   +itemsCount: number,
@@ -64,28 +65,32 @@ function LocationsPaginatedBidirectional(props: Props) {
           <Location key={edge?.node?.id} location={edge?.node} />
         ))}
       </ol>
-      <Box flex={true} direction="row">
+      <div className={styles('buttonBox')}>
         <Button
           onClick={openPreviousPage}
           disabled={!pageInfo.hasPreviousPage}
-          size="small"
-          label="Previous page"
-          primary
-          icon={<Previous color="white" size="small" />}
-        />
+          iconLeft={<Previous color="white" size="small" />}
+        >
+          Previous page
+        </Button>
         <Button
-          label="Next page"
           onClick={openNextPage}
           disabled={!pageInfo.hasNextPage}
-          size="small"
-          primary
-          icon={<Next color="white" size="small" />}
-          reverse
-        />
-      </Box>
+          iconRight={<Next color="white" size="small" />}
+        >
+          Next page
+        </Button>
+      </div>
     </>
   );
 }
+
+const styles = sx.create({
+  buttonBox: {
+    display: 'flex',
+    gap: 'var(--space-small)',
+  },
+});
 
 export default (createRefetchContainer(
   LocationsPaginatedBidirectional,

--- a/src/example-relay/src/Homepage/locations/LocationsPaginatedRefetch.js
+++ b/src/example-relay/src/Homepage/locations/LocationsPaginatedRefetch.js
@@ -7,8 +7,8 @@ import {
   type RefetchRelayProp,
   type RefetchContainerType,
 } from '@adeira/relay';
-import { Button } from 'grommet';
 
+import Button from '../../components/Button';
 import Location from './Location';
 import type { LocationsPaginatedRefetch_data as LocationsDataType } from './__generated__/LocationsPaginatedRefetch_data.graphql';
 
@@ -42,7 +42,9 @@ function LocationsPaginatedRefetch(props: Props) {
           <Location key={edge?.node?.id} location={edge?.node} />
         ))}
       </ol>
-      <Button label="Load more!" dataTest="loadMore" onClick={loadMore} size="small" primary />
+      <Button dataTest="loadMore" onClick={loadMore}>
+        Load more!
+      </Button>
     </>
   );
 }

--- a/src/example-relay/src/LocalForm/index.js
+++ b/src/example-relay/src/LocalForm/index.js
@@ -9,19 +9,15 @@ import {
 } from '@adeira/relay';
 // FIXME:
 import { generateClientID } from 'relay-runtime'; // eslint-disable-line import/no-extraneous-dependencies
-import { TextInput, TextArea, Box, Heading, Text } from 'grommet';
-import styled from 'styled-components';
+import * as sx from '@adeira/sx';
 
 import type { LocalFormQueryResponse } from './__generated__/LocalFormQuery.graphql';
-
+import Heading from '../components/Heading';
+import Text from '../components/Text';
+import TextInput from '../components/TextInput';
 // We are overwriting here the application env context and replacing it with our custom local env.
 const environment = createLocalEnvironment();
 const consoleStyle = 'color: green; background-color: lightgreen;';
-
-const Separator = styled.hr`
-  border-width: 0.5px;
-  margin: 16px 0;
-`;
 
 type LocalData = {|
   +subject?: string,
@@ -57,18 +53,20 @@ function persist(data: LocalData) {
 
 function handleResponse(rendererProps: LocalFormQueryResponse) {
   return (
-    <Box gap="small">
+    <div className={styles('formContainer')}>
       <TextInput
         value={rendererProps.localForm?.subject ?? ''}
-        onChange={(e) => persist({ subject: e.target.value })}
+        onChange={(subject) => persist({ subject })}
         placeholder="Subject"
+        label="Subject"
       />
-      <TextArea
+      <TextInput
         value={rendererProps.localForm?.message ?? ''}
         placeholder="Message"
-        onChange={(e) => persist({ message: e.target.value })}
+        label="Message"
+        onChange={(message) => persist({ message })}
       />
-    </Box>
+    </div>
   );
 }
 
@@ -78,17 +76,15 @@ export default function LocalForm(): Node {
   });
 
   return (
-    <Box>
-      <Heading level={1} size="small">
-        Persisted form
-      </Heading>
+    <div>
+      <Heading level={1}>Persisted form</Heading>
       <Text size="small">
         This example shows how Relay local schema can be used with form inputs. As a bonus, values
         are persisted into the LocalStorage so anything you typed should &quot;survive&quot; page
         reload.
       </Text>
 
-      <Separator />
+      <hr className={styles('separator')} />
 
       <LocalQueryRenderer
         environment={environment}
@@ -106,6 +102,18 @@ export default function LocalForm(): Node {
         `}
         onResponse={handleResponse}
       />
-    </Box>
+    </div>
   );
 }
+
+const styles = sx.create({
+  separator: {
+    borderWidth: '0.5px',
+    margin: 'var(--space-medium) 0',
+  },
+  formContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--space-small)',
+  },
+});

--- a/src/example-relay/src/components/Button.js
+++ b/src/example-relay/src/components/Button.js
@@ -1,0 +1,73 @@
+// @flow
+
+import * as React from 'react';
+import * as sx from '@adeira/sx';
+
+type Props = {|
+  +onClick?: () => void,
+  +children: React.Node,
+  +dataTest?: string,
+  +disabled?: boolean,
+  +iconLeft?: React.Node,
+  +iconRight?: React.Node,
+  +type?: 'submit' | 'button',
+|};
+
+export default function Button({
+  children,
+  dataTest,
+  iconLeft,
+  iconRight,
+  type = 'button',
+  ...rest
+}: Props): React.Node {
+  return (
+    <button
+      // eslint-disable-next-line react/button-has-type
+      type={type}
+      data-testid={dataTest}
+      className={styles('button', 'primary', rest.disabled ? 'disabled' : null)}
+      {...rest}
+    >
+      <span className={styles('spacer')}>
+        {iconLeft}
+        {children}
+        {iconRight}
+      </span>
+    </button>
+  );
+}
+
+const styles = sx.create({
+  button: {
+    cursor: 'pointer',
+    outline: 'none',
+    fontSize: 14,
+    lineHeight: 1.42857,
+    background: 'none',
+    padding: '4px 20px',
+    borderRadius: '3px',
+  },
+  disabled: {
+    opacity: 0.3,
+    cursor: 'not-allowed',
+  },
+  primary: {
+    'border': '2px solid var(--color-primary)',
+    'backgroundColor': 'var(--color-primary)',
+    'color': 'white',
+    ':hover': {
+      boxShadow: 'var(--box-shadow-active)',
+    },
+    ':active': {
+      boxShadow: 'var(--box-shadow-active)',
+      opacity: 0.5,
+    },
+  },
+  spacer: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 'var(--space-small)',
+    justifyContent: 'center',
+  },
+});

--- a/src/example-relay/src/components/Header.js
+++ b/src/example-relay/src/components/Header.js
@@ -1,0 +1,24 @@
+// @flow
+
+import * as React from 'react';
+import * as sx from '@adeira/sx';
+
+import { tablet } from './breakpoints';
+
+type Props = {|
+  +children: React.Node,
+|};
+
+export default function Header(props: Props): React.Node {
+  return <header className={styles('header')}>{props.children}</header>;
+}
+
+const styles = sx.create({
+  header: {
+    backgroundColor: 'var(--color-primary)',
+    padding: 'var(--space-small)',
+    [tablet]: {
+      padding: 'var(--space-x-large)',
+    },
+  },
+});

--- a/src/example-relay/src/components/Heading.js
+++ b/src/example-relay/src/components/Heading.js
@@ -1,0 +1,29 @@
+// @flow
+
+import * as React from 'react';
+import * as sx from '@adeira/sx';
+
+type Props = {|
+  +level: 1 | 2 | 3 | 4 | 5 | 6,
+  +children: React.Node,
+|};
+
+export default function Heading({ level, children }: Props): React.Node {
+  const Component = `h${level}`;
+  return (
+    <Component className={styles(level === 1 && 'h1', level === 2 && 'h2')}>{children}</Component>
+  );
+}
+
+const styles = sx.create({
+  h1: {
+    fontSize: 34,
+    lineHeight: 1.1674,
+    fontWeight: 600,
+  },
+  h2: {
+    fontSize: 26,
+    lineHeight: 1.2307,
+    fontWeight: 600,
+  },
+});

--- a/src/example-relay/src/components/Navbar.js
+++ b/src/example-relay/src/components/Navbar.js
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import * as sx from '@adeira/sx';
-import Link from 'next/link';
 import { Menu } from 'grommet-icons';
 import { useRouter } from 'next/router';
 
@@ -10,6 +9,14 @@ import { useRouter } from 'next/router';
 // Next.js does this automatically (https://nextjs.org/docs/api-reference/next/link)
 
 type Props = {||};
+
+function Link({ children, href }) {
+  // Currently deactivating client side routing, since sx styles are not correctly
+  // set on client side routing
+  return React.cloneElement(children, {
+    href,
+  });
+}
 
 function NavLinks() {
   return (
@@ -82,13 +89,6 @@ const styles = sx.create({
   nav: {
     width: '100%',
   },
-  link: {
-    color: '#fff',
-    fontWeight: 600,
-    textDecoration: 'none',
-    cursor: 'pointer',
-    marginRight: 24,
-  },
   navInner: {
     display: 'flex',
     justifyContent: 'space-between',
@@ -106,6 +106,22 @@ const styles = sx.create({
     background: 'none',
     border: 'none',
     cursor: 'pointer',
+  },
+  link: {
+    'fontSize': 18,
+    'lineHeight': 1.333333,
+    'marginRight': 24,
+    'color': 'white',
+    'fontWeight': 600,
+    'cursor': 'pointer',
+    'textDecoration': 'none',
+    ':hover': {
+      textDecoration: 'underline',
+    },
+    ':focus': {
+      textDecoration: 'underline',
+      outline: 'none',
+    },
   },
 });
 

--- a/src/example-relay/src/components/Select.js
+++ b/src/example-relay/src/components/Select.js
@@ -1,0 +1,85 @@
+// @flow
+
+import * as React from 'react';
+import * as sx from '@adeira/sx';
+import { FormDown } from 'grommet-icons';
+
+import Text from './Text';
+
+type Option = {|
+  +label: string,
+  +value: string,
+|};
+
+type Props = {|
+  +options: $ReadOnlyArray<Option>,
+  +label: string,
+  +onChange: (string) => void,
+  +placeholder?: string,
+  +name?: string,
+|};
+
+export default function Select({
+  options,
+  label,
+  placeholder,
+  onChange,
+  ...rest
+}: Props): React.Node {
+  const [value, setValue] = React.useState('');
+  const handleChange = (e) => {
+    setValue(e.target.value);
+    onChange(e.target.value);
+  };
+  return (
+    <label className={styles('label')}>
+      <Text size="small">{label}</Text>
+      <select
+        {...rest}
+        onChange={handleChange}
+        className={styles('select', value === '' && 'placeholder')}
+      >
+        {placeholder != null && <option value="">{placeholder}</option>}
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <div className={styles('iconContainer')}>
+        <FormDown color="#30b8ba" />
+      </div>
+    </label>
+  );
+}
+
+const styles = sx.create({
+  label: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    position: 'relative',
+  },
+  select: {
+    'appearance': 'none',
+    'background': 'transparent',
+    'width': '100%',
+    'lineHeight': 1.15,
+    'fontWeight': 600,
+    'padding': 'var(--space-small)',
+    'border': '1px solid rgba(0, 0, 0, 0.33)',
+    'borderRadius': 'var(--border-radius-normal)',
+    ':focus': {
+      outline: 'none',
+      boxShadow: 'var(--box-shadow-active)',
+    },
+  },
+  placeholder: {
+    color: '#757575',
+  },
+  iconContainer: {
+    position: 'absolute',
+    right: '12px',
+    top: '29px',
+  },
+});

--- a/src/example-relay/src/components/Text.js
+++ b/src/example-relay/src/components/Text.js
@@ -1,0 +1,29 @@
+// @flow
+
+import * as React from 'react';
+import * as sx from '@adeira/sx';
+
+type Props = {|
+  +size?: 'small' | 'normal',
+  +children: React.Node,
+  +dataTest?: string,
+|};
+
+export default function Text({ size = 'normal', children, dataTest }: Props): React.Node {
+  return (
+    <span data-testid={dataTest} className={styles(size)}>
+      {children}
+    </span>
+  );
+}
+
+const styles = sx.create({
+  small: {
+    fontSize: 14,
+    lineHeight: 1.42857,
+  },
+  normal: {
+    fontSize: 16,
+    lineHeight: 1.42857,
+  },
+});

--- a/src/example-relay/src/components/TextInput.js
+++ b/src/example-relay/src/components/TextInput.js
@@ -1,0 +1,41 @@
+// @flow
+
+import * as React from 'react';
+import * as sx from '@adeira/sx';
+
+import Text from './Text';
+
+type Props = {|
+  +onChange: (string) => void,
+  +value: string,
+  +placeholder?: string,
+  +label: string,
+  +name?: string,
+|};
+
+export default function TextInput({ onChange, label, ...rest }: Props): React.Node {
+  const handleChange = (e) => {
+    onChange(e.target.value);
+  };
+  return (
+    <label>
+      <Text size="small">{label}</Text>
+      <input {...rest} className={styles('input')} onChange={handleChange} />
+    </label>
+  );
+}
+
+const styles = sx.create({
+  input: {
+    'width': '100%',
+    'lineHeight': 1.15,
+    'fontWeight': 600,
+    'padding': 'var(--space-small)',
+    'border': '1px solid rgba(0, 0, 0, 0.33)',
+    'borderRadius': 'var(--border-radius-normal)',
+    ':focus': {
+      outline: 'none',
+      boxShadow: 'var(--box-shadow-active)',
+    },
+  },
+});

--- a/src/example-relay/src/components/breakpoints.js
+++ b/src/example-relay/src/components/breakpoints.js
@@ -1,0 +1,3 @@
+// @flow
+
+export const tablet = '@media (min-width: 768px)';

--- a/src/example-relay/src/mutations/LocationsList.js
+++ b/src/example-relay/src/mutations/LocationsList.js
@@ -3,11 +3,12 @@
 import * as React from 'react';
 import { createFragmentContainer, graphql, type FragmentContainerType } from '@adeira/relay';
 import { TransitionGroup } from 'react-transition-group';
-import { Grid, Box } from 'grommet';
+import * as sx from '@adeira/sx';
 
 import type { LocationsList_data as Data } from './__generated__/LocationsList_data.graphql';
 import FadeIn from './FadeIn';
 import LocationsForm from './RangeAdd/LocationsForm';
+import { tablet } from '../components/breakpoints';
 
 type Props = {|
   +data: Data,
@@ -15,29 +16,38 @@ type Props = {|
 
 function LocationsList(props: Props) {
   return (
-    <Grid columns={{ count: 2, size: 'auto' }} gap="medium">
-      <Box>
-        <>
-          <h3>My favorite locations</h3>
-          <TransitionGroup component={null} className="location-list">
-            {props.data.locations?.edges?.map<React.Node>((edge) => (
-              <FadeIn key={edge?.node?.id} timeout={320}>
-                <div style={{ padding: '12px', borderBottom: '1px solid black' }}>
-                  <div>
-                    name: {edge?.node?.name}, type: {edge?.node?.type}
-                  </div>
-                </div>
-              </FadeIn>
-            ))}
-          </TransitionGroup>
-        </>
-      </Box>
-      <Box>
+    <div className={styles('grid')}>
+      <div>
         <LocationsForm connectionId={props.data.locations?.__id ?? ''} />
-      </Box>
-    </Grid>
+      </div>
+      <div>
+        <h3>My favorite locations</h3>
+        <TransitionGroup component={null} className="location-list">
+          {props.data.locations?.edges?.map<React.Node>((edge) => (
+            <FadeIn key={edge?.node?.id} timeout={320}>
+              <div style={{ padding: '12px', borderBottom: '1px solid black' }}>
+                <div>
+                  name: {edge?.node?.name}, type: {edge?.node?.type}
+                </div>
+              </div>
+            </FadeIn>
+          ))}
+        </TransitionGroup>
+      </div>
+    </div>
   );
 }
+
+const styles = sx.create({
+  grid: {
+    display: 'grid',
+    gap: 'var(--space-x-large)',
+    gridTemplateColumns: '1fr',
+    [tablet]: {
+      gridTemplateColumns: 'repeat(2,minmax(auto,1fr))',
+    },
+  },
+});
 
 export default (createFragmentContainer(LocationsList, {
   data: graphql`

--- a/src/example-relay/src/mutations/RangeAdd/LocationsForm.js
+++ b/src/example-relay/src/mutations/RangeAdd/LocationsForm.js
@@ -3,10 +3,13 @@
 /* eslint-disable no-alert */
 
 import * as React from 'react';
-import { TextInput, Box, Button, Select } from 'grommet';
 import { graphql, useMutation } from '@adeira/relay';
+import * as sx from '@adeira/sx';
 
 import type { LocationsFormMutation } from './__generated__/LocationsFormMutation.graphql';
+import TextInput from '../../components/TextInput';
+import Button from '../../components/Button';
+import Select from '../../components/Select';
 
 type Props = {|
   +connectionId: string,
@@ -92,31 +95,39 @@ export default (function LocationsForm(props: Props) {
     <>
       <h3>Add a location</h3>
       <form onSubmit={onSubmit}>
-        <Box gap="small">
+        <div className={styles('formContainer')}>
           <TextInput
             placeholder="locationId"
+            label="locationId"
             name="locationId"
             value={locationId}
-            onChange={(e) => setLocationId(e.target.value)}
+            onChange={setLocationId}
           />
-          <TextInput
-            placeholder="name"
-            name="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-          />
+          <TextInput placeholder="name" label="name" name="name" value={name} onChange={setName} />
           <Select
-            options={['AIRPORT', 'CITY', 'COUNTRY']}
             name="type"
             placeholder="type"
-            value={type}
-            onChange={(option) => {
-              setType(option.value);
-            }}
+            onChange={setType}
+            label="type"
+            options={[
+              { label: 'Airport', value: 'AIRPORT' },
+              { label: 'City', value: 'CITY' },
+              { label: 'Country', value: 'COUNTRY' },
+            ]}
           />
-          <Button label="Submit" disabled={loading} type="submit" primary />
-        </Box>
+          <Button disabled={loading} type="submit">
+            Submit
+          </Button>
+        </div>
       </form>
     </>
   );
 }: React.ComponentType<Props>);
+
+const styles = sx.create({
+  formContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--space-small)',
+  },
+});

--- a/src/example-relay/src/mutations/RangeAdd/__tests__/RangeAdd.test.js
+++ b/src/example-relay/src/mutations/RangeAdd/__tests__/RangeAdd.test.js
@@ -65,11 +65,12 @@ it('adds a location to the connection', async () => {
   expect(screen.queryByText(/name: prague/i)).not.toBeInTheDocument();
   const idInput = screen.getByPlaceholderText('locationId');
   const nameInput = screen.getByPlaceholderText('name');
+  const select = screen.getByRole('combobox', { name: /type/i });
 
   fireEvent.change(idInput, { target: { value: 'OCD' } });
   fireEvent.change(nameInput, { target: { value: 'Prague' } });
-  fireEvent.click(screen.getByRole('button', { name: /open drop/i }));
-  fireEvent.click(screen.getByRole('menuitem', { name: /city/i }));
+  fireEvent.change(select, { target: { value: 'CITY' } });
+
   fireEvent.click(screen.getByRole('button', { name: /submit/i }));
 
   const operation = await waitFor(() => environment.mock.getMostRecentOperation());

--- a/src/example-relay/src/pages/_app.js
+++ b/src/example-relay/src/pages/_app.js
@@ -7,40 +7,12 @@ import Head from 'next/head';
 import Router from 'next/router';
 import NProgress from 'nprogress';
 import { RelayEnvironmentProvider } from '@adeira/relay';
-import { Grommet, grommet as grommetTheme, Header, Box } from 'grommet';
-import { createGlobalStyle } from 'styled-components';
-import { deepMerge } from 'grommet/utils';
 
 import createRelayEnvironment from '../createRelayEnvironment';
 import Navbar from '../components/Navbar';
-
-const GlobalStyle = createGlobalStyle`
-html, body {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-`;
-
-const theme = deepMerge(grommetTheme, {
-  button: {
-    extend: `border-radius: 3px; color: #fff`,
-  },
-  select: {
-    options: {
-      text: { color: '#444444' },
-    },
-    control: {
-      extend: `color: #444444;`,
-    },
-  },
-  global: {
-    colors: {
-      brand: '#30b8ba',
-      white: '#fff',
-    },
-  },
-});
+import Header from '../components/Header';
+import '../styles/app.css';
+import { tablet } from '../components/breakpoints';
 
 export default class MyApp extends App {
   componentDidMount: () => void = () => {
@@ -69,30 +41,27 @@ export default class MyApp extends App {
         <Head>
           <title>Relay Example</title>
         </Head>
-        <GlobalStyle />
-        <Grommet theme={theme}>
-          <Header background="brand" pad="medium">
-            <Navbar />
-          </Header>
-          <Box pad="medium">
-            {__DEV__ ? (
-              <div className={styles('box')}>
-                TIP: Open a console to see what&apos;s going on behind the scenes.
-              </div>
-            ) : (
-              <div className={styles('box', 'boxWarning')}>
-                It&apos;s better to clone this repository and try it in development mode so you can
-                see what&apos;s going on behind the scenes:{' '}
-                <a href="https://github.com/adeira/relay-example">
-                  https://github.com/adeira/relay-example
-                </a>
-              </div>
-            )}
-            <Box margin={{ top: 'small' }}>
-              <Component {...pageProps} />
-            </Box>
-          </Box>
-        </Grommet>
+        <Header>
+          <Navbar />
+        </Header>
+        <div className={styles('padMedium')}>
+          {__DEV__ ? (
+            <div className={styles('box')}>
+              TIP: Open a console to see what&apos;s going on behind the scenes.
+            </div>
+          ) : (
+            <div className={styles('box', 'boxWarning')}>
+              It&apos;s better to clone this repository and try it in development mode so you can
+              see what&apos;s going on behind the scenes:{' '}
+              <a href="https://github.com/adeira/relay-example">
+                https://github.com/adeira/relay-example
+              </a>
+            </div>
+          )}
+          <div className={styles('marginTopSmall')}>
+            <Component {...pageProps} />
+          </div>
+        </div>
       </RelayEnvironmentProvider>
     );
   }
@@ -102,9 +71,21 @@ const styles = sx.create({
   box: {
     backgroundColor: '#FFF8E1',
     maxWidth: '100%',
-    padding: 12,
+    padding: 'var(--space-small)',
   },
   boxWarning: {
     backgroundColor: '#FFCA28',
+  },
+  padMedium: {
+    padding: 'var(--space-small)',
+    [tablet]: {
+      padding: 'var(--space-x-large)',
+    },
+  },
+  marginTopSmall: {
+    marginTop: 'var(--space-x-small)',
+    [tablet]: {
+      marginTop: 'var(--space-small)',
+    },
   },
 });

--- a/src/example-relay/src/pages/mutations/range-add.js
+++ b/src/example-relay/src/pages/mutations/range-add.js
@@ -1,16 +1,15 @@
 // @flow
 
 import * as React from 'react';
-import { Heading, Text } from 'grommet';
 
 import RangeAddExample from '../../mutations/RangeAdd/RangeAdd';
+import Heading from '../../components/Heading';
+import Text from '../../components/Text';
 
 export default function RangeAdd(): React.Node {
   return (
     <>
-      <Heading level={1} size="small">
-        Range add mutation
-      </Heading>
+      <Heading level={1}>Range add mutation</Heading>
       <Text size="small">
         This example shows how you can use relays range add config to easily add new object to your
         connections

--- a/src/example-relay/src/styles/app.css
+++ b/src/example-relay/src/styles/app.css
@@ -1,0 +1,26 @@
+:root {
+  /* Colors */
+  --color-primary: #30b8ba;
+
+
+  /* Box shadow */
+  --box-shadow-active: 0 0 2px 2px #6FFFB0;
+
+  /* Spacing */
+  --space-x-small: 6px;
+  --space-small: 12px;
+  --space-medium: 16px;
+  --space-large: 20px;
+  --space-x-large: 24px;
+
+  /* Border radius */
+  --border-radius-normal: 3px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Roboto, sans-serif;
+}

--- a/src/monorepo-scanner/src/scans/WorkspacesDependencies.scan.js
+++ b/src/monorepo-scanner/src/scans/WorkspacesDependencies.scan.js
@@ -21,8 +21,6 @@ const similarities = new Map([
       'unfetch',
     ],
   ],
-  // Design systems
-  ['grommet', ['@kiwicom/orbit-components']],
   [
     // helper functions
     'ramda',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7455,7 +7455,7 @@ gray-matter@^4.0.2:
     section-matter "^1.0.0"
     strip-bom-string "^1.0.0"
 
-grommet-icons@^4.2.0, grommet-icons@^4.4.0:
+grommet-icons@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.4.0.tgz#6503a33ca29e3c9d89ba56ef1b2bc786222e62a7"
   integrity sha512-uOc3rsgIBVOm/iuN8dj2lKuBq0uhIPYxH84zDoY0jrJZLjcVH1bHUQLlv0R/e9oB/pCFYEBse1mnvps+f3ylmw==
@@ -7466,18 +7466,6 @@ grommet-styles@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/grommet-styles/-/grommet-styles-0.2.0.tgz#b2eac2b7e2747cb523434d21728ce5234f8ce4f4"
   integrity sha512-0OMSYuGeyifYKpg4Gv2HzL8rUdd0ddnJ5LbCBKgDuloC71XIwr9g/Fxa6rs737MbPV7OZ4pEm4wvrjH4epzf1A==
-
-grommet@^2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/grommet/-/grommet-2.15.0.tgz#8bff25b214ff4aa95d9b8452427f3b3e91651e1e"
-  integrity sha512-5TVbiLrMpZOoB9oZAqWVttj6lO4rcKqBW1rWr4iovTuyyfYYOUQbuNfcFtUqp+MdB0fsQ1Vvci4PiTBvhRJqHA==
-  dependencies:
-    grommet-icons "^4.2.0"
-    hoist-non-react-statics "^3.2.0"
-    markdown-to-jsx "^6.11.4"
-    polished "^3.4.1"
-    prop-types "^15.7.2"
-    react-desc "^4.1.2"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -7724,7 +7712,7 @@ hoek@6.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.3.tgz#73b7d33952e01fe27a38b0457294b79dd8da242c"
   integrity sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -9729,14 +9717,6 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
-markdown-to-jsx@^6.11.4:
-  version "6.11.4"
-  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz#b4528b1ab668aef7fe61c1535c27e837819392c5"
-  integrity sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==
-  dependencies:
-    prop-types "^15.6.2"
-    unquote "^1.1.0"
-
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -11165,13 +11145,6 @@ pnp-webpack-plugin@1.6.4, pnp-webpack-plugin@^1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
-polished@^3.4.1:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-3.6.5.tgz#dbefdde64c675935ec55119fe2a2ab627ca82e9c"
-  integrity sha512-VwhC9MlhW7O5dg/z7k32dabcAFW1VI2+7fSe8cE/kXcfL7mVdoa5UxciYGW2sJU78ldDLT6+ROEKIZKFNTnUXQ==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
-
 portfinder@^1.0.26:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
@@ -12163,11 +12136,6 @@ react-base16-styling@^0.6.0:
     lodash.curry "^4.0.1"
     lodash.flow "^3.3.0"
     pure-color "^1.2.0"
-
-react-desc@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/react-desc/-/react-desc-4.1.2.tgz#83fc4ede66b2d45ae4ef63c18421474d55972966"
-  integrity sha512-JAVe89uaLr0HZ0IKodnpTPNgNyJ/SPDQnl3VJPVwI+SpebmHvJiBNZEOwX201QmSbsVGqRY8ql/VFPlAx85WzA==
 
 react-dev-utils@^10.2.1:
   version "10.2.1"
@@ -14591,7 +14559,7 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
-unquote@^1.1.0, unquote@~1.1.1:
+unquote@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
   integrity sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=


### PR DESCRIPTION
- Currently deactivate client side routing, since it doesn't work with sx
- Next up: remove gromment-icons, so we can remove styled-components