### PR TITLE
Shipit: strip BUILD files by default

### DIFF
--- a/src/monorepo-shipit/config/__tests__/docs-adeira-dev.test.js
+++ b/src/monorepo-shipit/config/__tests__/docs-adeira-dev.test.js
@@ -12,5 +12,9 @@ testExportedPaths(path.join(__dirname, '..', 'docs-adeira-dev.js'), [
 
   // invalid cases:
   ['src/packages/monorepo/outsideScope.js', undefined], // correctly deleted
+  ['src/docs/BUILD.bazel', undefined], // correctly deleted
+  ['src/docs/BUILD', undefined], // correctly deleted
+  ['src/docs/WORKSPACE.bazel', undefined], // correctly deleted
+  ['src/docs/WORKSPACE', undefined], // correctly deleted
   ['package.json', undefined], // correctly deleted
 ]);

--- a/src/monorepo-shipit/config/__tests__/example-relay.test.js
+++ b/src/monorepo-shipit/config/__tests__/example-relay.test.js
@@ -20,8 +20,12 @@ testExportedPaths(path.join(__dirname, '..', 'example-relay.js'), [
   ['src/example-relay/scripts/jest/setupTests.js', 'scripts/jest/setupTests.js'],
 
   // invalid cases:
+  ['src/packages/monorepo/outsideScope.js', undefined], // correctly deleted
   ['src/example-relay/.babelrc.js', undefined], // correctly deleted
   ['src/example-relay/__github__/unknown.js', undefined], // correctly deleted
-  ['src/packages/monorepo/outsideScope.js', undefined], // correctly deleted
+  ['src/example-relay/BUILD.bazel', undefined], // correctly deleted
+  ['src/example-relay/BUILD', undefined], // correctly deleted
+  ['src/example-relay/WORKSPACE.bazel', undefined], // correctly deleted
+  ['src/example-relay/WORKSPACE', undefined], // correctly deleted
   ['package.json', undefined], // correctly deleted
 ]);

--- a/src/monorepo-shipit/config/__tests__/monorepo-shipit.test.js
+++ b/src/monorepo-shipit/config/__tests__/monorepo-shipit.test.js
@@ -12,5 +12,9 @@ testExportedPaths(path.join(__dirname, '..', 'monorepo-shipit.js'), [
 
   // invalid cases:
   ['src/packages/monorepo/outsideScope.js', undefined], // correctly deleted
+  ['src/monorepo-shipit/BUILD.bazel', undefined], // correctly deleted
+  ['src/monorepo-shipit/BUILD', undefined], // correctly deleted
+  ['src/monorepo-shipit/WORKSPACE.bazel', undefined], // correctly deleted
+  ['src/monorepo-shipit/WORKSPACE', undefined], // correctly deleted
   ['package.json', undefined], // correctly deleted
 ]);

--- a/src/monorepo-shipit/config/__tests__/sx.test.js
+++ b/src/monorepo-shipit/config/__tests__/sx.test.js
@@ -11,5 +11,9 @@ testExportedPaths(path.join(__dirname, '..', 'sx.js'), [
 
   // invalid cases:
   ['src/packages/monorepo/outsideScope.js', undefined], // correctly deleted
+  ['src/sx/BUILD.bazel', undefined], // correctly deleted
+  ['src/sx/BUILD', undefined], // correctly deleted
+  ['src/sx/WORKSPACE.bazel', undefined], // correctly deleted
+  ['src/sx/WORKSPACE', undefined], // correctly deleted
   ['package.json', undefined], // correctly deleted
 ]);

--- a/src/monorepo-shipit/src/ShipitConfig.js
+++ b/src/monorepo-shipit/src/ShipitConfig.js
@@ -70,11 +70,19 @@ export default class ShipitConfig {
       const ch2 = stripExceptDirectories(ch1, this.getSourceRoots());
       const ch3 = moveDirectories(ch2, this.directoryMapping);
       const ch4 = stripPaths(ch3, this.strippedFiles);
+      const ch5 = stripPaths(
+        ch4,
+        new Set([
+          // These files are being stripped by default. It's currently not configurable.
+          /^BUILD(?:\.bazel)?$/,
+          /^WORKSPACE(?:\.bazel)?$/,
+        ]),
+      );
 
       // First we comment out lines marked with `@x-shipit-disable`.
-      const ch5 = commentLines(ch4, '@x-shipit-disable', '//', null);
+      const ch6 = commentLines(ch5, '@x-shipit-disable', '//', null);
       // Then we uncomment lines marked with `@x-shipit-enable`.
-      return uncommentLines(ch5, '@x-shipit-enable', '//', null);
+      return uncommentLines(ch6, '@x-shipit-enable', '//', null);
     };
   }
 

--- a/src/monorepo-shipit/src/__tests__/RepoGit.commitPatch.test.js
+++ b/src/monorepo-shipit/src/__tests__/RepoGit.commitPatch.test.js
@@ -1,11 +1,11 @@
 // @flow
 
 import RepoGitFake from '../RepoGitFake';
