### PR TITLE
SX Babel plugin: disable Babel Register call for OSS

### DIFF
--- a/src/babel-plugin-transform-sx-tailwind/src/index.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/index.js
@@ -1,9 +1,10 @@
 // @flow
 
-require('@babel/register')({
-  ignore: [/node_modules\/(?!@adeira)/],
-  rootMode: 'upward',
-});
+// prettier-ignore
+require('@babel/register')({ // @x-shipit-disable
+  ignore: [/node_modules\/(?!@adeira)/], // @x-shipit-disable
+  rootMode: 'upward', // @x-shipit-disable
+}); // @x-shipit-disable
 
 const template = require('@babel/template').default;
 const t = require('@babel/types');


### PR DESCRIPTION
This should be needed only for Universe and doesn't work well on OSS. It should fix the following error:

> Error: Reentrant plugin detected trying to load "/adeira/sx-tailwind-website/node_modules/@adeira/babel-plugin-transform-sx-tailwind/src/index.js". This module is not ignored and is trying to load itself while compiling itself, leading to a dependency cycle. We recommend adding it to your "ignore" list in your babelrc, or to a .babelignore.