### PR TITLE
SXT Babel: Template literals support

### DIFF
--- a/src/babel-plugin-transform-sx-tailwind/package.json
+++ b/src/babel-plugin-transform-sx-tailwind/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/babel-plugin-transform-sx-tailwind",
   "license": "MIT",
   "private": false,
-  "version": "0.5.1",
+  "version": "0.6.0",
   "main": "src/index",
   "sideEffects": false,
   "module": false,

--- a/src/babel-plugin-transform-sx-tailwind/src/TemplateLiteralHandler.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/TemplateLiteralHandler.js
@@ -1,0 +1,62 @@
+// @flow
+
+const t = require('@babel/types');
+
+export default function TemplateLiteralHandler(
+  path /*: any */,
+  stylesCollector /*: any[] */,
+  stylesVarName /*: string */,
+) {
+  if (path.node.expressions.length === 0) {
+    // Simple template literal without any expressions
+    const classNames = path.node.quasis.map((q) => q.value.raw).join(' ');
+    path.replaceWith(t.StringLiteral(classNames));
+  } else {
+    // some expressions inside of the template literal
+    const conditionals = path.node.expressions
+      .filter(
+        ({ type, consequent, alternate }) =>
+          type === 'ConditionalExpression' &&
+          ['TemplateLiteral', 'StringLiteral'].includes(consequent.type) &&
+          ['TemplateLiteral', 'StringLiteral'].includes(alternate.type),
+      )
+      .map((e) => {
+        e.consequent = t.ArrayExpression(getStringLiterals(e.consequent));
+        e.alternate = t.ArrayExpression(getStringLiterals(e.alternate));
+        stylesCollector.push(
+          ...e.consequent.elements.map((s) => s.value),
+          ...e.alternate.elements.map((s) => s.value),
+        );
+        return e;
+      });
+
+    // Get all quasis and expressions sorted as they were in the original code
+    const args = new Map(conditionals.map((c) => [c.start, t.SpreadElement(c)]));
+    path.node.quasis.forEach((q) => {
+      const literals = getStringLiterals(q);
+      stylesCollector.push(...literals.map((l) => l.value));
+      args.set(q.start, literals);
+    });
+    const sortedArgs = Array.from(args.keys())
+      .sort()
+      .map((i) => args.get(i))
+      .flat();
+
+    const expression = t.callExpression(t.identifier(stylesVarName), sortedArgs);
+    path.parentPath.replaceWith(expression);
+  }
+}
+
+function getStringLiterals(input) {
+  if (!['StringLiteral', 'TemplateElement', 'TemplateLiteral'].includes(input.type)) {
+    return [];
+  }
+  const strings =
+    // eslint-disable-next-line no-nested-ternary
+    input.type === 'StringLiteral'
+      ? input.value.split(' ')
+      : input.type === 'TemplateLiteral'
+      ? input.quasis.map((q) => q.value.raw.split(' ')).flat()
+      : input.value.raw.split(' ');
+  return strings.filter((s) => s !== '').map((s) => t.StringLiteral(s));
+}

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal-condition/code.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal-condition/code.js
@@ -1,0 +1,13 @@
+// @flow
+
+import React, { type Node } from 'react';
+import { sxt, tailwind } from '@adeira/sx-tailwind';
+
+export default function Example(): Node {
+  const darkMode = true;
+  return (
+    <div className={tailwind(`px-4 font-bold ${darkMode ? `text-white bg-black` : 'text-black bg-white'} rounded`)}>
+      Lorem lipsum
+    </div>
+  );
+}

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal-condition/output.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal-condition/output.js
@@ -1,0 +1,43 @@
+// @flow
+import React, { type Node } from 'react';
+import * as sx from '@adeira/sx';
+export default function Example(): Node {
+  const darkMode = true;
+  return (
+    <div
+      className={__styles_3kp10j(
+        'px-4',
+        'font-bold',
+        ...(darkMode ? ['text-white', 'bg-black'] : ['text-black', 'bg-white']),
+        'rounded',
+      )}
+    >
+      Lorem lipsum
+    </div>
+  );
+}
+
+const __styles_3kp10j = sx.create({
+  'text-white': {
+    color: '#fff',
+  },
+  'bg-black': {
+    backgroundColor: '#000',
+  },
+  'text-black': {
+    color: '#000',
+  },
+  'bg-white': {
+    backgroundColor: '#fff',
+  },
+  'px-4': {
+    paddingLeft: '1rem',
+    paddingRight: '1rem',
+  },
+  'font-bold': {
+    fontWeight: 700,
+  },
+  'rounded': {
+    borderRadius: '0.25rem',
+  },
+});

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal/code.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal/code.js
@@ -1,0 +1,12 @@
+// @flow
+
+import React, { type Node } from 'react';
+import { sxt, tailwind } from '@adeira/sx-tailwind';
+
+export default function Example(): Node {
+  return (
+    <div className={tailwind(`text-black bg-white`)}>
+      Lorem lipsum
+    </div>
+  );
+}

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal/output.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal/output.js
@@ -1,0 +1,15 @@
+// @flow
+import React, { type Node } from 'react';
+import * as sx from '@adeira/sx';
+export default function Example(): Node {
+  return <div className={__styles_18CL3W('text-black', 'bg-white')}>Lorem lipsum</div>;
+}
+
+const __styles_18CL3W = sx.create({
+  'text-black': {
+    color: '#000',
+  },
+  'bg-white': {
+    backgroundColor: '#fff',
+  },
+});

--- a/src/sx-tailwind-website/package.json
+++ b/src/sx-tailwind-website/package.json
@@ -16,7 +16,7 @@
     "react-syntax-highlighter": "^15.3.0"
   },
   "devDependencies": {
-    "@adeira/babel-plugin-transform-sx-tailwind": "^0.5.1",
+    "@adeira/babel-plugin-transform-sx-tailwind": "^0.6.0",
     "@adeira/babel-preset-adeira": "^1.1.0",
     "flow-bin": "^0.137.0"
   },

--- a/src/sx-tailwind-website/src/components/Sidebar.js
+++ b/src/sx-tailwind-website/src/components/Sidebar.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { tailwind } from '@adeira/sx-tailwind';
+import { useRouter } from 'next/router';
 
 type Props = {|
   +label: string,
@@ -9,11 +10,17 @@ type Props = {|
 |};
 
 function MenuItem({ label, href }: Props): React.Node {
+  const router = useRouter();
+
   return (
     <a
       href={href}
       className={tailwind(
-        'flex items-center px-2 py-2 text-sm leading-6 font-medium rounded-md transition ease-in-out duration-150 my-1 focus:outline-none focus:bg-teal-500 text-teal-100 hover:text-white hover:bg-teal-500',
+        `flex items-center px-2 py-2 text-sm leading-6 font-medium rounded-md transition ease-in-out duration-150 my-1 focus:outline-none focus:bg-teal-500 ${
+          router.pathname === href
+            ? 'text-white bg-teal-500'
+            : 'text-teal-100 hover:text-white hover:bg-teal-500'
+        }`,
       )}
     >
       {label}


### PR DESCRIPTION
`tailwind` method can now contain template literals with conditional expressions