### PR TITLE
Add root license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+See license in individual packages of this monorepo.


### PR DESCRIPTION
I need a link to the license of this repository so this placeholder should serve the purpose (we have different licences per project in the monorepo).