### PR TITLE
SX: remove CSS reset

### DIFF
--- a/src/example-relay/public/reset.css
+++ b/src/example-relay/public/reset.css
@@ -1,0 +1,10 @@
+body {
+  box-sizing: border-box;
+}
+*,
+*::after,
+*::before {
+  margin: 0;
+  padding: 0;
+  box-sizing: inherit;
+}

--- a/src/example-relay/src/pages/_document.js
+++ b/src/example-relay/src/pages/_document.js
@@ -12,7 +12,7 @@ type RenderPageResult = {|
 
 export default class MyDocument extends Document {
   static getInitialProps(ctx: DocumentContext): RenderPageResult {
-    return sx.renderPageWithSX(ctx.renderPage, { includeReset: true });
+    return sx.renderPageWithSX(ctx.renderPage);
   }
 
   render(): React.Element<'html'> {
@@ -23,6 +23,7 @@ export default class MyDocument extends Document {
             href="https://fonts.googleapis.com/css?family=Roboto:400,400i,500,500i,700"
             rel="stylesheet"
           />
+          <link rel="stylesheet" type="text/css" href="/reset.css" />
           <link rel="stylesheet" type="text/css" href="/nprogress.css" />
         </Head>
         <body>

--- a/src/sx/README.md
+++ b/src/sx/README.md
@@ -6,7 +6,6 @@ In conventional applications, CSS rules are duplicated throughout the stylesheet
   - [Pseudo CSS classes and elements](#pseudo-css-classes-and-elements)
   - [`@media` and `@supports`](#media-and-supports)
   - [Precise Flow types](#precise-flow-types)
-  - [CSS reset](#css-reset)
 - [Architecture](#architecture)
 - [Prior Art](#prior-art)
 
@@ -226,37 +225,10 @@ const styles = sx.create({
 
 Sometimes it's hard or even impossible to have sound types for some CSS properties/values though. In such case, we choose the unsound strategy. Typical example of such unsoundness is when it comes to complex media queries - they cannot be statically analyzed. These situations are usually complemented with runtime checks and eventually even Eslint rules.
 
-### CSS reset
+## Production usage considerations
 
-You can opt in to add the most common CSS reset automatically. Usage like this:
-
-```jsx
-import * as sx from '@adeira/sx';
-import Document from 'next/document';
-
-export default class MyDocument extends Document {
-  static getInitialProps(ctx: DocumentContext) {
-    return sx.renderPageWithSX(ctx.renderPage, { includeReset: true });
-  }
-
-  // `render` is not needed to change
-}
-```
-
-This will add the following css to your stylesheet:
-
-```css
-body {
-  box-sizing: border-box;
-}
-*,
-*::after,
-*::before {
-  margin: 0;
-  padding: 0;
-  box-sizing: inherit;
-}
-```
+1. SX does not include any CSS reset or CSS normalization. It's because we couldn't decide which strategy would be the best. We concluded that each user should choose their own strategy (either reset, normalizer or nothing) alongside SX.
+2. _TKTK (Babel transpilation, font-size)_
 
 ## Architecture
 

--- a/src/sx/src/__tests__/SxDomTests.test.js
+++ b/src/sx/src/__tests__/SxDomTests.test.js
@@ -60,29 +60,6 @@ it('applies correct styles', () => {
   expect(pseudoRed).toHaveStyle(`color:${normalizeColor('red')}`); // red wins (non-hover)
 });
 
-it('includes reset', () => {
-  render(
-    <div data-test="container">
-      {sx.renderPageWithSX(jest.fn(), { includeReset: true }).styles}
-    </div>,
-  );
-
-  expect(document.querySelector('[data-adeira-sx="true"]')?.innerHTML).toMatchInlineSnapshot(`
-    "
-    body {
-      box-sizing: border-box;
-    }
-    *,
-    *::after,
-    *::before {
-      margin: 0;
-      padding: 0;
-      box-sizing: inherit;
-    }
-    "
-  `);
-});
-
 it('correctly handles shorthand properties specificity', () => {
   const styles = sx.create({
     primary: { marginTop: '10px' },

--- a/src/sx/src/renderPageWithSX.js
+++ b/src/sx/src/renderPageWithSX.js
@@ -10,28 +10,8 @@ type RenderPageResult = {|
   +styles: $ReadOnlyArray<any>,
 |};
 
-const cssReset = `
-body {
-  box-sizing: border-box;
-}
-*,
-*::after,
-*::before {
-  margin: 0;
-  padding: 0;
-  box-sizing: inherit;
-}
-`;
-
-type Options = {|
-  +includeReset?: boolean,
-|};
-
 // Note: this is currently a bit Next.js centric, we can make it more abstract later
-export default function renderPageWithSX(
-  renderPage: () => any,
-  options?: Options,
-): RenderPageResult {
+export default function renderPageWithSX(renderPage: () => any): RenderPageResult {
   const html = renderPage();
 
   return {
@@ -41,9 +21,7 @@ export default function renderPageWithSX(
       <style
         key="adeira-sx"
         data-adeira-sx={true}
-        dangerouslySetInnerHTML={{
-          __html: `${options?.includeReset === true ? cssReset : ''}${StyleCollector.print()}`,
-        }}
+        dangerouslySetInnerHTML={{ __html: StyleCollector.print() }}
       />,
     ],
   };


### PR DESCRIPTION
We couldn't decide whether to use CSS reset or normalization and concluded that we should leave this decision for the user.