### PR TITLE
sx: Remove auto adding of quotes in content

### DIFF
--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -13,7 +13,7 @@
     "@adeira/relay": "^2.1.0",
     "@adeira/relay-runtime": "^0.17.0",
     "@adeira/relay-utils": "0.11.0",
-    "@adeira/sx": "^0.14.0",
+    "@adeira/sx": "^0.15.0",
     "@adeira/test-utils": "^0.6.0",
     "apollo-server-micro": "^2.18.2",
     "cors": "^2.8.5",

--- a/src/sx-tailwind-website/package.json
+++ b/src/sx-tailwind-website/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@adeira/js": "^1.2.4",
     "@adeira/monorepo-utils": "^0.9.0",
-    "@adeira/sx": "^0.14.0",
+    "@adeira/sx": "^0.15.0",
     "@adeira/sx-tailwind": "^0.4.1",
     "next": "^10.0.0",
     "next-plugin-custom-babel-config": "^1.0.4",

--- a/src/sx-tailwind/package.json
+++ b/src/sx-tailwind/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@adeira/js": "^1.3.0",
     "@adeira/signed-source": "^1.0.0",
-    "@adeira/sx": "^0.14.0",
+    "@adeira/sx": "^0.15.0",
     "@babel/runtime": "^7.12.1",
     "change-case": "^4.1.1",
     "css-tree": "^1.0.0-alpha.39",

--- a/src/sx/README.md
+++ b/src/sx/README.md
@@ -95,7 +95,7 @@ const styles = sx.create({
       textDecoration: 'underline',
     },
     '::after': {
-      content: '∞',
+      content: '"∞"',
     },
   },
 });

--- a/src/sx/__flowtests__/css-properties.js
+++ b/src/sx/__flowtests__/css-properties.js
@@ -10,7 +10,7 @@ sx.create({
       color: 'blue',
     },
     '::after': {
-      content: '∞',
+      content: '"∞"',
     },
     '@media (min-width: 30em) and (max-width: 50em)': {
       color: 'blue',
@@ -44,7 +44,7 @@ sx.create({
   InvalidNestedPseudos: {
     '::before': {
       '::before': {
-        content: '∞',
+        content: '"∞"',
       },
     },
   },

--- a/src/sx/__flowtests__/sx.js
+++ b/src/sx/__flowtests__/sx.js
@@ -19,7 +19,7 @@ export function NoErrorsWithPseudo(): Node {
         color: 'blue',
       },
       '::after': {
-        content: '★',
+        content: '"★"',
       },
     },
   });

--- a/src/sx/package.json
+++ b/src/sx/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/sx",
   "license": "MIT",
   "private": false,
-  "version": "0.14.0",
+  "version": "0.15.0",
   "main": "index",
   "sideEffects": false,
   "module": false,

--- a/src/sx/src/__tests__/SxDomTests.test.js
+++ b/src/sx/src/__tests__/SxDomTests.test.js
@@ -24,7 +24,7 @@ const styles = sx.create({
       color: 'purple',
     },
     '::after': {
-      content: '🤓',
+      content: '"🤓"',
     },
   },
 });
