### PR TITLE
adeira.dev: Add babel.config.js to adeira.dev project

### DIFF
--- a/src/adeira.dev/.babelrc.js
+++ b/src/adeira.dev/.babelrc.js
@@ -1,0 +1,5 @@
+// @flow strict
+
+module.exports = {
+  presets: ['@adeira/babel-preset-adeira'],
+};

--- a/src/adeira.dev/__github__/babel.config.js
+++ b/src/adeira.dev/__github__/babel.config.js
@@ -1,0 +1,5 @@
+// @flow strict
+
+module.exports = {
+  presets: ['@adeira/babel-preset-adeira'],
+};

--- a/src/adeira.dev/package.json
+++ b/src/adeira.dev/package.json
@@ -15,5 +15,8 @@
     "@docusaurus/preset-classic": "^2.0.0-alpha.66",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
+  },
+  "devDependencies": {
+    "@adeira/babel-preset-adeira": "^2.0.0"
   }
 }

--- a/src/monorepo-shipit/config/__tests__/adeira-dev.test.js
+++ b/src/monorepo-shipit/config/__tests__/adeira-dev.test.js
@@ -8,6 +8,7 @@ testExportedPaths(path.join(__dirname, '..', 'adeira-dev.js'), [
   ['src/adeira.dev/package.json', 'package.json'],
   ['src/adeira.dev/README.md', 'README.md'],
   ['src/adeira.dev/docs/general/introduction.md', 'docs/general/introduction.md'],
+  ['src/adeira.dev/__github__/babel.config.js', 'babel.config.js'],
 
   // invalid cases:
   ['src/packages/monorepo/outsideScope.js', undefined], // correctly deleted
@@ -16,4 +17,5 @@ testExportedPaths(path.join(__dirname, '..', 'adeira-dev.js'), [
   ['src/adeira.dev/WORKSPACE.bazel', undefined], // correctly deleted
   ['src/adeira.dev/WORKSPACE', undefined], // correctly deleted
   ['package.json', undefined], // correctly deleted
+  ['src/adeira.dev/.babelrc.js', undefined], // correctly deleted
 ]);

--- a/src/monorepo-shipit/config/adeira-dev.js
+++ b/src/monorepo-shipit/config/adeira-dev.js
@@ -9,6 +9,12 @@ module.exports = ({
     };
   },
   getPathMappings() {
-    return new Map([['src/adeira.dev/', '']]);
+    return new Map([
+      ['src/adeira.dev/__github__/babel.config.js', 'babel.config.js'],
+      ['src/adeira.dev/', ''],
+    ]);
+  },
+  getStrippedFiles() {
+    return new Set([/__github__/, /^\.babelrc\.js$/]);
   },
 }: ConfigType);


### PR DESCRIPTION
The build was failing after we added the new JSX transform.
This should fix the failing build