### PR TITLE
SX: Render media queries as last on the page

### DIFF
--- a/src/sx/src/StyleCollector.js
+++ b/src/sx/src/StyleCollector.js
@@ -26,7 +26,7 @@ export class StyleNode {
   }
 }
 
-class StyleCollector {
+export class StyleCollector {
   styles: Map<string, StyleNode | StyleCollector>;
   atRuleName: ?string;
 

--- a/src/sx/src/__tests__/__snapshots__/renderPageWithSX.test.js.snap
+++ b/src/sx/src/__tests__/__snapshots__/renderPageWithSX.test.js.snap
@@ -151,6 +151,40 @@ class="wUqnh _4fo5TC"
 
 `;
 
+exports[`matches expected output: media-queries-goes-last.json 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+{
+  "aaa": {
+    "@media (min-width: 640px)": {
+      "color": "#00f"
+    }
+  },
+  "bbb": {
+    "color": "#0f0"
+  }
+}
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+._9MIuv {
+  color: #0f0;
+}
+@media (min-width: 640px) {
+  ._2dHaKY {
+    color: #00f;
+  }
+}
+
+~~~~~~~~~~ USAGE ~~~~~~~~~~
+
+className={styles('aaa')}
+  ↓ ↓ ↓
+class="_2dHaKY"
+
+className={styles('bbb')}
+  ↓ ↓ ↓
+class="_9MIuv"
+
+`;
+
 exports[`matches expected output: media-queries-multiple.json 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 {

--- a/src/sx/src/__tests__/fixtures/media-queries-goes-last.json
+++ b/src/sx/src/__tests__/fixtures/media-queries-goes-last.json
@@ -1,0 +1,10 @@
+{
+  "aaa": {
+    "@media (min-width: 640px)": {
+      "color": "#00f"
+    }
+  },
+  "bbb": {
+    "color": "#0f0"
+  }
+}


### PR DESCRIPTION
In CSS the rule that is set last, is the one that will be executed. That means rules in media queries would never be used if they are not at the end.

Here the red always wins:
```
@media (max-width: 640px) {
  color: blue;
}
color: red;
```

Here the color is blue on a screen smaller than 640px:
```
color: red;
@media (max-width: 640px) {
  color: blue;
}
```