### PR TITLE
SX: add support for runtime styles

### DIFF
--- a/src/example-relay/src/components/Navbar.js
+++ b/src/example-relay/src/components/Navbar.js
@@ -1,8 +1,9 @@
 // @flow
 
-import { cloneElement, useState, useEffect, type ComponentType, type Element } from 'react';
+import { useState, useEffect, type ComponentType, type Node } from 'react';
 import * as sx from '@adeira/sx';
 import { MdMenu } from 'react-icons/md';
+import Link from 'next/link';
 import { CSSTransition } from 'react-transition-group';
 
 import cssStyles from './Navbar.module.css';
@@ -12,26 +13,11 @@ import { Media } from './Media';
 /* eslint-disable jsx-a11y/anchor-is-valid */
 // Next.js does this automatically (https://nextjs.org/docs/api-reference/next/link)
 
-type Props = {||};
-
-function Link({
-  children,
-  href,
-  onClick,
-}: {|
-  +children: Element<'a'>,
-  +href: string,
+type Props = {|
   +onClick?: () => void,
-|}) {
-  // Currently deactivating client side routing, since sx styles are not correctly
-  // set on client side routing
-  return cloneElement(children, {
-    href,
-    onClick,
-  });
-}
+|};
 
-function NavLinks({ onClick }: {| +onClick?: () => void |}) {
+function NavLinks({ onClick }: Props): Node {
   return (
     <div className={styles('navLinkWrapper')}>
       <Link onClick={onClick} href="/">

--- a/src/example-relay/src/styles/nprogress.css
+++ b/src/example-relay/src/styles/nprogress.css
@@ -4,7 +4,7 @@
 }
 
 #nprogress .bar {
-  background: #29d;
+  background: #000;
 
   position: fixed;
   z-index: 1031;
@@ -22,7 +22,7 @@
   right: 0px;
   width: 100px;
   height: 100%;
-  box-shadow: 0 0 10px #29d, 0 0 5px #29d;
+  box-shadow: 0 0 10px #000, 0 0 5px #000;
   opacity: 1;
 
   -webkit-transform: rotate(3deg) translate(0px, -4px);
@@ -45,8 +45,8 @@
   box-sizing: border-box;
 
   border: solid 2px transparent;
-  border-top-color: #29d;
-  border-left-color: #29d;
+  border-top-color: #000;
+  border-left-color: #000;
   border-radius: 50%;
 
   -webkit-animation: nprogress-spinner 400ms linear infinite;

--- a/src/sx-tailwind-website/src/components/Sidebar.js
+++ b/src/sx-tailwind-website/src/components/Sidebar.js
@@ -3,6 +3,7 @@
 import type { Node } from 'react';
 import { tailwind } from '@adeira/sx-tailwind';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 type Props = {|
   +screenSize?: 'small' | 'large',
@@ -17,20 +18,22 @@ type MenuItemProps = {|
 function MenuItem({ label, href, screenSize }: MenuItemProps): Node {
   const router = useRouter();
   return (
-    <a
-      href={href}
-      className={tailwind(
-        `flex items-center px-2 ${
-          screenSize === 'small' ? 'py-4 text-base' : 'py-2 text-sm'
-        } leading-6 font-medium rounded-md transition ease-in-out duration-150 my-1 focus:outline-none focus:bg-teal-500 ${
-          router.pathname === href
-            ? 'text-white bg-teal-500'
-            : 'text-teal-100 hover:text-white hover:bg-teal-500'
-        }`,
-      )}
-    >
-      {label}
-    </a>
+    <Link href={href}>
+      <a
+        href={href}
+        className={tailwind(
+          `flex items-center px-2 ${
+            screenSize === 'small' ? 'py-4 text-base' : 'py-2 text-sm'
+          } leading-6 font-medium rounded-md transition ease-in-out duration-150 my-1 focus:outline-none focus:bg-teal-500 ${
+            router.pathname === href
+              ? 'text-white bg-teal-500'
+              : 'text-teal-100 hover:text-white hover:bg-teal-500'
+          }`,
+        )}
+      >
+        {label}
+      </a>
+    </Link>
   );
 }
 
@@ -43,15 +46,17 @@ export default function Sidebar({ screenSize = 'large' }: Props): Node {
     >
       <div className={tailwind(`flex ${screenSize === 'small' ? 'w-full' : 'w-64'}`)}>
         <div className={tailwind('flex-grow bg-teal-600 pt-5 pb-4 overflow-y-auto')}>
-          <a href="/">
-            <div
-              className={tailwind(
-                'flex items-center flex-shrink-0 px-4 text-white text-4xl font-extrabold tracking-tighter',
-              )}
-            >
-              SX Tailwind
-            </div>
-          </a>
+          <Link href="/">
+            <a href="/">
+              <div
+                className={tailwind(
+                  'flex items-center flex-shrink-0 px-4 text-white text-4xl font-extrabold tracking-tighter',
+                )}
+              >
+                SX Tailwind
+              </div>
+            </a>
+          </Link>
 
           <div className={tailwind('mt-5 flex-1 flex flex-col overflow-y-auto')}>
             <div className={tailwind('overflow-y-auto')}>

--- a/src/sx/README.md
+++ b/src/sx/README.md
@@ -7,6 +7,7 @@ In conventional applications, CSS rules are duplicated throughout the stylesheet
   - [`@media` and `@supports`](#media-and-supports)
   - [Precise Flow types](#precise-flow-types)
 - [Production usage considerations](#production-usage-considerations)
+- [Server-side rendering](#server-side-rendering)
 - [Architecture](#architecture)
 - [Prior Art](#prior-art)
 
@@ -39,7 +40,7 @@ const styles = sx.create({
 });
 ```
 
-The example above will generate something like this:
+That's it. The example above will generate atomic CSS like this:
 
 ```text
 ._1DKsqE { font-size: 32px; }
@@ -47,20 +48,7 @@ The example above will generate something like this:
 .stDQH { background-color: var(--main-bg-color); }
 ```
 
-Finally, render somewhere the styles and HTML. Example for Next.js with [custom document](https://nextjs.org/docs/advanced-features/custom-document) would be:
-
-```jsx
-import * as sx from '@adeira/sx';
-import Document from 'next/document';
-
-export default class MyDocument extends Document {
-  static getInitialProps(ctx: DocumentContext) {
-    return sx.renderPageWithSX(ctx.renderPage);
-  }
-
-  // `render` is not needed to change
-}
-```
+It's highly recommended enabling [server-side rendered styles](#server-side-rendering) for production use (see below).
 
 ## Features
 
@@ -231,6 +219,27 @@ Sometimes it's hard or even impossible to have sound types for some CSS properti
 
 1. SX does not include any CSS reset or CSS normalization. It's because we couldn't decide which strategy would be the best. We concluded that each user should choose their own strategy (either reset, normalizer or nothing) alongside SX.
 1. _TKTK (Babel transpilation)_
+
+## Server-side rendering
+
+_This is an optional part, `@adeira/sx` will work even without it. However, it's highly recommended._
+
+Example for Next.js with [custom document](https://nextjs.org/docs/advanced-features/custom-document):
+
+```jsx
+import * as sx from '@adeira/sx';
+import Document from 'next/document';
+
+export default class MyDocument extends Document {
+  static getInitialProps(ctx: DocumentContext) {
+    return sx.renderPageWithSX(ctx.renderPage);
+  }
+
+  // `render` is not needed to change
+}
+```
+
+This simple code should create a `style` tag in your HTML header with all the CSS styles geenrated by SX.
 
 ## Architecture
 

--- a/src/sx/src/StyleCollector.js
+++ b/src/sx/src/StyleCollector.js
@@ -5,7 +5,7 @@ import { invariant, warning } from '@adeira/js';
 import expandShorthandProperties from './expandShorthandProperties';
 import StyleCollectorAtNode from './StyleCollectorAtNode';
 import StyleCollectorPseudoNode from './StyleCollectorPseudoNode';
-import { type StyleCollectorNodeInterface } from './StyleCollectorNode';
+import { type StyleCollectorNodeInterface } from './StyleCollectorNodeInterface';
 
 // "hashRegistry": Map {
 //   "aaa" => Map {
@@ -35,7 +35,7 @@ type HashRegistryType = Map<string, Map<string, string>>;
 //     "styleValue": "#00f",
 //   },
 // },
-type StyleBufferType = Map<string, StyleCollectorNodeInterface>;
+export type StyleBufferType = Map<string, StyleCollectorNodeInterface>;
 
 class StyleCollector {
   #styleBuffer: StyleBufferType = new Map();
@@ -107,7 +107,7 @@ class StyleCollector {
   print(): string {
     let sxStyle = '';
     this.#styleBuffer.forEach((node) => {
-      sxStyle += node.print();
+      sxStyle += node.printNodes().join('');
     });
     return sxStyle;
   }

--- a/src/sx/src/StyleCollectorAtNode.js
+++ b/src/sx/src/StyleCollectorAtNode.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { type StyleCollectorNodeInterface, type PrintConfig } from './StyleCollectorNode';
+import type { PrintConfig, StyleCollectorNodeInterface } from './StyleCollectorNodeInterface';
 
 /**
  * Represents any "at" rule:
@@ -48,11 +48,11 @@ export default class StyleCollectorAtNode implements StyleCollectorNodeInterface
   }
 
   // eslint-disable-next-line no-unused-vars
-  print(config?: PrintConfig): string {
+  printNodes(config?: PrintConfig): $ReadOnlyArray<string> {
     let output = '';
     this.nodes.forEach((node) => {
-      output += node.print({ bumpSpecificity: true });
+      output += node.printNodes({ bumpSpecificity: true }).join('');
     });
-    return `${this.atRuleName}{${output}}`;
+    return [`${this.atRuleName}{${output}}`];
   }
 }

--- a/src/sx/src/StyleCollectorNode.js
+++ b/src/sx/src/StyleCollectorNode.js
@@ -5,16 +5,7 @@ import { invariant } from '@adeira/js';
 import hashStyle from './hashStyle';
 import transformValue from './transformValue';
 import transformStyleName from './transformStyleName';
-
-export type PrintConfig = {|
-  +pseudo?: string,
-  +bumpSpecificity?: boolean,
-|};
-
-export interface StyleCollectorNodeInterface {
-  print(config?: PrintConfig): string;
-  addNodes(nodes: Map<string, StyleCollectorNodeInterface>): void;
-}
+import type { PrintConfig, StyleCollectorNodeInterface } from './StyleCollectorNodeInterface';
 
 /**
  * Represents the most basic style node:
@@ -61,9 +52,9 @@ export default class StyleCollectorNode implements StyleCollectorNodeInterface {
     return this.styleValue;
   }
 
-  print(config?: PrintConfig): string {
+  printNodes(config?: PrintConfig): $ReadOnlyArray<string> {
     const className = `.${this.hash}`.repeat(config?.bumpSpecificity === true ? 2 : 1);
     const pseudo = config?.pseudo ?? '';
-    return `${className}${pseudo}{${this.styleName}:${this.styleValue}}`;
+    return [`${className}${pseudo}{${this.styleName}:${this.styleValue}}`];
   }
 }

--- a/src/sx/src/StyleCollectorNodeInterface.js
+++ b/src/sx/src/StyleCollectorNodeInterface.js
@@ -1,0 +1,11 @@
+// @flow strict
+
+export type PrintConfig = {|
+  +pseudo?: string,
+  +bumpSpecificity?: boolean,
+|};
+
+export interface StyleCollectorNodeInterface {
+  addNodes(nodes: Map<string, StyleCollectorNodeInterface>): void;
+  printNodes(config?: PrintConfig): $ReadOnlyArray<string>;
+}

--- a/src/sx/src/StyleCollectorPseudoNode.js
+++ b/src/sx/src/StyleCollectorPseudoNode.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { type StyleCollectorNodeInterface, type PrintConfig } from './StyleCollectorNode';
+import type { PrintConfig, StyleCollectorNodeInterface } from './StyleCollectorNodeInterface';
 
 /**
  * Represents basic style node with pseudo class:
@@ -41,10 +41,10 @@ export default class StyleCollectorPseudoNode implements StyleCollectorNodeInter
     return this.pseudo;
   }
 
-  print(config?: PrintConfig): string {
-    let output = '';
+  printNodes(config?: PrintConfig): $ReadOnlyArray<string> {
+    let output = [];
     this.nodes.forEach((node) => {
-      output += node.print({ ...config, pseudo: this.pseudo });
+      output = output.concat(node.printNodes({ ...config, pseudo: this.pseudo }));
     });
     return output;
   }

--- a/src/sx/src/__tests__/StyleCollectorAtNode.test.js
+++ b/src/sx/src/__tests__/StyleCollectorAtNode.test.js
@@ -19,7 +19,9 @@ it('works as expected', () => {
     ]),
   );
 
-  expect(node.print()).toMatchInlineSnapshot(
-    `"@media print{._324Crd._324Crd{color:#f00}._2dHaKY._2dHaKY:hover{color:#00f}}"`,
-  );
+  expect(node.printNodes()).toMatchInlineSnapshot(`
+    Array [
+      "@media print{._324Crd._324Crd{color:#f00}._2dHaKY._2dHaKY:hover{color:#00f}}",
+    ]
+  `);
 });

--- a/src/sx/src/__tests__/StyleCollectorNode.test.js
+++ b/src/sx/src/__tests__/StyleCollectorNode.test.js
@@ -7,22 +7,42 @@ it('works as expected', () => {
   expect(node.getHash()).toBe('_324Crd');
   expect(node.getStyleName()).toBe('color');
   expect(node.getStyleValue()).toBe('#f00');
-  expect(node.print()).toBe('._324Crd{color:#f00}');
-  expect(node.print({ pseudo: ':hover' })).toBe('._324Crd:hover{color:#f00}');
+  expect(node.printNodes()).toMatchInlineSnapshot(`
+    Array [
+      "._324Crd{color:#f00}",
+    ]
+  `);
+  expect(node.printNodes({ pseudo: ':hover' })).toMatchInlineSnapshot(`
+    Array [
+      "._324Crd:hover{color:#f00}",
+    ]
+  `);
   expect(
-    node.print({
+    node.printNodes({
       pseudo: ':hover',
       bumpSpecificity: true,
     }),
-  ).toBe('._324Crd._324Crd:hover{color:#f00}');
+  ).toMatchInlineSnapshot(`
+    Array [
+      "._324Crd._324Crd:hover{color:#f00}",
+    ]
+  `);
 });
 
 it('hashed the transformed values rather than raw input', () => {
   const node1 = new StyleCollectorNode('color', 'red');
   const node2 = new StyleCollectorNode('color', '#f00');
 
-  expect(node1.print()).toMatchInlineSnapshot(`"._324Crd{color:#f00}"`);
-  expect(node2.print()).toMatchInlineSnapshot(`"._324Crd{color:#f00}"`);
-  expect(node1.print()).toBe(node2.print());
+  expect(node1.printNodes()).toMatchInlineSnapshot(`
+    Array [
+      "._324Crd{color:#f00}",
+    ]
+  `);
+  expect(node2.printNodes()).toMatchInlineSnapshot(`
+    Array [
+      "._324Crd{color:#f00}",
+    ]
+  `);
+  expect(node1.printNodes()).toStrictEqual(node2.printNodes());
   expect(node1.getHash()).toBe(node2.getHash());
 });

--- a/src/sx/src/__tests__/StyleCollectorPseudoNode.test.js
+++ b/src/sx/src/__tests__/StyleCollectorPseudoNode.test.js
@@ -14,10 +14,18 @@ it('works as expected', () => {
   );
   expect(node.getPseudo()).toBe(':hover');
 
-  expect(node.print()).toMatchInlineSnapshot(
-    `"._324Crd:hover{color:#f00}._9MIuv:hover{color:#0f0}._2dHaKY:hover{color:#00f}"`,
-  );
-  expect(node.print({ bumpSpecificity: true })).toMatchInlineSnapshot(
-    `"._324Crd._324Crd:hover{color:#f00}._9MIuv._9MIuv:hover{color:#0f0}._2dHaKY._2dHaKY:hover{color:#00f}"`,
-  );
+  expect(node.printNodes()).toMatchInlineSnapshot(`
+    Array [
+      "._324Crd:hover{color:#f00}",
+      "._9MIuv:hover{color:#0f0}",
+      "._2dHaKY:hover{color:#00f}",
+    ]
+  `);
+  expect(node.printNodes({ bumpSpecificity: true })).toMatchInlineSnapshot(`
+    Array [
+      "._324Crd._324Crd:hover{color:#f00}",
+      "._9MIuv._9MIuv:hover{color:#0f0}",
+      "._2dHaKY._2dHaKY:hover{color:#00f}",
+    ]
+  `);
 });

--- a/src/sx/src/__tests__/expandShorthandProperties.test.js
+++ b/src/sx/src/__tests__/expandShorthandProperties.test.js
@@ -2,10 +2,13 @@
 
 import expandShorthandProperties from '../expandShorthandProperties';
 
+function printNodes(node) {
+  return node.printNodes().join('');
+}
+
 it('ignores unknown properties', () => {
-  expect(
-    expandShorthandProperties('unknownProperty', 'thisShouldNotChange').map((node) => node.print()),
-  ).toMatchInlineSnapshot(`
+  expect(expandShorthandProperties('unknownProperty', 'thisShouldNotChange').map(printNodes))
+    .toMatchInlineSnapshot(`
     Array [
       "._3BbwKd{unknown-property:thisShouldNotChange}",
     ]
@@ -13,8 +16,7 @@ it('ignores unknown properties', () => {
 });
 
 it('expands background as expected', () => {
-  expect(expandShorthandProperties('background', 'red').map((node) => node.print()))
-    .toMatchInlineSnapshot(`
+  expect(expandShorthandProperties('background', 'red').map(printNodes)).toMatchInlineSnapshot(`
     Array [
       "._2rGYXd{background-image:none}",
       ".vSqk6{background-position:0% 0%}",
@@ -27,8 +29,7 @@ it('expands background as expected', () => {
     ]
   `);
 
-  expect(expandShorthandProperties('background', 'none').map((node) => node.print()))
-    .toMatchInlineSnapshot(`
+  expect(expandShorthandProperties('background', 'none').map(printNodes)).toMatchInlineSnapshot(`
     Array [
       "._2rGYXd{background-image:none}",
       ".vSqk6{background-position:0% 0%}",
@@ -44,10 +45,9 @@ it('expands background as expected', () => {
 
 it('ignores more complex background syntaxes', () => {
   expect(
-    expandShorthandProperties(
-      'background',
-      'no-repeat url("../../media/examples/lizard.png")',
-    ).map((node) => node.print()),
+    expandShorthandProperties('background', 'no-repeat url("../../media/examples/lizard.png")').map(
+      printNodes,
+    ),
   ).toMatchInlineSnapshot(`
     Array [
       "._3yHEnM{background:no-repeat url(\\"../../media/examples/lizard.png\\")}",
@@ -56,8 +56,7 @@ it('ignores more complex background syntaxes', () => {
 });
 
 it('expands border as expected', () => {
-  expect(expandShorthandProperties('border', 'red').map((node) => node.print()))
-    .toMatchInlineSnapshot(`
+  expect(expandShorthandProperties('border', 'red').map(printNodes)).toMatchInlineSnapshot(`
     Array [
       "._37Z8WG{border-width:medium}",
       "._1QzWHp{border-style:none}",
@@ -67,11 +66,8 @@ it('expands border as expected', () => {
 });
 
 it('ignores more complex border syntaxes', () => {
-  expect(
-    expandShorthandProperties('border', '4mm ridge rgba(170, 50, 220, .6)').map((node) =>
-      node.print(),
-    ),
-  ).toMatchInlineSnapshot(`
+  expect(expandShorthandProperties('border', '4mm ridge rgba(170, 50, 220, .6)').map(printNodes))
+    .toMatchInlineSnapshot(`
     Array [
       "._4kdXYU{border:4mm ridge rgba(170, 50, 220, .6)}",
     ]
@@ -80,7 +76,7 @@ it('ignores more complex border syntaxes', () => {
 
 it('expands margins and paddings as expected', () => {
   // 1) single number
-  expect(expandShorthandProperties('margin', 0).map((node) => node.print())).toMatchInlineSnapshot(`
+  expect(expandShorthandProperties('margin', 0).map(printNodes)).toMatchInlineSnapshot(`
     Array [
       "._4pgUgJ{margin-top:0px}",
       "._37wPvZ{margin-right:0px}",
@@ -88,8 +84,7 @@ it('expands margins and paddings as expected', () => {
       "._3DMcik{margin-left:0px}",
     ]
   `);
-  expect(expandShorthandProperties('padding', 0).map((node) => node.print()))
-    .toMatchInlineSnapshot(`
+  expect(expandShorthandProperties('padding', 0).map(printNodes)).toMatchInlineSnapshot(`
     Array [
       "._2YU8Lt{padding-top:0px}",
       "._1b3SDU{padding-right:0px}",
@@ -99,8 +94,7 @@ it('expands margins and paddings as expected', () => {
   `);
 
   // 1) single string value
-  expect(expandShorthandProperties('margin', '10px').map((node) => node.print()))
-    .toMatchInlineSnapshot(`
+  expect(expandShorthandProperties('margin', '10px').map(printNodes)).toMatchInlineSnapshot(`
     Array [
       "._3sgLnu{margin-top:10px}",
       "._42OSNq{margin-right:10px}",
@@ -108,8 +102,7 @@ it('expands margins and paddings as expected', () => {
       "._21Xfw8{margin-left:10px}",
     ]
   `);
-  expect(expandShorthandProperties('padding', '10px').map((node) => node.print()))
-    .toMatchInlineSnapshot(`
+  expect(expandShorthandProperties('padding', '10px').map(printNodes)).toMatchInlineSnapshot(`
     Array [
       "._2h8fCA{padding-top:10px}",
       "._18S2bQ{padding-right:10px}",
@@ -119,8 +112,7 @@ it('expands margins and paddings as expected', () => {
   `);
 
   // 2) two values
-  expect(expandShorthandProperties('margin', '10px 20px').map((node) => node.print()))
-    .toMatchInlineSnapshot(`
+  expect(expandShorthandProperties('margin', '10px 20px').map(printNodes)).toMatchInlineSnapshot(`
     Array [
       "._3sgLnu{margin-top:10px}",
       "._4098WN{margin-right:20px}",
@@ -128,8 +120,7 @@ it('expands margins and paddings as expected', () => {
       "._1yVWfq{margin-left:20px}",
     ]
   `);
-  expect(expandShorthandProperties('padding', '10px 20px').map((node) => node.print()))
-    .toMatchInlineSnapshot(`
+  expect(expandShorthandProperties('padding', '10px 20px').map(printNodes)).toMatchInlineSnapshot(`
     Array [
       "._2h8fCA{padding-top:10px}",
       "._3PTJRo{padding-right:20px}",
@@ -139,7 +130,7 @@ it('expands margins and paddings as expected', () => {
   `);
 
   // 3) three values
-  expect(expandShorthandProperties('margin', '10px 20px 30px').map((node) => node.print()))
+  expect(expandShorthandProperties('margin', '10px 20px 30px').map(printNodes))
     .toMatchInlineSnapshot(`
     Array [
       "._3sgLnu{margin-top:10px}",
@@ -148,7 +139,7 @@ it('expands margins and paddings as expected', () => {
       "._1yVWfq{margin-left:20px}",
     ]
   `);
-  expect(expandShorthandProperties('padding', '10px 20px 30px').map((node) => node.print()))
+  expect(expandShorthandProperties('padding', '10px 20px 30px').map(printNodes))
     .toMatchInlineSnapshot(`
     Array [
       "._2h8fCA{padding-top:10px}",
@@ -159,7 +150,7 @@ it('expands margins and paddings as expected', () => {
   `);
 
   // 4) four values
-  expect(expandShorthandProperties('margin', '10px 20px 30px 40px').map((node) => node.print()))
+  expect(expandShorthandProperties('margin', '10px 20px 30px 40px').map(printNodes))
     .toMatchInlineSnapshot(`
     Array [
       "._3sgLnu{margin-top:10px}",
@@ -168,7 +159,7 @@ it('expands margins and paddings as expected', () => {
       "._2frFkL{margin-left:40px}",
     ]
   `);
-  expect(expandShorthandProperties('padding', '10px 20px 30px 40px').map((node) => node.print()))
+  expect(expandShorthandProperties('padding', '10px 20px 30px 40px').map(printNodes))
     .toMatchInlineSnapshot(`
     Array [
       "._2h8fCA{padding-top:10px}",

--- a/src/sx/src/create.js
+++ b/src/sx/src/create.js
@@ -1,8 +1,9 @@
 // @flow
 
-import { invariant, isObjectEmpty } from '@adeira/js';
+import { invariant, isBrowser, isObjectEmpty } from '@adeira/js';
 import levenshtein from 'fast-levenshtein';
 
+import injectRuntimeStyles from './injectRuntimeStyles';
 import styleCollector from './StyleCollector';
 import type { AllCSSPropertyTypes } from './css-properties/__generated__/AllCSSPropertyTypes';
 import type { AllCSSPseudoTypes } from './css-properties/__generated__/AllCSSPseudoTypes';
@@ -50,7 +51,11 @@ export default function create<T: SheetDefinitions>(
     `Function 'sx.create' cannot be called with empty stylesheet definition.`,
   );
 
-  const { hashRegistry } = styleCollector.collect(sheetDefinitions);
+  const { hashRegistry, styleBuffer } = styleCollector.collect(sheetDefinitions);
+
+  if (isBrowser()) {
+    injectRuntimeStyles(styleBuffer);
+  }
 
   return function sx(...sheetDefinitionNames) {
     invariant(

--- a/src/sx/src/injectRuntimeStyles.js
+++ b/src/sx/src/injectRuntimeStyles.js
@@ -1,0 +1,74 @@
+// @flow
+
+/* global document */
+
+import { invariant, warning } from '@adeira/js';
+
+import StyleCollectorAtNode from './StyleCollectorAtNode';
+import StyleCollectorNode from './StyleCollectorNode';
+import StyleCollectorPseudoNode from './StyleCollectorPseudoNode';
+import type { StyleBufferType } from './StyleCollector';
+
+// <style data-adeira-sx />
+opaque type StyleElementType = HTMLStyleElement | null;
+let styleAdeiraSXTag: StyleElementType = null;
+
+// https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model
+export default function injectRuntimeStyles(styleBuffer: StyleBufferType) {
+  if (styleAdeiraSXTag === null) {
+    styleAdeiraSXTag = ((document.querySelector('style[data-adeira-sx]'): any): StyleElementType);
+    if (styleAdeiraSXTag === null) {
+      // Still `null` so let's create the style element:
+      const htmlHead = document.head;
+      styleAdeiraSXTag = document.createElement('style');
+      styleAdeiraSXTag.type = 'text/css';
+      styleAdeiraSXTag.setAttribute('data-adeira-sx', '');
+      htmlHead?.appendChild(styleAdeiraSXTag);
+    }
+
+    invariant(
+      styleAdeiraSXTag != null,
+      'SX cannot render any styles because <style data-adeira-sx /> was not found and could not be created in the HTML document.',
+    );
+  }
+
+  const styleSheet = styleAdeiraSXTag.sheet;
+  invariant(
+    styleSheet != null,
+    'SX cannot apply runtime styles because HTMLStyleElement.sheet does not exist.',
+  );
+
+  function findStyleRule(selectorText) {
+    for (const cssRule of styleSheet.cssRules) {
+      // eslint-disable-next-line no-undef
+      if (cssRule.type === CSSRule.STYLE_RULE) {
+        const styleRule = ((cssRule: any): CSSStyleRule);
+        if (styleRule.selectorText === `.${selectorText}`) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  const insertIndex = styleSheet.cssRules.length;
+  styleBuffer.forEach((node) => {
+    if (node instanceof StyleCollectorNode) {
+      if (findStyleRule(node.getHash()) === false) {
+        // apply missing styles
+        styleSheet.insertRule(node.printNodes().join(''), insertIndex);
+      }
+    } else if (node instanceof StyleCollectorAtNode) {
+      // TODO: make sure we are not adding already added styles (?)
+      styleSheet.insertRule(node.printNodes().join(''), insertIndex);
+    } else if (node instanceof StyleCollectorPseudoNode) {
+      const nodes = node.printNodes();
+      for (const nodeElement of nodes) {
+        // TODO: make sure we are not adding already added styles (?)
+        styleSheet.insertRule(nodeElement, insertIndex);
+      }
+    } else {
+      warning(false, 'Node not supported in runtime styles: %j', node);
+    }
+  });
+}


### PR DESCRIPTION
Runtime styles should be now working. You can test it by running Relay Example or SX Tailwind Website and try to go from page to page. You should see that the styles work as expected without the need to SSR the styles.

Closes: https://github.com/adeira/universe/issues/1012

TODO:

- [x] merge https://github.com/adeira/universe/pull/1239
- [x] revert https://github.com/adeira/universe/pull/1244