### PR TITLE
eslint-runner: Add space after total in progressbar

### DIFF
--- a/src/eslint-runner/reporter.js
+++ b/src/eslint-runner/reporter.js
@@ -43,7 +43,8 @@ class JestProgressBarReporter {
 
   onTestStart() /*: void */ {
     if (this._bar == null) {
-      this._bar = new ProgressBar(':bar :current/:total', {
+      // Note that the space behind :total is necessary so that the cursor doesn't cover the last number of the total.
+      this._bar = new ProgressBar(':bar :current/:total ', {
         complete: '█',
         incomplete: '░',
         total: this._numTotalTestSuites,


### PR DESCRIPTION
The last number of the total was cut behind the cursor.
Now you can see the entire total.

Before

![Screenshot 2020-11-14 at 09 44 00](https://user-images.githubusercontent.com/7705041/99143649-7f095a00-265f-11eb-9c71-c3a4666c7fe8.png)

After
![Screenshot 2020-11-14 at 09 42 00](https://user-images.githubusercontent.com/7705041/99143648-76188880-265f-11eb-9a08-dfbda2763bdc.png)
