### PR TITLE
SX: fix style buffer collecting and resetting

### DIFF
--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -13,7 +13,7 @@
     "@adeira/relay": "^2.1.0",
     "@adeira/relay-runtime": "^0.17.0",
     "@adeira/relay-utils": "0.11.0",
-    "@adeira/sx": "^0.11.0",
+    "@adeira/sx": "^0.13.0",
     "@adeira/test-utils": "^0.5.0",
     "apollo-server-micro": "^2.18.2",
     "cors": "^2.8.5",

--- a/src/sx/src/StyleCollectorAtNode.js
+++ b/src/sx/src/StyleCollectorAtNode.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { type PrintableNode, type PrintConfig } from './StyleCollectorNode';
+import { type StyleCollectorNodeInterface, type PrintConfig } from './StyleCollectorNode';
 
 /**
  * Represents any "at" rule:
@@ -30,13 +30,21 @@ import { type PrintableNode, type PrintConfig } from './StyleCollectorNode';
  * }
  * ```
  */
-export default class StyleCollectorAtNode implements PrintableNode {
+export default class StyleCollectorAtNode implements StyleCollectorNodeInterface {
   atRuleName: string;
-  nodes: Set<PrintableNode>;
+  nodes: Map<string, StyleCollectorNodeInterface>;
 
-  constructor(atRuleName: string, nodes: Set<PrintableNode>) {
+  constructor(atRuleName: string, nodes: Map<string, StyleCollectorNodeInterface>) {
     this.atRuleName = atRuleName;
     this.nodes = nodes;
+  }
+
+  addNodes(nodes: Map<string, StyleCollectorNodeInterface>) {
+    this.nodes = new Map([...this.nodes, ...nodes]);
+  }
+
+  getAtRuleName(): string {
+    return this.atRuleName;
   }
 
   // eslint-disable-next-line no-unused-vars

--- a/src/sx/src/StyleCollectorNode.js
+++ b/src/sx/src/StyleCollectorNode.js
@@ -1,5 +1,7 @@
 // @flow
 
+import { invariant } from '@adeira/js';
+
 import hashStyle from './hashStyle';
 import transformValue from './transformValue';
 import transformStyleName from './transformStyleName';
@@ -9,8 +11,9 @@ export type PrintConfig = {|
   +bumpSpecificity?: boolean,
 |};
 
-export interface PrintableNode {
+export interface StyleCollectorNodeInterface {
   print(config?: PrintConfig): string;
+  addNodes(nodes: Map<string, StyleCollectorNodeInterface>): void;
 }
 
 /**
@@ -30,7 +33,7 @@ export interface PrintableNode {
  * }
  * ```
  */
-export default class StyleCollectorNode implements PrintableNode {
+export default class StyleCollectorNode implements StyleCollectorNodeInterface {
   hash: string;
   styleName: string;
   styleValue: string | number;
@@ -39,6 +42,11 @@ export default class StyleCollectorNode implements PrintableNode {
     this.hash = hashStyle(`${styleName}${styleValue}${hashSeed}`);
     this.styleName = transformStyleName(styleName);
     this.styleValue = transformValue(styleName, styleValue);
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  addNodes(nodes: Map<string, StyleCollectorNodeInterface>) {
+    invariant(false, 'StyleCollectorNode cannot have nested nodes,');
   }
 
   getHash(): string {

--- a/src/sx/src/StyleCollectorPseudoNode.js
+++ b/src/sx/src/StyleCollectorPseudoNode.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { type PrintableNode, type PrintConfig } from './StyleCollectorNode';
+import { type StyleCollectorNodeInterface, type PrintConfig } from './StyleCollectorNode';
 
 /**
  * Represents basic style node with pseudo class:
@@ -24,13 +24,17 @@ import { type PrintableNode, type PrintConfig } from './StyleCollectorNode';
  * }
  * ```
  */
-export default class StyleCollectorPseudoNode implements PrintableNode {
+export default class StyleCollectorPseudoNode implements StyleCollectorNodeInterface {
   pseudo: string;
-  nodes: Set<PrintableNode>;
+  nodes: Map<string, StyleCollectorNodeInterface>;
 
-  constructor(pseudo: string, nodes: Set<PrintableNode>) {
+  constructor(pseudo: string, nodes: Map<string, StyleCollectorNodeInterface>) {
     this.pseudo = pseudo;
     this.nodes = nodes;
+  }
+
+  addNodes(nodes: Map<string, StyleCollectorNodeInterface>) {
+    this.nodes = new Map([...this.nodes, ...nodes]);
   }
 
   getPseudo(): string {

--- a/src/sx/src/__tests__/StyleCollector.test.js
+++ b/src/sx/src/__tests__/StyleCollector.test.js
@@ -1,10 +1,14 @@
 // @flow
 
-import styleCollector from '../StyleCollector';
+import StyleCollector from '../StyleCollector';
+
+afterEach(() => {
+  StyleCollector.reset();
+});
 
 it('works with simple styles', () => {
   expect(
-    styleCollector.collect({
+    StyleCollector.collect({
       test: { color: 'blue' },
       lol: {
         fontSize: 16,
@@ -23,24 +27,15 @@ it('works with simple styles', () => {
         },
       },
       "styleBuffer": Map {
-        "test" => Set {
-          StyleCollectorNode {
-            "hash": "_4fo5TC",
-            "styleName": "color",
-            "styleValue": "#00f",
-          },
+        "_4fo5TC" => StyleCollectorNode {
+          "hash": "_4fo5TC",
+          "styleName": "color",
+          "styleValue": "#00f",
         },
-        "lol" => Set {
-          StyleCollectorNode {
-            "hash": "Zld8p",
-            "styleName": "font-size",
-            "styleValue": "1rem",
-          },
-          StyleCollectorNode {
-            "hash": "_4fo5TC",
-            "styleName": "color",
-            "styleValue": "#00f",
-          },
+        "Zld8p" => StyleCollectorNode {
+          "hash": "Zld8p",
+          "styleName": "font-size",
+          "styleValue": "1rem",
         },
       },
     }
@@ -49,7 +44,7 @@ it('works with simple styles', () => {
 
 it('works with pseudo styles', () => {
   expect(
-    styleCollector.collect({
+    StyleCollector.collect({
       lol: {
         'fontSize': 16,
         'color': 'blue',
@@ -70,32 +65,30 @@ it('works with pseudo styles', () => {
         },
       },
       "styleBuffer": Map {
-        "lol" => Set {
-          StyleCollectorNode {
-            "hash": "Zld8p",
-            "styleName": "font-size",
-            "styleValue": "1rem",
-          },
-          StyleCollectorNode {
-            "hash": "_4fo5TC",
-            "styleName": "color",
-            "styleValue": "#00f",
-          },
-          StyleCollectorPseudoNode {
-            "nodes": Set {
-              StyleCollectorNode {
-                "hash": "_4rAdwD",
-                "styleName": "color",
-                "styleValue": "#ffc0cb",
-              },
-              StyleCollectorNode {
-                "hash": "_22QzO9",
-                "styleName": "text-decoration",
-                "styleValue": "underline",
-              },
+        "Zld8p" => StyleCollectorNode {
+          "hash": "Zld8p",
+          "styleName": "font-size",
+          "styleValue": "1rem",
+        },
+        "_4fo5TC" => StyleCollectorNode {
+          "hash": "_4fo5TC",
+          "styleName": "color",
+          "styleValue": "#00f",
+        },
+        ":hover" => StyleCollectorPseudoNode {
+          "nodes": Map {
+            "_4rAdwD" => StyleCollectorNode {
+              "hash": "_4rAdwD",
+              "styleName": "color",
+              "styleValue": "#ffc0cb",
             },
-            "pseudo": ":hover",
+            "_22QzO9" => StyleCollectorNode {
+              "hash": "_22QzO9",
+              "styleName": "text-decoration",
+              "styleValue": "underline",
+            },
           },
+          "pseudo": ":hover",
         },
       },
     }
@@ -104,7 +97,7 @@ it('works with pseudo styles', () => {
 
 it('works with mediaQueries', () => {
   expect(
-    styleCollector.collect({
+    StyleCollector.collect({
       test: {
         '@media (min-width: 900px)': {
           color: 'blue',
@@ -131,35 +124,31 @@ it('works with mediaQueries', () => {
         },
       },
       "styleBuffer": Map {
-        "test" => Set {
-          StyleCollectorAtNode {
-            "atRuleName": "@media (min-width: 900px)",
-            "nodes": Set {
-              StyleCollectorNode {
-                "hash": "jwIA4",
-                "styleName": "color",
-                "styleValue": "#00f",
-              },
+        "@media (min-width: 900px)" => StyleCollectorAtNode {
+          "atRuleName": "@media (min-width: 900px)",
+          "nodes": Map {
+            "jwIA4" => StyleCollectorNode {
+              "hash": "jwIA4",
+              "styleName": "color",
+              "styleValue": "#00f",
             },
           },
         },
-        "nestedMedia" => Set {
-          StyleCollectorAtNode {
-            "atRuleName": "@media print",
-            "nodes": Set {
-              StyleCollectorNode {
-                "hash": "zIzjk",
-                "styleName": "color",
-                "styleValue": "#f00",
-              },
-              StyleCollectorAtNode {
-                "atRuleName": "@media (max-width: 12cm)",
-                "nodes": Set {
-                  StyleCollectorNode {
-                    "hash": "Uxdbe",
-                    "styleName": "color",
-                    "styleValue": "#00f",
-                  },
+        "@media print" => StyleCollectorAtNode {
+          "atRuleName": "@media print",
+          "nodes": Map {
+            "zIzjk" => StyleCollectorNode {
+              "hash": "zIzjk",
+              "styleName": "color",
+              "styleValue": "#f00",
+            },
+            "@media (max-width: 12cm)" => StyleCollectorAtNode {
+              "atRuleName": "@media (max-width: 12cm)",
+              "nodes": Map {
+                "Uxdbe" => StyleCollectorNode {
+                  "hash": "Uxdbe",
+                  "styleName": "color",
+                  "styleValue": "#00f",
                 },
               },
             },

--- a/src/sx/src/__tests__/StyleCollectorAtNode.test.js
+++ b/src/sx/src/__tests__/StyleCollectorAtNode.test.js
@@ -7,9 +7,15 @@ import StyleCollectorPseudoNode from '../StyleCollectorPseudoNode';
 it('works as expected', () => {
   const node = new StyleCollectorAtNode(
     '@media print',
-    new Set([
-      new StyleCollectorNode('color', 'red'),
-      new StyleCollectorPseudoNode(':hover', new Set([new StyleCollectorNode('color', 'blue')])),
+    new Map([
+      ['c0', new StyleCollectorNode('color', 'red')],
+      [
+        ':hover',
+        new StyleCollectorPseudoNode(
+          ':hover',
+          new Map([['c0', new StyleCollectorNode('color', 'blue')]]),
+        ),
+      ],
     ]),
   );
 

--- a/src/sx/src/__tests__/StyleCollectorPseudoNode.test.js
+++ b/src/sx/src/__tests__/StyleCollectorPseudoNode.test.js
@@ -6,10 +6,10 @@ import StyleCollectorPseudoNode from '../StyleCollectorPseudoNode';
 it('works as expected', () => {
   const node = new StyleCollectorPseudoNode(
     ':hover',
-    new Set([
-      new StyleCollectorNode('color', 'red'),
-      new StyleCollectorNode('color', 'lime'),
-      new StyleCollectorNode('color', 'blue'),
+    new Map([
+      ['c0', new StyleCollectorNode('color', 'red')],
+      ['c1', new StyleCollectorNode('color', 'lime')],
+      ['c2', new StyleCollectorNode('color', 'blue')],
     ]),
   );
   expect(node.getPseudo()).toBe(':hover');

--- a/src/sx/src/__tests__/__snapshots__/renderPageWithSX.test.js.snap
+++ b/src/sx/src/__tests__/__snapshots__/renderPageWithSX.test.js.snap
@@ -186,15 +186,13 @@ exports[`matches expected output: media-queries-multiple.json 1`] = `
   .uxyoC.uxyoC {
     font-size: 1rem;
   }
+  .v2909.v2909 {
+    color: #008000;
+  }
 }
 @media (min-width: 30em) and (max-width: 50em) {
   ._27Xk5F._27Xk5F {
     color: #00f;
-  }
-}
-@media print {
-  .v2909.v2909 {
-    color: #008000;
   }
 }
 
@@ -435,7 +433,7 @@ class="_134wwt _22QzO9"
 exports[`matches expected output: pseudo-classes-multiple.json 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 {
-  "link": {
+  "aaa": {
     "textDecoration": "none",
     ":hover": {
       "textDecoration": "none",
@@ -443,6 +441,11 @@ exports[`matches expected output: pseudo-classes-multiple.json 1`] = `
     },
     ":active": {
       "color": "red"
+    }
+  },
+  "bbb": {
+    ":hover": {
+      "color": "blue"
     }
   }
 }
@@ -457,15 +460,22 @@ exports[`matches expected output: pseudo-classes-multiple.json 1`] = `
 ._4sFdkU:hover {
   color: #f00;
 }
+.UddGc:hover {
+  color: #00f;
+}
 .ERwS0:active {
   color: #f00;
 }
 
 ~~~~~~~~~~ USAGE ~~~~~~~~~~
 
-className={styles('link')}
+className={styles('aaa')}
   ↓ ↓ ↓
 class="_134wwt XJjf5 _4sFdkU ERwS0"
+
+className={styles('bbb')}
+  ↓ ↓ ↓
+class="UddGc"
 
 `;
 

--- a/src/sx/src/__tests__/fixtures/pseudo-classes-multiple.json
+++ b/src/sx/src/__tests__/fixtures/pseudo-classes-multiple.json
@@ -1,5 +1,5 @@
 {
-  "link": {
+  "aaa": {
     "textDecoration": "none",
     ":hover": {
       "textDecoration": "none",
@@ -7,6 +7,11 @@
     },
     ":active": {
       "color": "red"
+    }
+  },
+  "bbb": {
+    ":hover": {
+      "color": "blue"
     }
   }
 }

--- a/src/sx/src/__tests__/renderPageWithSX.test.js
+++ b/src/sx/src/__tests__/renderPageWithSX.test.js
@@ -7,11 +7,16 @@ import { sprintf } from '@adeira/js';
 import TestRenderer from 'react-test-renderer';
 
 import * as sx from '../../index';
+import StyleCollector from '../StyleCollector';
 
 const renderPageMock = () => ({
   html: '',
   head: [''],
   styles: [''],
+});
+
+afterEach(() => {
+  StyleCollector.reset();
 });
 
 generateTestsFromFixtures(path.join(__dirname, 'fixtures'), (input) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,21 +9,6 @@
   dependencies:
     "@babel/runtime" "^7.11.2"
 
-"@adeira/sx@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@adeira/sx/-/sx-0.11.0.tgz#b1cca103ac0c865c2ec821f4b0821d111a3b0dc5"
-  integrity sha512-tfCTgbZ9g/wlZIKzALWBnhyLwIHrUBDV2bOEB6v3ZZ4xaQC839NxSfc/FRk8uBw+RmyNiKiZiGkXF68fEz522g==
-  dependencies:
-    "@adeira/js" "^1.2.4"
-    "@adeira/murmur-hash" "^0.1.0"
-    "@adeira/signed-source" "^1.0.0"
-    "@babel/runtime" "^7.11.2"
-    change-case "^4.1.1"
-    css-tree "^1.0.0-alpha.39"
-    fast-levenshtein "^3.0.0"
-    mdn-data "^2.0.11"
-    prettier "^2.0.5"
-
 "@adeira/test-utils@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@adeira/test-utils/-/test-utils-0.2.0.tgz#9e9feef7bb10968d161dcd4a568e760af25b7c50"
@@ -13438,7 +13423,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.0.5, prettier@^2.1.2:
+prettier@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==


### PR DESCRIPTION
I broke this here: https://github.com/adeira/universe/commit/692f3e1c0c2383663bf39de3eb087df0b2022f43 (Relay example was using the old SX version and I incorrectly thought it works fine)

The style buffer must be initialized only once and reset only when needed (explicitly) because it must remember the styles across the whole application. Moreover, the collected styles must be merged in the style buffer rather than adding them to the set.

Test plan: make sure the relay example still works as expected.