### PR TITLE
SX: improve color detection to support rgba() and hsla()

### DIFF
--- a/src/sx/src/__tests__/colorNormalizer.test.js
+++ b/src/sx/src/__tests__/colorNormalizer.test.js
@@ -5,45 +5,71 @@ import { invariant } from '@adeira/js';
 import { normalizeColor, isColor } from '../colorNormalizer';
 
 test.each`
-  color          | result
-  ${1}           | ${false}
-  ${true}        | ${false}
-  ${'blue'}      | ${true}
-  ${'aliceblue'} | ${true}
-  ${'#fff'}      | ${true}
-  ${'#ffffff'}   | ${true}
-  ${'#000000'}   | ${true}
-  ${'#xxxxxx'}   | ${false}
-  ${'#0000'}     | ${false}
+  color                           | result
+  ${1}                            | ${false}
+  ${true}                         | ${false}
+  ${'blue'}                       | ${true}
+  ${'aliceblue'}                  | ${true}
+  ${'#fff'}                       | ${true}
+  ${'#ffffff'}                    | ${true}
+  ${'#000000'}                    | ${true}
+  ${'#xxxxxx'}                    | ${false}
+  ${'#1fe0'}                      | ${true}
+  ${'#1fef'}                      | ${true}
+  ${'#11ffee00'}                  | ${true}
+  ${'#11ffeeff'}                  | ${true}
+  ${'transparent'}                | ${true}
+  ${'currentcolor'}               | ${false}
+  ${'rgb(255,255,128)'}           | ${true}
+  ${'RGB(255,255,128)'}           | ${true}
+  ${'rgb(255, 255, 128)'}         | ${true}
+  ${'rgba(255, 255, 128)'}        | ${true}
+  ${'rgb(100%, 50, 50%)'}         | ${true}
+  ${'rgb(100%,0%,60%)'}           | ${true}
+  ${'rgb( 255  ,  255  ,  128 )'} | ${true}
+  ${'rgba(117, 190, 218, 0.5)'}   | ${true}
+  ${'rgb(117 , 190 , 218 , 0.5)'} | ${true}
+  ${'rgb(tada)'}                  | ${false}
+  ${'rgb(a, b, c)'}               | ${false}
+  ${'hsl(50, 33%, 25%)'}          | ${true}
+  ${'HSL(50, 33%, 25%)'}          | ${true}
+  ${'hsl( 50  ,  33%  ,  25% )'}  | ${true}
+  ${'hsla(50, 33%, 25%, 0.75)'}   | ${true}
+  ${'hsl(50, 33, 25%)'}           | ${false}
+  ${'hsl(50, 33%, 25)'}           | ${false}
+  ${'hsl(45deg, 33%, 25%)'}       | ${true}
 `('detects color "$color" correctly ($result)', ({ color, result }) => {
   expect(isColor(color)).toBe(result);
 });
 
 test.each`
-  color        | result
-  ${'red'}     | ${'#f00'}
-  ${'lime'}    | ${'#0f0'}
-  ${'blue'}    | ${'#00f'}
-  ${'#F00'}    | ${'#f00'}
-  ${'#0F0'}    | ${'#0f0'}
-  ${'#00F'}    | ${'#00f'}
-  ${'#ff0000'} | ${'#f00'}
-  ${'#00ff00'} | ${'#0f0'}
-  ${'#0000ff'} | ${'#00f'}
+  color                          | result
+  ${'red'}                       | ${'#f00'}
+  ${'lime'}                      | ${'#0f0'}
+  ${'blue'}                      | ${'#00f'}
+  ${'#F00'}                      | ${'#f00'}
+  ${'#0F0'}                      | ${'#0f0'}
+  ${'#00F'}                      | ${'#00f'}
+  ${'#ff0000'}                   | ${'#f00'}
+  ${'#00ff00'}                   | ${'#0f0'}
+  ${'#0000ff'}                   | ${'#00f'}
+  ${'rgb(255, 255, 128)'}        | ${'rgb(255, 255, 128)'}
+  ${'hsl( 50  ,  33%  ,  25% )'} | ${'hsl( 50  ,  33%  ,  25% )'}
 `('normalizes color "$color" correctly ($result)', ({ color, result }) => {
   invariant(isColor(color), '"%s" is not a color', color);
   expect(normalizeColor(color)).toBe(result);
 });
 
 test.each`
-  notColor      | result
-  ${'#0'}       | ${'#0'}
-  ${'#00'}      | ${'#00'}
-  ${'#0000'}    | ${'#0000'}
-  ${'#00000'}   | ${'#00000'}
-  ${'#0000000'} | ${'#0000000'}
-  ${'yaDAda'}   | ${'yadada'}
-  ${'#acegik'}  | ${'#acegik'}
+  notColor              | result
+  ${'#0'}               | ${'#0'}
+  ${'#00'}              | ${'#00'}
+  ${'#00000'}           | ${'#00000'}
+  ${'#0000000'}         | ${'#0000000'}
+  ${'yaDAda'}           | ${'yadada'}
+  ${'#acegik'}          | ${'#acegik'}
+  ${'rgb(a, b, c)'}     | ${'rgb(a, b, c)'}
+  ${'hsl(50, 33, 25%)'} | ${'hsl(50, 33, 25%)'}
 `('normalizes unknown color "$notColor" gracefully', ({ notColor, result }) => {
   expect(isColor(notColor)).toBe(false);
   expect(normalizeColor(notColor)).toBe(result);

--- a/src/sx/src/colorNormalizer.js
+++ b/src/sx/src/colorNormalizer.js
@@ -19,11 +19,27 @@ function hex6ToHex3(value: string): string {
   return value;
 }
 
+// https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
 export function isColor(value: string): boolean {
   if (typeof value !== 'string') {
     return false;
   }
-  return cssColorNames.has(value) || /^#[0-9a-f]{3}$/i.test(value) || /^#[0-9a-f]{6}$/i.test(value);
+
+  // TODO: consider `currentcolor` (can be used as `background-color:currentcolor` for example)
+  return (
+    value === 'transparent' ||
+    cssColorNames.has(value) || // keyword values
+    /^#[0-9a-f]{3}$/i.test(value) || // RGB hexadecimal shorthand
+    /^#[0-9a-f]{4}$/i.test(value) || // RGB hexadecimal shorthand (with alpha)
+    /^#[0-9a-f]{6}$/i.test(value) || // RGB hexadecimal full
+    /^#[0-9a-f]{8}$/i.test(value) || // RGB hexadecimal full (with alpha)
+    // RGB[A] functional (simplified):
+    /^rgba?\(\s*[0-9.]+%?\s*,\s*[0-9.]+%?\s*,\s*[0-9.]+%?\s*(?:,\s*[0-9.]+%?\s*)?\)$/i.test(
+      value,
+    ) ||
+    // HSL[A] functional (simplified):
+    /^hsla?\(\s*.+\s*,\s*[0-9.]+%\s*,\s*[0-9.]+%\s*(?:,\s*[0-9.]+%?\s*)?\)$/i.test(value)
+  );
 }
 
 // Taken from https://github.com/bahamas10/css-color-names/blob/master/css-color-names.json


### PR DESCRIPTION
This commit introduces and improved detection of colors. Specifically, it understands hexadecimal RGB syntaxes with alpha channel as well as rgb(), rgba(), hsl() and hsla(). The functional syntaxes are simplified (no whitespace syntax support, weak floats values, no further validation like mixing percentages and numbers). This can be improved later when needed.

We need to improve this `isColor` function because some parts of the SX system rely on this detection (for example expansion of shorthand properties where we need to detect what is a color in `background` property).

I am also considering a new package `@adeira/css-color` because it might be quite handly when we master this.