### PR TITLE
Open-source new 'eslint-plugin-sx'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,10 @@ module.exports = {
     },
   ],
 
+  plugins: ['eslint-plugin-sx'], // TODO: move to `eslint-config-adeira`
+
   rules: {
+    'sx/no-unused-stylesheet': ERROR, // TODO: move to `eslint-config-adeira`
     'no-restricted-imports': [
       ERROR,
       {

--- a/scripts/publishedPackages.json
+++ b/scripts/publishedPackages.json
@@ -23,5 +23,6 @@
   "@adeira/sx",
   "@adeira/sx-tailwind",
   "@adeira/test-utils",
-  "eslint-plugin-adeira"
+  "eslint-plugin-adeira",
+  "eslint-plugin-sx"
 ]

--- a/src/eslint-plugin-sx/.npmignore
+++ b/src/eslint-plugin-sx/.npmignore
@@ -1,0 +1,4 @@
+__flowtests__
+__tests__
+BUILD.bazel
+BUILD

--- a/src/eslint-plugin-sx/LICENSE
+++ b/src/eslint-plugin-sx/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019-present, Adeira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/eslint-plugin-sx/README.md
+++ b/src/eslint-plugin-sx/README.md
@@ -1,0 +1,42 @@
+# eslint-plugin-sx
+
+Eslint rules for [@adeira/sx](https://www.npmjs.com/package/@adeira/sx)
+
+## Installation
+
+You'll first need to install [ESLint](http://eslint.org):
+
+```
+$ npm i eslint --save-dev
+```
+
+Next, install `eslint-plugin-sx`:
+
+```
+$ npm install eslint-plugin-sx --save-dev
+```
+
+## Usage
+
+Add `sx` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+
+```json
+{
+  "plugins": ["sx"]
+}
+```
+
+Then configure the rules you want to use under the rules section.
+
+```json
+{
+  "rules": {
+    "sx/no-unused-stylesheet": 2
+  }
+}
+```
+
+## Supported Rules
+
+- [no-unused-stylesheet](docs/rules/no-unused-stylesheet.md)
+- TODO

--- a/src/eslint-plugin-sx/docs/rules/no-unused-stylesheet.md
+++ b/src/eslint-plugin-sx/docs/rules/no-unused-stylesheet.md
@@ -1,0 +1,56 @@
+# no-unused-stylesheet
+
+## Rule Details
+
+This rule aims to find unused SX stylesheet definitions.
+
+Examples of **incorrect** code for this rule:
+
+```js
+import * as sx from '@adeira/sx';
+
+export default function MyComponent() {
+  return null;
+}
+
+// Unused ⚠️
+const styles = sx.create({
+  aaa: { color: 'red' },
+});
+```
+
+```js
+import * as sx from '@adeira/sx';
+
+export default function MyComponent() {
+  return <div className={styles('aaa')} />;
+}
+
+const styles = sx.create({
+  aaa: { color: 'red' },
+  bbb: { color: 'blue' }, // Unused ⚠️
+  ccc: { color: 'green' }, // Unused ⚠️
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import * as sx from '@adeira/sx';
+
+export default function MyComponent() {
+  return <div className={styles('aaa')} />;
+}
+
+const styles = sx.create({
+  aaa: { color: 'red' },
+});
+```
+
+### Options
+
+_none_
+
+## When Not To Use It
+
+TKTK

--- a/src/eslint-plugin-sx/package.json
+++ b/src/eslint-plugin-sx/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "eslint-plugin-sx",
+  "description": "Eslint plugin for @adeira/sx",
+  "homepage": "https://github.com/adeira/universe/tree/master/src/eslint-plugin-sx",
+  "version": "0.1.0",
+  "license": "MIT",
+  "private": false,
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
+  ],
+  "main": "src/index",
+  "dependencies": {
+    "@babel/runtime": "^7.12.5",
+    "requireindex": "^1.1.0"
+  },
+  "devDependencies": {
+    "@adeira/flow-types-eslint": "0.0.0",
+    "eslint": "^7.1.0",
+    "jest-docblock": "^26.0.0"
+  },
+  "peerDependencies": {
+    "@adeira/sx": "^0.19.0"
+  }
+}

--- a/src/eslint-plugin-sx/src/index.js
+++ b/src/eslint-plugin-sx/src/index.js
@@ -1,0 +1,7 @@
+// @flow
+
+const path = require('path');
+const requireIndex = require('requireindex');
+
+// import all rules in src/rules
+module.exports.rules = (requireIndex(path.join(__dirname, 'rules')) /*: any */);

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/.eslintrc.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/.eslintrc.js
@@ -1,0 +1,14 @@
+// @flow strict
+
+/* eslint-disable no-unused-vars */
+const OFF = 0;
+const WARN = 1;
+const ERROR = 2;
+/* eslint-enable no-unused-vars */
+
+module.exports = {
+  rules: {
+    // we are having here fixtures with invalid SX definitions on purpose
+    'sx/no-unused-stylesheet': OFF,
+  },
+};

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/sx-empty-argument.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/sx-empty-argument.js
@@ -1,0 +1,15 @@
+/**
+ * @flow
+ * @eslintExpectedError SX create must be called with object in a first argument.
+ */
+
+import type { Node } from 'react';
+import * as sx from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  // $FlowExpectedError[incompatible-call] wrong on purpose (see below)
+  return <div className={styles('aaa')} />;
+}
+
+// $FlowExpectedError[incompatible-call] empty on purpose (see above)
+const styles = sx.create();

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/sx-invalid-argument.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/sx-invalid-argument.js
@@ -1,0 +1,15 @@
+/**
+ * @flow
+ * @eslintExpectedError SX create must be called with object in a first argument.
+ */
+
+import type { Node } from 'react';
+import * as sx from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  // $FlowExpectedError[incompatible-call] for testing purposes
+  return <div className={styles('aaa')} />;
+}
+
+// $FlowExpectedError[incompatible-call] for testing purposes
+const styles = sx.create('should be an object, not a string');

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/sx-invalid-stylesheet-type.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/sx-invalid-stylesheet-type.js
@@ -1,0 +1,16 @@
+/**
+ * @flow
+ * @eslintExpectedError Each SX definition property must be an object.
+ */
+
+import type { Node } from 'react';
+import * as sx from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  return <div className={styles('aaa')} />;
+}
+
+const styles = sx.create({
+  // $FlowExpectedError[incompatible-call] for testing purposes
+  aaa: 'this should be an object',
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/sx-multiple-definitions.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/sx-multiple-definitions.js
@@ -1,0 +1,27 @@
+/**
+ * @flow
+ * @eslintExpectedError Unused stylesheet: bbb (defined via "foo" variable)
+ * @eslintExpectedError Unused stylesheet: aaa (defined via "bar" variable)
+ */
+
+import type { Node } from 'react';
+import { create as sxCreate } from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  return (
+    <>
+      <div className={foo('aaa')} />
+      <div className={bar('bbb')} />
+    </>
+  );
+}
+
+const foo = sxCreate({
+  aaa: { color: 'red' },
+  bbb: { color: 'blue' }, // unused
+});
+
+const bar = sxCreate({
+  aaa: { color: 'red' }, // unused
+  bbb: { color: 'blue' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/sx-too-many-arguments.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/sx-too-many-arguments.js
@@ -1,0 +1,21 @@
+/**
+ * @flow
+ * @eslintExpectedError SX create was called with too many arguments. Only one is allowed.
+ */
+
+import type { Node } from 'react';
+import * as sx from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  return <div className={styles('aaa')} />;
+}
+
+const styles = sx.create(
+  {
+    aaa: {
+      color: 'red',
+    },
+  },
+  // $FlowExpectedError[extra-arg] - for testing purposes
+  'unknown argument',
+);

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/unknown-stylesheet.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/unknown-stylesheet.js
@@ -1,0 +1,17 @@
+/**
+ * @flow
+ * @eslintExpectedError Unused stylesheet: aaa (defined via "styles" variable)
+ * @eslintExpectedError Unknown stylesheet used: yadada (not defined anywhere)
+ */
+
+import type { Node } from 'react';
+import * as sx from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  // $FlowExpectedError[incompatible-call] - yadada is not defined in the stylesheet below
+  return <div className={styles('yadada')} />;
+}
+
+const styles = sx.create({
+  aaa: { color: 'red' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/unused-stylesheet.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/unused-stylesheet.js
@@ -1,0 +1,18 @@
+/**
+ * @flow
+ * @eslintExpectedError Unused stylesheet: bbb (defined via "styles" variable)
+ * @eslintExpectedError Unused stylesheet: ccc (defined via "styles" variable)
+ */
+
+import type { Node } from 'react';
+import * as sx from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  return <div className={styles('aaa')} />;
+}
+
+const styles = sx.create({
+  aaa: { color: 'red' },
+  bbb: { color: 'blue' }, // unused
+  ccc: { color: 'green' }, // unused
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/unused-sx-multiple.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/unused-sx-multiple.js
@@ -1,0 +1,28 @@
+/**
+ * @flow
+ * @eslintExpectedError SX function "styles1" was not used anywhere in JSX.
+ * @eslintExpectedError Unused stylesheet: aaa (defined via "styles1" variable)
+ * @eslintExpectedError SX function "styles3" was not used anywhere in JSX.
+ * @eslintExpectedError Unused stylesheet: ccc (defined via "styles3" variable)
+ */
+
+import type { Node } from 'react';
+import * as sx from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  return <div className={styles2('bbb')} />;
+}
+
+// eslint-disable-next-line no-unused-vars
+const styles1 = sx.create({
+  aaa: { color: 'red' },
+});
+
+const styles2 = sx.create({
+  bbb: { color: 'red' },
+});
+
+// eslint-disable-next-line no-unused-vars
+const styles3 = sx.create({
+  ccc: { color: 'red' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/unused-sx.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/invalid/unused-sx.js
@@ -1,0 +1,17 @@
+/**
+ * @flow
+ * @eslintExpectedError SX function "styles" was not used anywhere in JSX.
+ * @eslintExpectedError Unused stylesheet: aaa (defined via "styles" variable)
+ */
+
+import type { Node } from 'react';
+import * as sx from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  return null;
+}
+
+// eslint-disable-next-line no-unused-vars
+const styles = sx.create({
+  aaa: { color: 'red' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/react-component-unused-sx.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/react-component-unused-sx.js
@@ -1,0 +1,19 @@
+// @flow
+
+import type { Node } from 'react';
+import * as tada from '@adeira/sx'; // eslint-disable-line no-unused-vars
+
+export default function MyComponent(): Node {
+  return styles('ok');
+}
+
+const sx = {
+  create(obj: any) {
+    return obj;
+  },
+};
+
+// this is something else, not "@adeira/sx"
+const styles = sx.create({
+  aaa: { color: 'red' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/react-component-without-sx.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/react-component-without-sx.js
@@ -1,0 +1,7 @@
+// @flow strict
+
+import type { Node } from 'react';
+
+export default function MyComponent(): Node {
+  return null;
+}

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-complex-className.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-complex-className.js
@@ -1,0 +1,14 @@
+// @flow
+
+import type { Node } from 'react';
+import { create as sxCreate } from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  // Please note: technically, this should not be allowed in SX, however,
+  // this rule doesn't care about it and should behave gracefully.
+  return <div className={`custom-class-name ${styles('aaa')}`} />;
+}
+
+const styles = sxCreate({
+  aaa: { color: 'red' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-conditional-call.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-conditional-call.js
@@ -1,0 +1,20 @@
+// @flow
+
+import type { Node } from 'react';
+import { create as sxCreate } from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  const isBBB = Boolean(Math.random());
+  return (
+    <>
+      <div className={styles('aaa', isBBB && 'bbb')} />
+      <div className={styles('aaa', isBBB ? 'bbb' : null)} />
+      <div className={styles('aaa', isBBB ? null : 'bbb')} />
+    </>
+  );
+}
+
+const styles = sxCreate({
+  aaa: { color: 'red' },
+  bbb: { color: 'blue' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-create-import-aliased.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-create-import-aliased.js
@@ -1,0 +1,12 @@
+// @flow
+
+import type { Node } from 'react';
+import { create as sxCreate } from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  return <div className={styles('aaa')} />;
+}
+
+const styles = sxCreate({
+  aaa: { color: 'red' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-create-import.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-create-import.js
@@ -1,0 +1,12 @@
+// @flow
+
+import type { Node } from 'react';
+import { create } from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  return <div className={styles('aaa')} />;
+}
+
+const styles = create({
+  aaa: { color: 'red' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-dynamic.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-dynamic.js
@@ -1,0 +1,13 @@
+// @flow
+
+import type { Node } from 'react';
+import { create as sxCreate } from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  const styleSheetDynamicName = 'aaa';
+  return <div className={styles(styleSheetDynamicName)} />;
+}
+
+const styles = sxCreate({
+  aaa: { color: 'red' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-multiple-definitions.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-multiple-definitions.js
@@ -1,0 +1,21 @@
+// @flow
+
+import type { Node } from 'react';
+import { create as sxCreate } from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  return (
+    <>
+      <div className={yada('aaa')} />
+      <div className={dada('bbb')} />
+    </>
+  );
+}
+
+const yada = sxCreate({
+  aaa: { color: 'red' },
+});
+
+const dada = sxCreate({
+  bbb: { color: 'blue' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-multiple-stylesheets.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-multiple-stylesheets.js
@@ -1,0 +1,13 @@
+// @flow
+
+import type { Node } from 'react';
+import { create as sxCreate } from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  return <div className={styles('aaa', 'bbb')} />;
+}
+
+const styles = sxCreate({
+  aaa: { color: 'red' },
+  bbb: { color: 'blue' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-multiple-usages.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-multiple-usages.js
@@ -1,0 +1,18 @@
+// @flow
+
+import type { Node } from 'react';
+import { create as sxCreate } from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  return (
+    <>
+      <div className={styles('aaa')} />
+      <div className={styles('bbb')} />
+    </>
+  );
+}
+
+const styles = sxCreate({
+  aaa: { color: 'red' },
+  bbb: { color: 'blue' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-namespace-import.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-namespace-import.js
@@ -1,0 +1,12 @@
+// @flow
+
+import type { Node } from 'react';
+import * as tada from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  return <div className={styles('aaa')} />;
+}
+
+const styles = tada.create({
+  aaa: { color: 'red' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-template-string.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-template-string.js
@@ -1,0 +1,20 @@
+// @flow
+
+import type { Node } from 'react';
+import { create as sxCreate } from '@adeira/sx';
+
+export default function MyComponent(): Node {
+  return (
+    <div
+      className={styles(
+        `aaa`, // please, leave it exactly like this
+        `bbb`, // please, leave it exactly like this
+      )}
+    />
+  );
+}
+
+const styles = sxCreate({
+  aaa: { color: 'red' },
+  bbb: { color: 'blue' },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-with-quoted-properties.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid/sx-with-quoted-properties.js
@@ -1,0 +1,15 @@
+// @flow
+
+import type { Node } from 'react';
+import { create } from '@adeira/sx';
+
+export default function Example(): Node {
+  return <div className={styles('text-red')}>Red text</div>;
+}
+
+const styles = create({
+  // Keep the quoted property here!
+  'text-red': {
+    color: 'red',
+  },
+});

--- a/src/eslint-plugin-sx/src/rules/__tests__/no-unused-stylesheet.test.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/no-unused-stylesheet.test.js
@@ -1,0 +1,47 @@
+// @flow
+
+const fs = require('fs');
+const path = require('path');
+const { extract, parse } = require('jest-docblock');
+const RuleTester = require('eslint').RuleTester;
+
+const rule = require('../no-unused-stylesheet');
+
+const fixturesPath = path.join(__dirname, 'fixtures');
+const validFixturesPath = path.join(fixturesPath, 'valid');
+const invalidFixturesPath = path.join(fixturesPath, 'invalid');
+const validFixtures = [];
+const invalidFixtures = [];
+for (const fixture of fs.readdirSync(validFixturesPath)) {
+  validFixtures.push({
+    code: fs.readFileSync(path.join(validFixturesPath, fixture), 'utf8'),
+  });
+}
+for (const fixture of fs.readdirSync(invalidFixturesPath)) {
+  const code = fs.readFileSync(path.join(invalidFixturesPath, fixture), 'utf8');
+  const docblock = extract(code);
+  const pragmas = parse(docblock);
+  if (pragmas.eslintExpectedError == null) {
+    throw new Error('Test fixture must define at least one @eslintExpectedError pragma.');
+  }
+  if (Array.isArray(pragmas.eslintExpectedError)) {
+    invalidFixtures.push({
+      code,
+      errors: pragmas.eslintExpectedError.map((message) => ({ message })),
+    });
+  } else {
+    invalidFixtures.push({
+      code,
+      errors: [{ message: pragmas.eslintExpectedError }],
+    });
+  }
+}
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+});
+
+ruleTester.run('no-unused-stylesheet', rule, {
+  valid: validFixtures,
+  invalid: invalidFixtures,
+});

--- a/src/eslint-plugin-sx/src/rules/no-unused-stylesheet.js
+++ b/src/eslint-plugin-sx/src/rules/no-unused-stylesheet.js
@@ -1,0 +1,175 @@
+// @flow
+
+/*::
+import type { EslintRule } from '@adeira/flow-types-eslint';
+*/
+
+// This rule makes sure that all defined stylesheets are used AND all used stylesheets are defined.
+module.exports = ({
+  create: function (context) {
+    // import * as sx from '@adeira/sx'
+    //             ^^
+    let importNamespaceSpecifier = null;
+
+    // import { create as sxCreate } from '@adeira/sx';
+    //                    ^^^^^^^^
+    let importSpecifier = null;
+
+    // stylesheet names which were defined via `sx.create`
+    // const xxx = sx.create({yyy, zzz})   =>   Map([["xxx", ["yyy", "zzz"]]])
+    const definedStylesheetNames = new Map();
+
+    // xxx('aaa', 'bbb')   =>   Map([["xxx", [aaaNode, bbbNode]]])
+    const usedStylesheetNames = new Map();
+
+    let unableToAnalyzeUsedStylesheets = false;
+
+    return {
+      // TODO: add support for `require("@adeira/sx")`
+      'ImportDeclaration'(node) {
+        if (node.source.value === '@adeira/sx') {
+          for (const specifier of node.specifiers) {
+            if (specifier.type === 'ImportNamespaceSpecifier') {
+              // import * as sx from '@adeira/sx'
+              // import * as tada from '@adeira/sx'
+              importNamespaceSpecifier = specifier.local.name; // "sx" or "tada"
+            } else if (specifier.type === 'ImportSpecifier') {
+              // import { create } from '@adeira/sx';
+              // import { create as sxCreate } from '@adeira/sx';
+              importSpecifier = specifier.local.name; // "create" or "sxCreate"
+            }
+          }
+        }
+      },
+
+      // const styles = sx.create({})
+      //       ^^^^^^^^^^^^^^^^^^^^^^
+      //       | id |
+      'VariableDeclarator'(node) {
+        const nodeCallee =
+          node.init && node.init.type === 'CallExpression' ? node.init.callee : undefined;
+        if (
+          nodeCallee &&
+          node.init &&
+          node.init.arguments &&
+          ((nodeCallee.object &&
+            nodeCallee.object.name === importNamespaceSpecifier && // "sx" in sx.create({})
+            nodeCallee.property &&
+            nodeCallee.property.name === 'create') || // "create" in sx.create({})
+            nodeCallee.name === importSpecifier) // "sxCreate" in sxCreate({})
+        ) {
+          if (node.init.arguments.length > 1) {
+            context.report({
+              node,
+              message: 'SX create was called with too many arguments. Only one is allowed.',
+            });
+          }
+
+          const firstArgument = node.init.arguments[0];
+          if ((firstArgument && firstArgument.type) !== 'ObjectExpression') {
+            context.report({
+              node,
+              message: 'SX create must be called with object in a first argument.',
+            });
+          }
+
+          const firstArgumentProperties = (firstArgument && firstArgument.properties) || [];
+          for (const property of firstArgumentProperties) {
+            if (property.value.type !== 'ObjectExpression') {
+              context.report({
+                node,
+                message: 'Each SX definition property must be an object.',
+              });
+            }
+
+            const alreadyCaptured = definedStylesheetNames.get(node.id.name) || [];
+            definedStylesheetNames.set(node.id.name, [
+              ...alreadyCaptured,
+              property.key.name || // in case property is type of "Identifier"
+                property.key.value, // in case property is type of "Literal"
+            ]);
+          }
+        }
+      },
+
+      // className={styles('aaa')}
+      //           ^^^^^^^^^^^^^^^
+      'JSXExpressionContainer'(node) {
+        const usedNames = new Set();
+        const expressionArguments = node.expression.arguments || [];
+        if (expressionArguments.length === 0) {
+          // some unexpected "className" construct
+          unableToAnalyzeUsedStylesheets = true;
+        }
+        for (const argument of expressionArguments) {
+          if (argument.type === 'Literal') {
+            usedNames.add(argument.value);
+          } else if (argument.type === 'TemplateLiteral') {
+            usedNames.add(argument.quasis[0].value.raw);
+          } else if (argument.type === 'LogicalExpression') {
+            usedNames.add(argument.right.value);
+          } else {
+            // TODO: more cases (deeper analysis)
+            unableToAnalyzeUsedStylesheets = true;
+          }
+        }
+
+        if (node.expression.callee) {
+          const maybeCaptured = usedStylesheetNames.get(node.expression.callee.name);
+          const alreadyCaptured = maybeCaptured ? maybeCaptured : [];
+          usedStylesheetNames.set(node.expression.callee.name, [...alreadyCaptured, ...usedNames]);
+        }
+      },
+
+      'Program:exit'(node) {
+        if (unableToAnalyzeUsedStylesheets === true) {
+          // backout early in cases we are not 100% sure about it
+          return;
+        }
+
+        definedStylesheetNames.forEach((definedNames, callee) => {
+          const usedNames = usedStylesheetNames.get(callee);
+          if (usedNames == null) {
+            context.report({
+              node, // TODO: improve the location by using more accurate node (?)
+              message: 'SX function "{{functionName}}" was not used anywhere in JSX.',
+              data: { functionName: callee },
+            });
+          }
+
+          const definedButNotUsed =
+            definedNames.filter((name) => {
+              return !(usedNames && usedNames.includes(name));
+            }) || [];
+          for (const name of definedButNotUsed) {
+            context.report({
+              node, // TODO: improve the location by using more accurate node (?)
+              message:
+                'Unused stylesheet: {{stylesheetName}} (defined via "{{definedBy}}" variable)',
+              data: {
+                stylesheetName: name,
+                definedBy: callee,
+              },
+            });
+          }
+
+          const usedButNotDefined =
+            (usedNames &&
+              usedNames.filter((name) => {
+                return !(definedNames && definedNames.includes(name));
+              })) ||
+            [];
+          for (const name of usedButNotDefined) {
+            context.report({
+              node, // TODO: improve the location by using more accurate node (?)
+              message: 'Unknown stylesheet used: {{stylesheetName}} (not defined anywhere)',
+              data: {
+                stylesheetName: name,
+              },
+            });
+          }
+        });
+      },
+    };
+  },
+} /*: EslintRule */);

--- a/src/flow-types-eslint/src/index.js
+++ b/src/flow-types-eslint/src/index.js
@@ -50,7 +50,7 @@ type ASTNodes = {|
 |};
 
 export type EslintRule = {|
-  +meta: {|
+  +meta?: {|
     +type?: 'problem' | 'suggestion' | 'layout',
     +docs?: {|
       +description?: string,

--- a/src/flow-types-eslint/src/types/CallExpression.js
+++ b/src/flow-types-eslint/src/types/CallExpression.js
@@ -6,6 +6,7 @@ import type { INode } from './INode';
 // ^^^^^
 export type CallExpression = $ReadOnly<{|
   ...INode,
+  +type: 'CallExpression',
   +callee: any, // TODO
   +arguments: any, // TODO
   +optional: boolean,

--- a/src/flow-types-eslint/src/types/NumericLiteral.js
+++ b/src/flow-types-eslint/src/types/NumericLiteral.js
@@ -1,0 +1,9 @@
+// @flow
+
+import type { INode } from './INode';
+
+export type NumericalLiteral = $ReadOnly<{|
+  ...INode,
+  +type: 'NumericalLiteral',
+  +value: number,
+|}>;

--- a/src/flow-types-eslint/src/types/StringLiteral.js
+++ b/src/flow-types-eslint/src/types/StringLiteral.js
@@ -1,0 +1,9 @@
+// @flow
+
+import type { INode } from './INode';
+
+export type StringLiteral = $ReadOnly<{|
+  ...INode,
+  +type: 'StringLiteral',
+  +value: string,
+|}>;

--- a/src/flow-types-eslint/src/types/VariableDeclarator.js
+++ b/src/flow-types-eslint/src/types/VariableDeclarator.js
@@ -1,11 +1,17 @@
 // @flow
 
-import type { INode } from './INode';
-import type { Identifier } from './Identifier';
 import type { CallExpression } from './CallExpression';
+import type { Identifier } from './Identifier';
+import type { INode } from './INode';
+import type { NumericalLiteral } from './NumericLiteral';
+import type { StringLiteral } from './StringLiteral';
 
 export type VariableDeclarator = $ReadOnly<{|
   ...INode,
   +id: Identifier,
-  +init: CallExpression,
+  +init:
+    | null // let x;
+    | CallExpression // let x = y();
+    | NumericalLiteral // let x = -1;
+    | StringLiteral, // let x = "";
 |}>;

--- a/src/sx/README.md
+++ b/src/sx/README.md
@@ -20,6 +20,12 @@ First, install the package from NPM:
 yarn add @adeira/sx
 ```
 
+It's highly recommended (but optional) to use related Eslint plugin as well:
+
+```text
+yarn add --dev eslint-plugin-sx
+```
+
 Create a stylesheet and use it to generate `className` props for React:
 
 ```jsx

--- a/yarn.lock
+++ b/yarn.lock
@@ -6515,7 +6515,7 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.13.0:
+eslint@^7.1.0, eslint@^7.13.0:
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.13.0.tgz#7f180126c0dcdef327bfb54b211d7802decc08da"
   integrity sha512-uCORMuOO8tUzJmsdRtrvcGq5qposf7Rw0LwkTJkoDbOycVQtQjmnhZSuLQnozLE4TmAzlMVV45eCHmQ1OpDKUQ==
@@ -13191,6 +13191,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requireindex@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This plugin has only one rule at this moment: `sx/no-unused-stylesheets`. This rule is trying to capture cases when the defined stylesheet is not used anywhere in the application (manual dead code elimination) or when used stylesheet was not defined.

It also validates the SX usage a little bit which should probably be moved into some other rule (to be done later).

TODO:

- [x] offload the Flow types in a different PR (https://github.com/adeira/universe/pull/1302)
- [x] fix all lint/Flow/tests issues