### PR TITLE
SX tailwind: remove '@babel/register' call from NPM

### DIFF
--- a/src/babel-plugin-transform-sx-tailwind/package.json
+++ b/src/babel-plugin-transform-sx-tailwind/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/babel-plugin-transform-sx-tailwind",
   "license": "MIT",
   "private": false,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "src/index",
   "sideEffects": false,
   "module": false,

--- a/src/babel-plugin-transform-sx-tailwind/src/index.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/index.js
@@ -1,10 +1,11 @@
 // @flow
 
-// prettier-ignore
-require('@babel/register')({ // @x-shipit-disable
-  ignore: [/node_modules\/(?!@adeira)/], // @x-shipit-disable
-  rootMode: 'upward', // @x-shipit-disable
-}); // @x-shipit-disable
+// BEGIN-ADEIRA-UNIVERSE-INTERNAL
+require('@babel/register')({
+  ignore: [/node_modules\/(?!@adeira)/],
+  rootMode: 'upward',
+});
+// END-ADEIRA-UNIVERSE-INTERNAL
 
 const template = require('@babel/template').default;
 const t = require('@babel/types');

--- a/src/monorepo-npm-publisher/README.md
+++ b/src/monorepo-npm-publisher/README.md
@@ -42,6 +42,21 @@ import publish from '@adeira/monorepo-npm-publisher';
 
 This NPM publisher automatically takes `.npmignore` (or `.gitignore`) files into account. Read this info for more details: https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package
 
+# BEGIN-ADEIRA-UNIVERSE-INTERNAL, END-ADEIRA-UNIVERSE-INTERNAL
+
+In rare scenarios, you might need to skip some part of the source code when publishing to NPM. It can be done like so:
+
+```js
+// BEGIN-ADEIRA-UNIVERSE-INTERNAL
+require('@babel/register')({
+  ignore: [/node_modules\/(?!@adeira)/],
+  rootMode: 'upward',
+});
+// END-ADEIRA-UNIVERSE-INTERNAL
+```
+
+The code block between `BEGIN-*` and `END-*` will be removed. Please try to use it sporadically - typical example would be to wrap a code which is required _only_ for Adeira Universe monorepo functioning. It's worth mentioning that we are actively looking for better and systematic solutions to this problem.
+
 # Behind the scenes explanation
 
 Let's have a look at our [JS project](https://github.com/adeira/universe/tree/master/src/js) and what happens when you run this publisher. Before:

--- a/src/monorepo-npm-publisher/src/transformFileVariants.js
+++ b/src/monorepo-npm-publisher/src/transformFileVariants.js
@@ -5,6 +5,16 @@ import { transformFileSync } from '@babel/core';
 
 import log from './log';
 
+function writeFileSync(path: string, data: string): void {
+  fs.writeFileSync(
+    path,
+    data.replace(
+      /\/\/\s+BEGIN-ADEIRA-UNIVERSE-INTERNAL[\w\W]+?END-ADEIRA-UNIVERSE-INTERNAL/g,
+      '// PLACEHOLDER-ADEIRA-UNIVERSE-INTERNAL',
+    ),
+  );
+}
+
 export default function transformFileVariants(
   originalFilename: string,
   destinationFilename: string,
@@ -27,7 +37,7 @@ export default function transformFileVariants(
   // 1) transform JS version
   try {
     log('%s 👉 %s', originalFilename, destinationFilename);
-    fs.writeFileSync(
+    writeFileSync(
       destinationFilename,
       transformFileSync(originalFilename, getBabelConfig('js')).code,
     );
@@ -41,7 +51,7 @@ export default function transformFileVariants(
     try {
       const modifiedDestinationFilename = destinationFilename.replace(/\.js$/, '.mjs');
       log('%s 👉 %s', originalFilename, modifiedDestinationFilename);
-      fs.writeFileSync(
+      writeFileSync(
         modifiedDestinationFilename,
         transformFileSync(originalFilename, getBabelConfig('js-esm')).code,
       );
@@ -55,7 +65,7 @@ export default function transformFileVariants(
   try {
     const modifiedDestinationFilename = `${destinationFilename}.flow`;
     log('%s 👉 %s', originalFilename, modifiedDestinationFilename);
-    fs.writeFileSync(
+    writeFileSync(
       modifiedDestinationFilename,
       transformFileSync(originalFilename, getBabelConfig('flow')).code,
     );

--- a/src/sx-tailwind-website/package.json
+++ b/src/sx-tailwind-website/package.json
@@ -16,7 +16,7 @@
     "react-syntax-highlighter": "^15.3.0"
   },
   "devDependencies": {
-    "@adeira/babel-plugin-transform-sx-tailwind": "^0.4.0",
+    "@adeira/babel-plugin-transform-sx-tailwind": "^0.5.0",
     "@adeira/babel-preset-adeira": "^1.1.0",
     "flow-bin": "^0.137.0"
   },


### PR DESCRIPTION
This should remove the `@babel/register` from NPM version since it's needed only for Adeira Universe monorepo and it's problematic when exported outside of the repo.

I tried to use the modified NPM output in SX Tailwind website and it worked well. It also works well under Universe workspace. This issue should be eventually solved by design with the migration to Bazel.