### PR TITLE
SX: add `font-size` to the CSS reset

### DIFF
--- a/src/sx/README.md
+++ b/src/sx/README.md
@@ -184,7 +184,9 @@ import Document from 'next/document';
 
 export default class MyDocument extends Document {
   static getInitialProps(ctx: DocumentContext) {
-    return sx.renderPageWithSX(ctx.renderPage, { includeReset: true });
+    return sx.renderPageWithSX(ctx.renderPage, {
+      includeReset: true, // <<<
+    });
   }
 
   // `render` is not needed to change
@@ -194,9 +196,12 @@ export default class MyDocument extends Document {
 This will add the following css to your stylesheet:
 
 ```css
+html,
 body {
+  font-size: 16px;
   box-sizing: border-box;
 }
+
 *,
 *::after,
 *::before {
@@ -205,6 +210,8 @@ body {
   box-sizing: inherit;
 }
 ```
+
+You might wonder why does it include the `font-size: 16px`? It's because SX automatically converts numbers to REM units and it expects `16px` to be the document base.
 
 ## Architecture
 

--- a/src/sx/src/__tests__/SxDomTests.test.js
+++ b/src/sx/src/__tests__/SxDomTests.test.js
@@ -57,7 +57,7 @@ it('applies correct styles', () => {
   expect(pseudoRed).toHaveStyle(`color:${normalizeColor('red')}`); // red wins (non-hover)
 });
 
-it('includes reset', () => {
+it('includes CSS reset', () => {
   render(
     <div data-test="container">
       {sx.renderPageWithSX(jest.fn(), { includeReset: true }).styles}
@@ -69,18 +69,7 @@ it('includes reset', () => {
     <style
       data-adeira-sx="true"
     >
-      
-    body {
-      box-sizing: border-box;
-    }
-    *,
-    *::after,
-    *::before {
-      margin: 0;
-      padding: 0;
-      box-sizing: inherit;
-    }
-
+      html,body{font-size:16px;box-sizing:border-box}*,*::after,*::before{margin:0;padding:0;box-sizing:inherit}
     </style>
   `);
 });

--- a/src/sx/src/cssReset.js
+++ b/src/sx/src/cssReset.js
@@ -1,0 +1,25 @@
+// @flow
+
+import csstree from 'css-tree';
+
+function css(strings): string {
+  const css = strings.join('');
+  return csstree.generate(csstree.parse(css));
+}
+
+// TODO: consider including https://github.com/necolas/normalize.css
+export default (css`
+  html,
+  body {
+    font-size: 16px; /* SX expects 16px to be the default (see "transformValue") */
+    box-sizing: border-box;
+  }
+
+  *,
+  *::after,
+  *::before {
+    margin: 0;
+    padding: 0;
+    box-sizing: inherit;
+  }
+`: string);

--- a/src/sx/src/renderPageWithSX.js
+++ b/src/sx/src/renderPageWithSX.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import cssReset from './cssReset';
 import StyleCollector from './StyleCollector';
 
 type RenderPageResult = {|
@@ -9,19 +10,6 @@ type RenderPageResult = {|
   +head: $ReadOnlyArray<React.Node>,
   +styles: $ReadOnlyArray<any>,
 |};
-
-const cssReset = `
-body {
-  box-sizing: border-box;
-}
-*,
-*::after,
-*::before {
-  margin: 0;
-  padding: 0;
-  box-sizing: inherit;
-}
-`;
 
 type Options = {|
   +includeReset?: boolean,
@@ -34,17 +22,15 @@ export default function renderPageWithSX(
 ): RenderPageResult {
   const html = renderPage();
 
+  const innerHTML = {
+    __html: `${options?.includeReset === true ? cssReset : ''}${StyleCollector.print()}`,
+  };
+
   return {
     ...html,
     styles: [
       // We need to render this as html, else things like `content: "ok"` will be rendered as `content: &quot;ok&quot;`, and it is not valid css
-      <style
-        key="adeira-sx"
-        data-adeira-sx={true}
-        dangerouslySetInnerHTML={{
-          __html: `${options?.includeReset === true ? cssReset : ''}${StyleCollector.print()}`,
-        }}
-      />,
+      <style key="adeira-sx" data-adeira-sx={true} dangerouslySetInnerHTML={innerHTML} />,
     ],
   };
 }


### PR DESCRIPTION
SX expects font size to be exactly 16px (otherwise px->rem conversion won't work correctly). This means it should be included by default. Which makes me wonder: should we include the CSS reset by default and make it opt-out?