### PR TITLE
Eslint config: remove '__' global

### DIFF
--- a/src/eslint-config-adeira/CHANGELOG.md
+++ b/src/eslint-config-adeira/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Remove `__` global, legacy of Nitrolib from Kiwi.com, see: https://kiwicom.github.io/nitrolib/services.html#intl
+
 # 3.2.0
 
 - Rule `adeira/no-invalid-flow-annotations` checks for typos like `@flow srict` (should be `@flow strict`).

--- a/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
+++ b/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
@@ -4,7 +4,6 @@ exports[`rules snapshot: all stable rules 1`] = `
 Object {
   "globals": Object {
     "FormData": "readonly",
-    "__": "readonly",
     "__DEV__": "readonly",
     "global": "readonly",
     "globalThis": "readonly",

--- a/src/eslint-config-adeira/getCommonConfig.js
+++ b/src/eslint-config-adeira/getCommonConfig.js
@@ -69,7 +69,6 @@ module.exports = function getCommonConfig(rules /*: EslintConfigRules */) /*: Es
     globals: {
       global: 'readonly', // TODO: make it 'off'
       globalThis: 'readonly', // https://github.com/tc39/proposal-global
-      __: 'readonly', // https://kiwicom.github.io/nitrolib/services.html#intl
       __DEV__: 'readonly',
       FormData: 'readonly', // https://developer.mozilla.org/en-US/docs/Web/API/FormData
     },

--- a/src/js/CHANGELOG.md
+++ b/src/js/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- TS types removed, use [`@types/adeira__js`](https://www.npmjs.com/package/@types/adeira__js), see: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48501
+
 # 1.2.4
 
 - Extend `isObjectEmpty` to check for non-enumerable properties


### PR DESCRIPTION
This seems to be very project specific and unused in Adeira universe.