### PR TITLE
SX: expand shorthand properties

### DIFF
--- a/src/sx/src/__tests__/StyleCollector.test.js
+++ b/src/sx/src/__tests__/StyleCollector.test.js
@@ -22,7 +22,7 @@ it('works with simple styles', () => {
           "color" => "_2dHaKY",
         },
         "lol" => Map {
-          "fontSize" => "_9bPFv",
+          "font-size" => "_9bPFv",
           "color" => "_2dHaKY",
         },
       },
@@ -58,10 +58,10 @@ it('works with pseudo styles', () => {
     Object {
       "hashRegistry": Map {
         "lol" => Map {
-          "fontSize" => "_9bPFv",
+          "font-size" => "_9bPFv",
           "color" => "_2dHaKY",
           "color:hover" => "_2sykgO",
-          "textDecoration:hover" => "crve5",
+          "text-decoration:hover" => "crve5",
         },
       },
       "styleBuffer": Map {

--- a/src/sx/src/__tests__/expandShorthandProperties.test.js
+++ b/src/sx/src/__tests__/expandShorthandProperties.test.js
@@ -1,0 +1,157 @@
+// @flow
+
+import expandShorthandProperties from '../expandShorthandProperties';
+
+it('expands background as expected', () => {
+  expect(expandShorthandProperties('background', 'red').map((node) => node.print()))
+    .toMatchInlineSnapshot(`
+    Array [
+      "._2rGYXd{background-image:none}",
+      ".vSqk6{background-position:0% 0%}",
+      "._1m2K58{background-size:auto auto}",
+      "._2RyIOg{background-repeat:repeat}",
+      "._87W4L{background-origin:padding-box}",
+      "._3IDiTj{background-clip:border-box}",
+      "._376SiR{background-attachment:scroll}",
+      ".pmdn8{background-color:#f00}",
+    ]
+  `);
+
+  expect(expandShorthandProperties('background', 'none').map((node) => node.print()))
+    .toMatchInlineSnapshot(`
+    Array [
+      "._2rGYXd{background-image:none}",
+      ".vSqk6{background-position:0% 0%}",
+      "._1m2K58{background-size:auto auto}",
+      "._2RyIOg{background-repeat:repeat}",
+      "._87W4L{background-origin:padding-box}",
+      "._3IDiTj{background-clip:border-box}",
+      "._376SiR{background-attachment:scroll}",
+      "._15yiKT{background-color:transparent}",
+    ]
+  `);
+});
+
+it('ignores more complex background syntaxes', () => {
+  expect(
+    expandShorthandProperties(
+      'background',
+      'no-repeat url("../../media/examples/lizard.png")',
+    ).map((node) => node.print()),
+  ).toMatchInlineSnapshot(`
+    Array [
+      "._3yHEnM{background:no-repeat url(\\"../../media/examples/lizard.png\\")}",
+    ]
+  `);
+});
+
+it('ignores unknown properties', () => {
+  expect(
+    expandShorthandProperties('unknownProperty', 'thisShouldNotChange').map((node) => node.print()),
+  ).toMatchInlineSnapshot(`
+    Array [
+      "._3BbwKd{unknown-property:thisShouldNotChange}",
+    ]
+  `);
+});
+
+it('expands margins and paddings as expected', () => {
+  // 1) single number
+  expect(expandShorthandProperties('margin', 0).map((node) => node.print())).toMatchInlineSnapshot(`
+    Array [
+      "._4pgUgJ{margin-top:0px}",
+      "._37wPvZ{margin-right:0px}",
+      "._32zari{margin-bottom:0px}",
+      "._3DMcik{margin-left:0px}",
+    ]
+  `);
+  expect(expandShorthandProperties('padding', 0).map((node) => node.print()))
+    .toMatchInlineSnapshot(`
+    Array [
+      "._2YU8Lt{padding-top:0px}",
+      "._1b3SDU{padding-right:0px}",
+      "._4vQ4Ez{padding-bottom:0px}",
+      "._1lfgYw{padding-left:0px}",
+    ]
+  `);
+
+  // 1) single string value
+  expect(expandShorthandProperties('margin', '10px').map((node) => node.print()))
+    .toMatchInlineSnapshot(`
+    Array [
+      "._3sgLnu{margin-top:10px}",
+      "._42OSNq{margin-right:10px}",
+      "._27cO38{margin-bottom:10px}",
+      "._21Xfw8{margin-left:10px}",
+    ]
+  `);
+  expect(expandShorthandProperties('padding', '10px').map((node) => node.print()))
+    .toMatchInlineSnapshot(`
+    Array [
+      "._2h8fCA{padding-top:10px}",
+      "._18S2bQ{padding-right:10px}",
+      "._1Dvao8{padding-bottom:10px}",
+      "._3RfpBN{padding-left:10px}",
+    ]
+  `);
+
+  // 2) two values
+  expect(expandShorthandProperties('margin', '10px 20px').map((node) => node.print()))
+    .toMatchInlineSnapshot(`
+    Array [
+      "._3sgLnu{margin-top:10px}",
+      "._4098WN{margin-right:20px}",
+      "._27cO38{margin-bottom:10px}",
+      "._1yVWfq{margin-left:20px}",
+    ]
+  `);
+  expect(expandShorthandProperties('padding', '10px 20px').map((node) => node.print()))
+    .toMatchInlineSnapshot(`
+    Array [
+      "._2h8fCA{padding-top:10px}",
+      "._3PTJRo{padding-right:20px}",
+      "._1Dvao8{padding-bottom:10px}",
+      "._2EBnAo{padding-left:20px}",
+    ]
+  `);
+
+  // 3) three values
+  expect(expandShorthandProperties('margin', '10px 20px 30px').map((node) => node.print()))
+    .toMatchInlineSnapshot(`
+    Array [
+      "._3sgLnu{margin-top:10px}",
+      "._4098WN{margin-right:20px}",
+      "._2ynoCr{margin-bottom:30px}",
+      "._1yVWfq{margin-left:20px}",
+    ]
+  `);
+  expect(expandShorthandProperties('padding', '10px 20px 30px').map((node) => node.print()))
+    .toMatchInlineSnapshot(`
+    Array [
+      "._2h8fCA{padding-top:10px}",
+      "._3PTJRo{padding-right:20px}",
+      "._2iKTDO{padding-bottom:30px}",
+      "._2EBnAo{padding-left:20px}",
+    ]
+  `);
+
+  // 4) four values
+  expect(expandShorthandProperties('margin', '10px 20px 30px 40px').map((node) => node.print()))
+    .toMatchInlineSnapshot(`
+    Array [
+      "._3sgLnu{margin-top:10px}",
+      "._4098WN{margin-right:20px}",
+      "._2ynoCr{margin-bottom:30px}",
+      "._2frFkL{margin-left:40px}",
+    ]
+  `);
+  expect(expandShorthandProperties('padding', '10px 20px 30px 40px').map((node) => node.print()))
+    .toMatchInlineSnapshot(`
+    Array [
+      "._2h8fCA{padding-top:10px}",
+      "._3PTJRo{padding-right:20px}",
+      "._2iKTDO{padding-bottom:30px}",
+      "._3I54Zi{padding-left:40px}",
+    ]
+  `);
+});

--- a/src/sx/src/__tests__/renderPageWithSX.test.js
+++ b/src/sx/src/__tests__/renderPageWithSX.test.js
@@ -35,3 +35,19 @@ it('works as expected', () => {
   expect(styles('pseudo')).toMatchInlineSnapshot(`"mRoJ3 _1O0igU crve5 _2DlVUN _3Wiz8a"`);
   expect(styles('pseudo', 'red')).toMatchInlineSnapshot(`"_324Crd _1O0igU crve5 _2DlVUN _3Wiz8a"`); // red wins (non-hover)
 });
+
+it('does not output conflicting classes', () => {
+  const styles = sx.create({
+    aaa: {
+      margin: 0, // expanded to margin-top, margin-left, margin-bottom and margin-right
+    },
+    bbb: { marginTop: 10 },
+  });
+
+  expect(styles('aaa')).toMatchInlineSnapshot(`"_4pgUgJ _37wPvZ _32zari _3DMcik"`);
+  expect(styles('bbb')).toMatchInlineSnapshot(`"_3sgLnu"`);
+
+  expect(styles('aaa', 'bbb')).toMatchInlineSnapshot(`"_3sgLnu _37wPvZ _32zari _3DMcik"`);
+  expect(styles('bbb', 'aaa')).toBe(styles('aaa'));
+  expect(styles('aaa', 'aaa')).toBe(styles('aaa'));
+});

--- a/src/sx/src/expandShorthandProperties.js
+++ b/src/sx/src/expandShorthandProperties.js
@@ -1,0 +1,140 @@
+// @flow
+
+import StyleCollectorNode from './StyleCollectorNode';
+import { isColor } from './colorNormalizer';
+
+/**
+ * Purpose of this function is to expand shorthand CSS properties which could cause conflics
+ * when defined together. Imagine the following example:
+ *
+ * ```
+ * const styles = sx.create({
+ *   primary: { marginTop: '10px' },
+ *   button: { margin: 0 },
+ * });
+ * ```
+ *
+ * It could generate the following CSS:
+ *
+ * ```
+ * .c0 { margin-top: 10px }
+ * .c1 { margin: 0px }
+ * ```
+ *
+ * That would be a tricky situation because CSS specificity depends on the CSS definition order
+ * and therefore the top margin would be always overwritten when used together. Instead, we
+ * expand the shorthand properties into something like this:
+ *
+ * ```
+ * .c0 { margin-top: 10px }   << primary
+ * .c1 { margin-top: 0px }    << button
+ * .c2 { margin-right: 0px }
+ * .c3 { margin-bottom: 0px }
+ * .c4 { margin-left: 0px }
+ * ```
+ *
+ * This way SX is not dependent on the CSS rules insertion order but rather on the markup.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties
+ */
+export default function expandShorthandProperties(
+  propertyName: string,
+  propertyValue: any,
+  hashSeed: string = '',
+): $ReadOnlyArray<StyleCollectorNode> {
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#Background_Properties
+  if (propertyName === 'background') {
+    const background = new Map([
+      ['backgroundImage', new StyleCollectorNode('backgroundImage', 'none', hashSeed)],
+      ['backgroundPosition', new StyleCollectorNode('backgroundPosition', '0% 0%', hashSeed)],
+      ['backgroundSize', new StyleCollectorNode('backgroundSize', 'auto auto', hashSeed)],
+      ['backgroundRepeat', new StyleCollectorNode('backgroundRepeat', 'repeat', hashSeed)],
+      ['backgroundOrigin', new StyleCollectorNode('backgroundOrigin', 'padding-box', hashSeed)],
+      ['backgroundClip', new StyleCollectorNode('backgroundClip', 'border-box', hashSeed)],
+      ['backgroundAttachment', new StyleCollectorNode('backgroundAttachment', 'scroll', hashSeed)],
+      ['backgroundColor', new StyleCollectorNode('backgroundColor', 'transparent', hashSeed)],
+    ]);
+    // Note: we ignore more complex syntaxes at this moment
+    // see: https://developer.mozilla.org/en-US/docs/Web/CSS/background#Formal_syntax
+    if (isColor(propertyValue)) {
+      background.set(
+        'backgroundColor',
+        new StyleCollectorNode('backgroundColor', propertyValue, hashSeed),
+      );
+      return Array.from(background.values());
+    } else if (propertyValue === 'none') {
+      background.set(
+        'backgroundImage',
+        new StyleCollectorNode('backgroundImage', propertyValue, hashSeed),
+      );
+      return Array.from(background.values());
+    }
+  }
+
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#Margin_and_Padding_Properties
+  if (propertyName === 'margin' || propertyName === 'padding') {
+    const top = `${propertyName}Top`;
+    const right = `${propertyName}Right`;
+    const bottom = `${propertyName}Bottom`;
+    const left = `${propertyName}Left`;
+    if (typeof propertyValue === 'string') {
+      const chunks = propertyValue.split(/\s+/);
+      if (chunks.length === 1) {
+        const chunk = chunks[0];
+        return [
+          new StyleCollectorNode(top, chunk, hashSeed),
+          new StyleCollectorNode(right, chunk, hashSeed),
+          new StyleCollectorNode(bottom, chunk, hashSeed),
+          new StyleCollectorNode(left, chunk, hashSeed),
+        ];
+      } else if (chunks.length === 2) {
+        return [
+          new StyleCollectorNode(top, chunks[0], hashSeed),
+          new StyleCollectorNode(right, chunks[1], hashSeed),
+          new StyleCollectorNode(bottom, chunks[0], hashSeed),
+          new StyleCollectorNode(left, chunks[1], hashSeed),
+        ];
+      } else if (chunks.length === 3) {
+        return [
+          new StyleCollectorNode(top, chunks[0], hashSeed),
+          new StyleCollectorNode(right, chunks[1], hashSeed),
+          new StyleCollectorNode(bottom, chunks[2], hashSeed),
+          new StyleCollectorNode(left, chunks[1], hashSeed),
+        ];
+      } else if (chunks.length === 4) {
+        return [
+          new StyleCollectorNode(top, chunks[0], hashSeed),
+          new StyleCollectorNode(right, chunks[1], hashSeed),
+          new StyleCollectorNode(bottom, chunks[2], hashSeed),
+          new StyleCollectorNode(left, chunks[3], hashSeed),
+        ];
+      }
+    } else if (typeof propertyValue === 'number') {
+      return [
+        new StyleCollectorNode(top, propertyValue, hashSeed),
+        new StyleCollectorNode(right, propertyValue, hashSeed),
+        new StyleCollectorNode(bottom, propertyValue, hashSeed),
+        new StyleCollectorNode(left, propertyValue, hashSeed),
+      ];
+    }
+  }
+
+  // TODO (inspired by React Native Web - https://github.com/necolas/react-native-web/):
+  //  - https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#Font_Properties
+  //  - https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#Border_Properties
+  //
+  //  - borderColor: ['borderTopColor', 'borderRightColor', 'borderBottomColor', 'borderLeftColor'],
+  //  - borderRadius: ['borderTopLeftRadius', 'borderTopRightRadius', 'borderBottomRightRadius', 'borderBottomLeftRadius'],
+  //  - borderStyle: ['borderTopStyle', 'borderRightStyle', 'borderBottomStyle', 'borderLeftStyle'],
+  //  - borderWidth: ['borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth'],
+  //  - overflow: ['overflowX', 'overflowY'],
+  //  - overscrollBehavior: ['overscrollBehaviorX', 'overscrollBehaviorY'],
+  //
+  //  RNW specifics:
+  //  - marginHorizontal: ['marginRight', 'marginLeft'],
+  //  - marginVertical: ['marginTop', 'marginBottom'],
+  //  - paddingHorizontal: ['paddingRight', 'paddingLeft'],
+  //  - paddingVertical: ['paddingTop', 'paddingBottom'],
+
+  return [new StyleCollectorNode(propertyName, propertyValue, hashSeed)];
+}


### PR DESCRIPTION
Purpose of this change is to expand shorthand CSS properties which could cause conflics when defined together. Imagine the following example:

```
const styles = sx.create({
  primary: { marginTop: '10px' },
  button: { margin: 0 },
});
```

It could generate the following CSS:

```
.c0 { margin-top: 10px }
.c1 { margin: 0px }
```

That would be a tricky situation because CSS specificity depends on the CSS definition order and therefore the top margin would be always overwritten when used together. Instead, we expand the shorthand properties into something like this:

```
.c0 { margin-top: 10px }   << primary
.c1 { margin-top: 0px }    << button
.c2 { margin-right: 0px }
.c3 { margin-bottom: 0px }
.c4 { margin-left: 0px }
```

This way SX is not dependent on the CSS rules insertion order but rather on the markup.

Inspired by this article: https://sebastienlorber.com/atomic-css-in-js (and React Native Web)