### PR TITLE
Shipit: fix 'sx-tailwind-website' Babel config export

### DIFF
--- a/src/monorepo-shipit/config/__tests__/adeira-dev.test.js
+++ b/src/monorepo-shipit/config/__tests__/adeira-dev.test.js
@@ -7,7 +7,6 @@ import testExportedPaths from './testExportedPaths';
 testExportedPaths(path.join(__dirname, '..', 'adeira-dev.js'), [
   ['src/adeira.dev/package.json', 'package.json'],
   ['src/adeira.dev/README.md', 'README.md'],
-  ['src/adeira.dev/core/Footer.js', 'core/Footer.js'],
   ['src/adeira.dev/docs/general/introduction.md', 'docs/general/introduction.md'],
 
   // invalid cases:

--- a/src/monorepo-shipit/config/__tests__/example-relay.test.js
+++ b/src/monorepo-shipit/config/__tests__/example-relay.test.js
@@ -6,9 +6,7 @@ import testExportedPaths from './testExportedPaths';
 
 testExportedPaths(path.join(__dirname, '..', 'example-relay.js'), [
   ['src/example-relay/package.json', 'package.json'],
-  ['src/example-relay/pages/index.js', 'pages/index.js'],
-  ['src/example-relay/src/locations/CountryFlag.js', 'src/locations/CountryFlag.js'],
-  ['src/example-relay/__generated__/AppQuery.graphql.js', '__generated__/AppQuery.graphql.js'],
+  ['src/example-relay/src/pages/index.js', 'src/pages/index.js'],
   ['src/example-relay/__github__/.flowconfig', '.flowconfig'],
   ['src/example-relay/__github__/babel.config.js', 'babel.config.js'],
   ['src/example-relay/__github__/flow-typed/globals.js', 'flow-typed/globals.js'],

--- a/src/monorepo-shipit/config/__tests__/sx-tailwind-website.test.js
+++ b/src/monorepo-shipit/config/__tests__/sx-tailwind-website.test.js
@@ -5,24 +5,25 @@ import path from 'path';
 import testExportedPaths from './testExportedPaths';
 
 testExportedPaths(path.join(__dirname, '..', 'sx-tailwind-website.js'), [
-  ['src/sx-tailwind-website/package.json', 'package.json'],
-  ['src/sx-tailwind-website/pages/index.js', 'pages/index.js'],
-  ['src/sx-tailwind-website/Documentation/index.js', 'Documentation/index.js'],
-  ['src/sx-tailwind-website/__github__/.flowconfig', '.flowconfig'],
-  ['src/sx-tailwind-website/__github__/.babelrc.js', '.babelrc.js'],
-  ['src/sx-tailwind-website/__github__/flow-typed/globals.js', 'flow-typed/globals.js'],
   [
     'src/sx-tailwind-website/__github__/.github/workflows/continuous-integration.yml',
     '.github/workflows/continuous-integration.yml',
   ],
+  ['src/sx-tailwind-website/__github__/.flowconfig', '.flowconfig'],
+  ['src/sx-tailwind-website/__github__/babel.config.js', 'babel.config.js'],
+  ['src/sx-tailwind-website/__github__/flow-typed/globals.js', 'flow-typed/globals.js'],
+  ['src/sx-tailwind-website/src/Documentation/index.js', 'src/Documentation/index.js'],
+  ['src/sx-tailwind-website/src/pages/index.js', 'src/pages/index.js'],
+  ['src/sx-tailwind-website/package.json', 'package.json'],
 
   // invalid cases:
-  ['src/sx-tailwind-website/next.config.js', undefined], // correctly deleted
+  ['src/sx-tailwind-website/.babelrc.js', undefined], // correctly deleted
   ['src/sx-tailwind-website/__github__/unknown.js', undefined], // correctly deleted
-  ['src/sx-tailwind-website/BUILD.bazel', undefined], // correctly deleted
+  ['src/sx-tailwind-website/next.config.js', undefined], // correctly deleted
   ['src/sx-tailwind-website/BUILD', undefined], // correctly deleted
-  ['src/sx-tailwind-website/WORKSPACE.bazel', undefined], // correctly deleted
+  ['src/sx-tailwind-website/BUILD.bazel', undefined], // correctly deleted
   ['src/sx-tailwind-website/WORKSPACE', undefined], // correctly deleted
+  ['src/sx-tailwind-website/WORKSPACE.bazel', undefined], // correctly deleted
   ['src/packages/monorepo/outsideScope.js', undefined], // correctly deleted
   ['package.json', undefined], // correctly deleted
 ]);

--- a/src/monorepo-shipit/config/__tests__/testExportedPaths.js
+++ b/src/monorepo-shipit/config/__tests__/testExportedPaths.js
@@ -1,10 +1,12 @@
 // @flow strict-local
 
+import fs from 'fs';
+import path from 'path';
+import { findMonorepoRoot } from '@adeira/monorepo-utils';
+
 import Changeset from '../../src/Changeset';
 import ShipitConfig from '../../src/ShipitConfig';
 import requireAndValidateConfig from '../../src/requireAndValidateConfig';
-
-jest.mock('fs');
 
 // eslint-disable-next-line jest/no-export
 export default function testExportedPaths(
@@ -17,6 +19,7 @@ export default function testExportedPaths(
   >,
 ) {
   const config = requireAndValidateConfig(configPath);
+  const monorepoRoot = findMonorepoRoot();
 
   test.each(mapping)('mapping: %s -> %s', (input, output) => {
     const defaultFilter = new ShipitConfig(
@@ -33,6 +36,10 @@ export default function testExportedPaths(
     if (output === undefined) {
       expect(...outputDataset.getDiffs()).toBeUndefined();
     } else {
+      // 1. verify the path we are testing actually exists (and therefore the test makes sense)
+      expect(fs.existsSync(path.join(monorepoRoot, input))).toBe(true);
+
+      // 2. make sure it's being exported correctly
       expect(...outputDataset.getDiffs()).toEqual({
         body: 'mocked',
         path: output,

--- a/src/monorepo-shipit/config/sx-tailwind-website.js
+++ b/src/monorepo-shipit/config/sx-tailwind-website.js
@@ -10,14 +10,18 @@ module.exports = ({
   },
   getPathMappings() {
     return new Map([
+      ['src/sx-tailwind-website/__github__/flow-typed/', 'flow-typed/'],
+      ['src/sx-tailwind-website/__github__/.github/', '.github/'],
       ['src/sx-tailwind-website/__github__/.flowconfig', '.flowconfig'],
-      ['src/sx-tailwind-website/__github__/.babelrc.js', '.babelrc.js'],
-      ['src/sx-tailwind-website/__github__/flow-typed', 'flow-typed'],
-      ['src/sx-tailwind-website/__github__/.github', '.github'],
+      ['src/sx-tailwind-website/__github__/babel.config.js', 'babel.config.js'],
       ['src/sx-tailwind-website/', ''],
     ]);
   },
   getStrippedFiles() {
-    return new Set([/__github__/, /^next\.config\.js$/]);
+    return new Set([
+      /^next\.config\.js$/, // not needed for OSS
+      /^\.babelrc\.js$/, // replaced by `__github__/babel.config.js` for OSS
+      /__github__/,
+    ]);
   },
 }: ConfigType);

--- a/src/sx-tailwind-website/__github__/babel.config.js
+++ b/src/sx-tailwind-website/__github__/babel.config.js
@@ -11,11 +11,7 @@ type ApiType = {|
 
 type BabelConfig = {|
   +presets: $ReadOnlyArray<string>,
-  +env: {|
-    +production: {|
-      +plugins: $ReadOnlyArray<string>,
-    |}
-  |}
+  +plugins: $ReadOnlyArray<string>,
 |}
 
 */


### PR DESCRIPTION
Shipit doesn't understand file replacing so it has to be done differently. Moreover, I think 'babel.config.js' is the right choice here (just like in Relay Example project).

Note: manual synchronization might be needed after this because seems like the exported repo is out of sync