### PR TITLE
SX: decouple CSS rendering logic

### DIFF
--- a/src/sx/src/create.js
+++ b/src/sx/src/create.js
@@ -128,6 +128,7 @@ export default function create<T: SheetDefinitions>(
       );
 
       buffer.set(hash, {
+        className: hash,
         styleName: transformStyleName(property),
         styleValue: transformValue(property, styleValue),
         pseudo,

--- a/src/sx/src/css-renderers/__tests__/renderAtomicClass.test.js
+++ b/src/sx/src/css-renderers/__tests__/renderAtomicClass.test.js
@@ -1,0 +1,31 @@
+// @flow strict
+
+import renderAtomicClass from '../renderAtomicClass';
+
+it('renders atomic classes as expected', () => {
+  expect(
+    renderAtomicClass({
+      className: 'aaa',
+      styleName: 'bbb',
+      styleValue: 'ccc',
+    }),
+  ).toMatchInlineSnapshot(`".aaa{bbb:ccc}"`);
+
+  expect(
+    renderAtomicClass({
+      className: 'aaa',
+      styleName: 'bbb',
+      styleValue: 'ccc',
+      pseudo: ':hover',
+    }),
+  ).toMatchInlineSnapshot(`".aaa:hover{bbb:ccc}"`);
+
+  expect(
+    renderAtomicClass({
+      className: 'aaa',
+      styleName: 'bbb',
+      styleValue: 'ccc',
+      pseudo: '::after',
+    }),
+  ).toMatchInlineSnapshot(`".aaa::after{bbb:ccc}"`);
+});

--- a/src/sx/src/css-renderers/__tests__/renderAtomicClasses.test.js
+++ b/src/sx/src/css-renderers/__tests__/renderAtomicClasses.test.js
@@ -1,0 +1,27 @@
+// @flow strict
+
+import renderAtomicClasses from '../renderAtomicClasses';
+
+it('renders atomic classes as expected', () => {
+  expect(
+    renderAtomicClasses([
+      {
+        className: 'aaa',
+        styleName: 'bbb',
+        styleValue: 'ccc',
+      },
+      {
+        className: 'aaa',
+        styleName: 'bbb',
+        styleValue: 'ccc',
+        pseudo: ':hover',
+      },
+      {
+        className: 'aaa',
+        styleName: 'bbb',
+        styleValue: 'ccc',
+        pseudo: '::after',
+      },
+    ]),
+  ).toMatchInlineSnapshot(`".aaa{bbb:ccc} .aaa:hover{bbb:ccc} .aaa::after{bbb:ccc}"`);
+});

--- a/src/sx/src/css-renderers/__tests__/renderMediaQuery.test.js
+++ b/src/sx/src/css-renderers/__tests__/renderMediaQuery.test.js
@@ -1,0 +1,27 @@
+// @flow strict
+
+import renderMediaQuery from '../renderMediaQuery';
+
+it('renders media queries as expected', () => {
+  expect(
+    renderMediaQuery('@media print', [
+      {
+        className: 'aaa',
+        styleName: 'bbb',
+        styleValue: 'ccc',
+      },
+      {
+        className: 'aaa',
+        styleName: 'bbb',
+        styleValue: 'ccc',
+        pseudo: ':hover',
+      },
+      {
+        className: 'aaa',
+        styleName: 'bbb',
+        styleValue: 'ccc',
+        pseudo: '::after',
+      },
+    ]),
+  ).toMatchInlineSnapshot(`"@media print{.aaa{bbb:ccc} .aaa:hover{bbb:ccc} .aaa::after{bbb:ccc}"`);
+});

--- a/src/sx/src/css-renderers/renderAtomicClass.js
+++ b/src/sx/src/css-renderers/renderAtomicClass.js
@@ -1,0 +1,17 @@
+// @flow strict
+
+type Input = {|
+  +className: string,
+  +styleName: string,
+  +styleValue: string,
+  +pseudo?: string,
+|};
+
+export default function renderAtomicClass({
+  className,
+  styleName,
+  styleValue,
+  pseudo,
+}: Input): string {
+  return `.${className}${pseudo ?? ''}{${styleName}:${styleValue}}`;
+}

--- a/src/sx/src/css-renderers/renderAtomicClasses.js
+++ b/src/sx/src/css-renderers/renderAtomicClasses.js
@@ -1,0 +1,20 @@
+// @flow strict
+
+import renderAtomicClass from './renderAtomicClass';
+
+type Input = {|
+  +className: string,
+  +styleName: string,
+  +styleValue: string,
+  +pseudo?: string,
+|};
+
+export default function renderAtomicClasses(inputArray: $ReadOnlyArray<Input>): string {
+  let css = '';
+  let prefix = '';
+  for (const input of inputArray) {
+    css += `${prefix}${renderAtomicClass(input)}`;
+    prefix = ' ';
+  }
+  return css;
+}

--- a/src/sx/src/css-renderers/renderMediaQuery.js
+++ b/src/sx/src/css-renderers/renderMediaQuery.js
@@ -1,0 +1,17 @@
+// @flow strict
+
+import renderAtomicClasses from './renderAtomicClasses';
+
+type Input = {|
+  +className: string,
+  +styleName: string,
+  +styleValue: string,
+  +pseudo?: string,
+|};
+
+export default function renderMediaQuery(
+  mediaQuery: string,
+  inputArray: $ReadOnlyArray<Input>,
+): string {
+  return `${mediaQuery}{${renderAtomicClasses(inputArray)}`;
+}

--- a/src/sx/src/renderStatic.js
+++ b/src/sx/src/renderStatic.js
@@ -1,30 +1,24 @@
 // @flow
 
 import { styleBuffer, mediaStyleBuffer } from './styleBuffer';
-
-function printBuffer(buffer) {
-  let css = '';
-  let prefix = '';
-  for (const [key, value] of buffer) {
-    css += `${prefix}.${key}${value.pseudo ?? ''}{${value.styleName}:${value.styleValue}}`;
-    prefix = ' ';
-  }
-  return css;
-}
+import renderAtomicClasses from './css-renderers/renderAtomicClasses';
+import renderMediaQuery from './css-renderers/renderMediaQuery';
 
 export default function renderStatic(
   renderFunc: () => $FlowFixMe,
 ): {| +html: $FlowFixMe, +css: string |} {
-  let css = printBuffer(styleBuffer);
+  const html = renderFunc();
+
+  let css = renderAtomicClasses(Array.from(styleBuffer.values()));
   let prefix = '';
 
   for (const [key, value] of mediaStyleBuffer) {
-    css += `${prefix}${key}{${printBuffer(value)}}`;
+    css += `${prefix}${renderMediaQuery(key, Array.from(value.values()))}}`;
     prefix = ' ';
   }
 
   return {
-    html: renderFunc(),
+    html,
     css,
   };
 }

--- a/src/sx/src/styleBuffer.js
+++ b/src/sx/src/styleBuffer.js
@@ -1,6 +1,7 @@
 // @flow strict
 
 type GenericStyleBuffer = {|
+  +className: string,
   +styleName: string,
   +styleValue: string,
   +pseudo?: string,


### PR DESCRIPTION
This way we can reuse it when working with the runtime styles.