@@ -81,7 +81,6 @@ it('includes reset', () => {
       box-sizing: inherit;
     }
 
-      
     </style>
   `);
 });

--- a/src/sx/src/__tests__/__snapshots__/fixtures.test.js.snap
+++ b/src/sx/src/__tests__/__snapshots__/fixtures.test.js.snap
@@ -495,12 +495,12 @@ exports[`matches expected output: pseudo-classes-nested-2.js 1`] = `
 {
   "test": {
     ":hover::after": {
-      "content": "this is OK"
+      "content": "\\"this is OK\\""
     }
   }
 }
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-._2BDpfz:hover::after {
+._4yRZ3O:hover::after {
   content: "this is OK";
 }
 
@@ -508,7 +508,7 @@ exports[`matches expected output: pseudo-classes-nested-2.js 1`] = `
 
 className={styles('test')}
   ↓ ↓ ↓
-class="_2BDpfz"
+class="_4yRZ3O"
 
 `;
 
@@ -521,10 +521,10 @@ exports[`matches expected output: pseudo-elements.js 1`] = `
       "textDecoration": "underline"
     },
     "::after": {
-      "content": "∞"
+      "content": "\\"∞\\""
     },
     "::before": {
-      "content": "∞"
+      "content": "\\"∞\\""
     }
   }
 }
@@ -535,10 +535,10 @@ exports[`matches expected output: pseudo-elements.js 1`] = `
 ._22QzO9:hover {
   text-decoration: underline;
 }
-._2Rpe4g::after {
+._2sj7wN::after {
   content: "∞";
 }
-._3ou8wp::before {
+._4vATsH::before {
   content: "∞";
 }
 
@@ -546,7 +546,43 @@ exports[`matches expected output: pseudo-elements.js 1`] = `
 
 className={styles('link')}
   ↓ ↓ ↓
-class="_134wwt _22QzO9 _2Rpe4g _3ou8wp"
+class="_134wwt _22QzO9 _2sj7wN _4vATsH"
+
+`;
+
+exports[`matches expected output: pseudo-elements-2.js 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+{
+  "ul": {
+    "counterReset": "my-reset"
+  },
+  "li": {
+    "counterIncrement": "my-reset",
+    "::before": {
+      "content": "counter(my-reset)"
+    }
+  }
+}
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+._3UELKF {
+  counter-reset: my-reset;
+}
+.FmLKl {
+  counter-increment: my-reset;
+}
+._3ybBud::before {
+  content: counter(my-reset);
+}
+
+~~~~~~~~~~ USAGE ~~~~~~~~~~
+
+className={styles('ul')}
+  ↓ ↓ ↓
+class="_3UELKF"
+
+className={styles('li')}
+  ↓ ↓ ↓
+class="FmLKl _3ybBud"
 
 `;
 

--- a/src/sx/src/__tests__/fixtures.test.js
+++ b/src/sx/src/__tests__/fixtures.test.js
@@ -45,10 +45,10 @@ test.each(fixturesPaths)('matches expected output: %s', (fixturePath) => {
 
   try {
     const styles = sx.create(stylesheetsDefinition);
-
     // 2) atomic CSS
     const renderer = TestRenderer.create(sx.renderPageWithSX(renderPageMock).styles[0]);
-    const css = renderer.root.children[0].toString();
+
+    const css = renderer.root.props.dangerouslySetInnerHTML.__html;
     const output = prettier.format(css, { filepath: 'test.css' });
 
     // 3) usage resulting CSS class names

--- a/src/sx/src/__tests__/fixtures/pseudo-classes-nested-2.js
+++ b/src/sx/src/__tests__/fixtures/pseudo-classes-nested-2.js
@@ -5,7 +5,7 @@ import type { SheetDefinitions } from '../../create';
 export default ({
   test: {
     ':hover::after': {
-      content: 'this is OK',
+      content: '"this is OK"',
     },
   },
 }: SheetDefinitions);

--- a/src/sx/src/__tests__/fixtures/pseudo-elements-2.js
+++ b/src/sx/src/__tests__/fixtures/pseudo-elements-2.js
@@ -1,0 +1,15 @@
+// @flow
+
+import type { SheetDefinitions } from '../../create';
+
+export default ({
+  ul: {
+    counterReset: 'my-reset',
+  },
+  li: {
+    'counterIncrement': 'my-reset',
+    '::before': {
+      content: 'counter(my-reset)',
+    },
+  },
+}: SheetDefinitions);

--- a/src/sx/src/__tests__/fixtures/pseudo-elements.js
+++ b/src/sx/src/__tests__/fixtures/pseudo-elements.js
@@ -9,10 +9,10 @@ export default ({
       textDecoration: 'underline',
     },
     '::after': {
-      content: '∞',
+      content: '"∞"',
     },
     '::before': {
-      content: '∞',
+      content: '"∞"',
     },
   },
 }: SheetDefinitions);

--- a/src/sx/src/__tests__/renderPageWithSX.test.js
+++ b/src/sx/src/__tests__/renderPageWithSX.test.js
@@ -21,7 +21,7 @@ it('works as expected', () => {
         color: 'purple',
       },
       '::after': {
-        content: '🤓',
+        content: '"🤓"',
       },
     },
   });
@@ -32,6 +32,6 @@ it('works as expected', () => {
   expect(styles('red', 'blue')).toMatchInlineSnapshot(`"_4fo5TC"`); // blue wins
   expect(styles('blue', 'red')).toMatchInlineSnapshot(`"wUqnh"`); // red wins
 
-  expect(styles('pseudo')).toMatchInlineSnapshot(`"PJDYD _4sFdkU _22QzO9 _3stS2V _14RYUP"`);
-  expect(styles('pseudo', 'red')).toMatchInlineSnapshot(`"wUqnh _4sFdkU _22QzO9 _3stS2V _14RYUP"`); // red wins (non-hover)
+  expect(styles('pseudo')).toMatchInlineSnapshot(`"PJDYD _4sFdkU _22QzO9 _3stS2V _3Wiz8a"`);
+  expect(styles('pseudo', 'red')).toMatchInlineSnapshot(`"wUqnh _4sFdkU _22QzO9 _3stS2V _3Wiz8a"`); // red wins (non-hover)
 });

--- a/src/sx/src/__tests__/transformValue.test.js
+++ b/src/sx/src/__tests__/transformValue.test.js
@@ -23,7 +23,7 @@ test.each`
   ${'color'}    | ${'white'}          | ${'#fff'}
   ${'color'}    | ${'aqua'}           | ${'#0ff'}
   ${'color'}    | ${'chocolate'}      | ${'#d2691e'}
-  ${'content'}  | ${'🦕'}             | ${'"🦕"'}
+  ${'content'}  | ${'"🦕"'}           | ${'"🦕"'}
 `(
   '$styleName:$styleValue => $styleName:$expectedValue',
   ({ styleName, styleValue, expectedValue }) => {

--- a/src/sx/src/renderPageWithSX.js
+++ b/src/sx/src/renderPageWithSX.js
@@ -37,10 +37,14 @@ export default function renderPageWithSX(
   return {
     ...html,
     styles: [
-      <style key="adeira-sx" data-adeira-sx={true}>
-        {options?.includeReset === true && cssReset}
-        {StyleCollector.print()}
-      </style>,
+      // We need to render this as html, else things like `content: "ok"` will be rendered as `content: &quot;ok&quot;`, and it is not valid css
+      <style
+        key="adeira-sx"
+        data-adeira-sx={true}
+        dangerouslySetInnerHTML={{
+          __html: `${options?.includeReset === true ? cssReset : ''}${StyleCollector.print()}`,
+        }}
+      />,
     ],
   };
 }

--- a/src/sx/src/transformValue.js
+++ b/src/sx/src/transformValue.js
@@ -12,9 +12,6 @@ export default function transformValue(
     // https://engineering.fb.com/web/facebook-com-accessibility/
     const defaultFontSize = 16;
     return `${Number(styleValue) / defaultFontSize}rem`;
-  } else if (styleName === 'content') {
-    // content style is the only one (?) which requires quoted value
-    return `"${styleValue}"`;
   } else if (typeof styleValue === 'string' && isColor(styleValue)) {
     // color normalization (to reduce duplicates in the atomic result)
     return normalizeColor(styleValue);


### PR DESCRIPTION
- Render generated css with dangerouslySetInnerHtml

It is necessary to specify the quoutes of the content, since
usage with a counter will not work if we automatically add the qoute.