### PR TITLE
relay-example: Specify grid colums on desktop size

### DIFF
--- a/src/example-relay/src/Homepage/index.js
+++ b/src/example-relay/src/Homepage/index.js
@@ -10,6 +10,7 @@ import LocationsPaginated from './locations/LocationsPaginated';
 import type { HomepageQueryResponse } from './__generated__/HomepageQuery.graphql';
 import Heading from '../components/Heading';
 import Text from '../components/Text';
+import { desktop } from '../components/breakpoints';
 
 function Demo(props) {
   return (
@@ -86,5 +87,8 @@ const styles = sx.create({
     display: 'grid',
     gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
     gap: 16,
+    [desktop]: {
+      gridTemplateColumns: 'repeat(3, 1fr)',
+    },
   },
 });

--- a/src/example-relay/src/components/breakpoints.js
+++ b/src/example-relay/src/components/breakpoints.js
@@ -1,3 +1,4 @@
 // @flow
 
 export const tablet = '@media (min-width: 768px)';
+export const desktop = '@media (min-width: 992px)';


### PR DESCRIPTION
Around 1300px, it would generate a 4th empty column.
Now it will use 3 columns on view width > 992px