### PR TITLE
eslint-config: Turn off eslint rule no-useless-computed-key

### DIFF
--- a/src/eslint-config-adeira/CHANGELOG.md
+++ b/src/eslint-config-adeira/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Unreleased
 
 - Enable [`node/process-exit-as-throw`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/process-exit-as-throw.md) rule. This is potentially breaking, however, the impact should be minimal and the migration simple.
-
 - Set `react/react-in-jsx-scope` to `OFF` since we are now using the new JSX transform internally.
+- Turn off `no-useless-computed-key`
 
 # 4.0.0
 

--- a/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
+++ b/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
@@ -583,7 +583,7 @@ Object {
     "no-useless-backreference": 2,
     "no-useless-call": 1,
     "no-useless-catch": 2,
-    "no-useless-computed-key": 2,
+    "no-useless-computed-key": 0,
     "no-useless-concat": 2,
     "no-useless-constructor": 2,
     "no-useless-escape": 2,

--- a/src/eslint-config-adeira/ourRules.js
+++ b/src/eslint-config-adeira/ourRules.js
@@ -236,7 +236,7 @@ module.exports = ({
   'no-new-symbol': WARN,
   'no-restricted-imports': OFF, // see: node/no-restricted-import (https://github.com/mysticatea/eslint-plugin-node/pull/206)
   'no-this-before-super': ERROR,
-  'no-useless-computed-key': ERROR,
+  'no-useless-computed-key': OFF, // Flow doesn't work with non-string literal property keys, https://github.com/facebook/flow/issues/380
   'no-useless-constructor': ERROR,
   'no-var': ERROR,
   'no-useless-rename': WARN,


### PR DESCRIPTION
Turning this eslint rule off since flow doesn't work with non-string literal
property keys, https://github.com/facebook/flow/issues/380.