### PR TITLE
SXT Babel: Nested usage fix

### DIFF
--- a/src/babel-plugin-transform-sx-tailwind/package.json
+++ b/src/babel-plugin-transform-sx-tailwind/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/babel-plugin-transform-sx-tailwind",
   "license": "MIT",
   "private": false,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index",
   "sideEffects": false,
   "module": false,

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/nested/code.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/nested/code.js
@@ -1,0 +1,15 @@
+// @flow
+
+import React, { type Node } from 'react';
+import { sxt, tailwind } from '@adeira/sx-tailwind';
+
+export default function Example(): Node {
+  return (
+    <div className={tailwind('text-white bg-black')}>
+      White on black
+      <div className={tailwind('text-black bg-white')}>
+        Black on white
+      </div>
+    </div>
+  );
+}

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/nested/output.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/nested/output.js
@@ -1,0 +1,26 @@
+// @flow
+import React, { type Node } from 'react';
+import * as sx from '@adeira/sx';
+export default function Example(): Node {
+  return (
+    <div className={__styles_1dWXTL('text-white', 'bg-black')}>
+      White on black
+      <div className={__styles_1dWXTL('text-black', 'bg-white')}>Black on white</div>
+    </div>
+  );
+}
+
+const __styles_1dWXTL = sx.create({
+  'text-white': {
+    color: '#fff',
+  },
+  'bg-black': {
+    backgroundColor: '#000',
+  },
+  'text-black': {
+    color: '#000',
+  },
+  'bg-white': {
+    backgroundColor: '#fff',
+  },
+});


### PR DESCRIPTION
This PR fixes bug when `tailwind` was used in nested elements. Styles of children elements were merged with styles of parents.