-import createFakeChangeset from '../utils/createFakeChangeset';
+import createMockChangeset from '../utils/createMockChangeset';
 
 it('can commit empty changeset', () => {
   const repo = new RepoGitFake();
-  const changeset = createFakeChangeset(0);
+  const changeset = createMockChangeset(0);
   repo.commitPatch(changeset);
   expect(repo.printFakeRepoHistory()).toMatchInlineSnapshot(`
     "SUBJ: Test subject
@@ -15,7 +15,7 @@ it('can commit empty changeset', () => {
 
 it('commits changeset with single diff correctly', () => {
   const repo = new RepoGitFake();
-  const changeset = createFakeChangeset(1);
+  const changeset = createMockChangeset(1);
   repo.commitPatch(changeset);
 
   expect(repo.printFakeRepoHistory()).toMatchInlineSnapshot(`
@@ -29,7 +29,7 @@ it('commits changeset with single diff correctly', () => {
 
 it('commits changeset with multiple diffs correctly', () => {
   const repo = new RepoGitFake();
-  const changeset = createFakeChangeset(3);
+  const changeset = createMockChangeset(3);
   repo.commitPatch(changeset);
 
   expect(repo.printFakeRepoHistory()).toMatchInlineSnapshot(`

--- a/src/monorepo-shipit/src/__tests__/ShipitConfig.test.js
+++ b/src/monorepo-shipit/src/__tests__/ShipitConfig.test.js
@@ -1,6 +1,7 @@
 // @flow strict-local
 
 import Config from '../ShipitConfig';
+import createMockChangeset from '../utils/createMockChangeset';
 
 jest.mock('fs');
 
@@ -26,4 +27,15 @@ it('returns empty set when trying to get roots of the exported repo', () => {
   ).toEqual(
     new Set(), // empty set expected
   );
+});
+
+it('creates and runs the default filters', () => {
+  const defaultFilter = new Config(
+    'fake monorepo path',
+    'fake exported repo URL',
+    new Map([['/known_path', '/destination_path']]),
+    new Set([/mocked/]),
+  ).getDefaultShipitFilter();
+
+  expect(defaultFilter(createMockChangeset(2, '/known_path/'))).toMatchSnapshot();
 });

--- a/src/monorepo-shipit/src/__tests__/__snapshots__/ShipitConfig.test.js.snap
+++ b/src/monorepo-shipit/src/__tests__/__snapshots__/ShipitConfig.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`creates and runs the default filters 1`] = `
+Changeset {
+  "author": "John Doe <john@doe.com>",
+  "description": "Test description
+
+adeira-source-id: 1234567890",
+  "diffs": Set {
+    Object {
+      "body": "new file mode 100644
+index 0000000000000000000000000000000000000000..1111111111111111111111111111111111111111
+--- /dev/null
++++ b//destination_path/fakeFile_1.txt
+@@ -0,0 +1 @@
++fake content",
+      "path": "/destination_path/fakeFile_1.txt",
+    },
+    Object {
+      "body": "new file mode 100644
+index 0000000000000000000000000000000000000000..1111111111111111111111111111111111111111
+--- /dev/null
++++ b//destination_path/fakeFile_2.txt
+@@ -0,0 +1 @@
++fake content",
+      "path": "/destination_path/fakeFile_2.txt",
+    },
+  },
+  "id": "1234567890",
+  "subject": "Test subject",
+  "timestamp": "Mon, 16 July 2019 10:55:04 -0100",
+}
+`;

--- a/src/monorepo-shipit/src/utils/createMockChangeset.js
+++ b/src/monorepo-shipit/src/utils/createMockChangeset.js
@@ -1,11 +1,12 @@
 // @flow strict
 
 import Changeset from '../Changeset';
+import createMockDiff from './createMockDiff';
 
 /**
  * This changeset contains valid but fake data and should be used only in tests.
  */
-export default function createFakeChangeset(
+export default function createMockChangeset(
   numberOfDiffs: number = 2,
   basePath: string = '',
 ): Changeset {
@@ -13,19 +14,11 @@ export default function createFakeChangeset(
 
   for (let i = 1; i <= numberOfDiffs; i++) {
     const filename = `${basePath}fakeFile_${i}.txt`;
-    diffs.add({
-      path: filename,
-      body:
-        'new file mode 100644\n' +
-        'index 0000000000000000000000000000000000000000..72943a16fb2c8f38f9dde202b7a70ccc19c52f34\n' +
-        '--- /dev/null\n' +
-        `+++ b/${filename}\n` +
-        '@@ -0,0 +1 @@\n' +
-        `+fake content ${i}`,
-    });
+    diffs.add(createMockDiff(filename));
   }
 
   return new Changeset()
+    .withID('1234567890')
     .withSubject('Test subject')
     .withDescription('Test description')
     .withAuthor('John Doe <john@doe.com>')

--- a/src/monorepo-shipit/src/utils/createMockDiff.js
+++ b/src/monorepo-shipit/src/utils/createMockDiff.js
@@ -1,0 +1,19 @@
+// @flow strict
+
+type Diff = {|
+  +path: string,
+  +body: string,
+|};
+
+export default function createMockDiff(filename: string): Diff {
+  return {
+    path: filename,
+    body:
+      'new file mode 100644\n' +
+      'index 0000000000000000000000000000000000000000..1111111111111111111111111111111111111111\n' +
+      '--- /dev/null\n' +
+      `+++ b/${filename}\n` +
+      '@@ -0,0 +1 @@\n' +
+      `+fake content`,
+  };
+}


### PR DESCRIPTION
I think it doesn't make sense to ship these files outside of monorepo so I am adding them to the default filter. It can be eventually made configurable if needed.