### PR TITLE
Eslint SX: improve error nodes location

### DIFF
--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-relay": "^1.8.1",
-    "eslint-plugin-sx": "^0.3.0",
+    "eslint-plugin-sx": "^0.4.0",
     "prettier": "^2.1.2"
   },
   "devDependencies": {

--- a/src/eslint-plugin-sx/package.json
+++ b/src/eslint-plugin-sx/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-sx",
   "description": "Eslint plugin for @adeira/sx",
   "homepage": "https://github.com/adeira/universe/tree/master/src/eslint-plugin-sx",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "private": false,
   "keywords": [
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@adeira/flow-types-eslint": "0.0.0",
     "@adeira/js": "^1.3.0",
+    "@babel/code-frame": "^7.10.4",
     "eslint": "^7.1.0",
     "jest-docblock": "^26.0.0"
   },

--- a/src/eslint-plugin-sx/src/rules/__tests__/__snapshots__/no-unused-stylesheet.test.js.snap
+++ b/src/eslint-plugin-sx/src/rules/__tests__/__snapshots__/no-unused-stylesheet.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reports correct lines and columns: SX function "styles" was not used anywhere in the "className" JSX attribute. 1`] = `
+"  1 | 
+  2 | import * as sx from '@adeira/sx';
+> 3 | const styles = sx.create({
+    |       ^^^^^^^^^^^^^^^^^^^^
+> 4 |   aaa: {
+    | ^^^^^^^^
+> 5 |     color: blue,
+    | ^^^^^^^^
+> 6 |   }
+    | ^^^^^^^^
+> 7 | });
+    | ^^^
+  8 | "
+`;
+
+exports[`reports correct lines and columns: Unknown stylesheet used: bbb (not defined anywhere) 1`] = `
+"  2 | import * as sx from '@adeira/sx';
+  3 | export default function TestComponent() {
+> 4 |   return <div className={styles('bbb')} />
+    |                                 ^^^^^
+  5 | }
+  6 | const styles = sx.create({
+  7 |   aaa: { color: blue }"
+`;
+
+exports[`reports correct lines and columns: Unused stylesheet: aaa (defined via "styles" variable) 1`] = `
+"  2 | import * as sx from '@adeira/sx';
+  3 | const styles = sx.create({
+> 4 |   aaa: {
+    |   ^^^^^^
+> 5 |     color: blue,
+    | ^^^^^^^^^^^^^^^^
+> 6 |   }
+    | ^^^^
+  7 | });
+  8 | "
+`;
+
+exports[`reports correct lines and columns: Unused stylesheet: aaa (defined via "styles" variable) 2`] = `
+"  5 | }
+  6 | const styles = sx.create({
+> 7 |   aaa: { color: blue }
+    |   ^^^^^^^^^^^^^^^^^^^^
+  8 | });
+  9 | "
+`;

--- a/src/eslint-plugin-sx/src/rules/__tests__/__snapshots__/normalizeIndent.test.js.snap
+++ b/src/eslint-plugin-sx/src/rules/__tests__/__snapshots__/normalizeIndent.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`normalizes indent correctly 1`] = `
+"
+import * as sx from '@adeira/sx';
+const styles = sx.create({
+  aaa: {
+    color: blue,
+  }
+});
+"
+`;

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/sx-multiple-definitions.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/sx-multiple-definitions.js
@@ -1,7 +1,7 @@
 /**
  * @flow
- * @eslintExpectedError Unused stylesheet: bbb (defined via "foo" variable)
  * @eslintExpectedError Unused stylesheet: aaa (defined via "bar" variable)
+ * @eslintExpectedError Unused stylesheet: bbb (defined via "foo" variable)
  */
 
 import type { Node } from 'react';

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/unknown-stylesheet.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/unknown-stylesheet.js
@@ -1,7 +1,7 @@
 /**
  * @flow
- * @eslintExpectedError Unused stylesheet: aaa (defined via "styles" variable)
  * @eslintExpectedError Unknown stylesheet used: yadada (not defined anywhere)
+ * @eslintExpectedError Unused stylesheet: aaa (defined via "styles" variable)
  */
 
 import type { Node } from 'react';

--- a/src/eslint-plugin-sx/src/rules/__tests__/no-unused-stylesheet.test.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/no-unused-stylesheet.test.js
@@ -1,15 +1,97 @@
 // @flow
 
 import path from 'path';
+import { RuleTester } from 'eslint';
+import { codeFrameColumns } from '@babel/code-frame';
 
+import normalizeIndent from './normalizeIndent';
 import testFixtures from './testFixtures';
 
 const fixturesPath = path.join(__dirname, 'fixtures', 'no-unused-stylesheet');
 const validFixturesPath = path.join(fixturesPath, 'valid');
 const invalidFixturesPath = path.join(fixturesPath, 'invalid');
 
+const rule = require('../no-unused-stylesheet');
+
 testFixtures({
-  rule: require('../no-unused-stylesheet'),
+  rule,
   validFixturesPath,
   invalidFixturesPath,
+});
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+});
+
+// This test makes sure we are reporting correct lines and columns:
+const invalidTests = [
+  {
+    code: normalizeIndent`
+      import * as sx from '@adeira/sx';
+      const styles = sx.create({
+        aaa: {
+          color: blue,
+        }
+      });
+    `,
+    errors: [
+      {
+        message: 'SX function "styles" was not used anywhere in the "className" JSX attribute.',
+        line: 3,
+        column: 7,
+        endLine: 7,
+        endColumn: 3,
+      },
+      {
+        message: 'Unused stylesheet: aaa (defined via "styles" variable)',
+        line: 4,
+        column: 3,
+        endLine: 6,
+        endColumn: 4,
+      },
+    ],
+  },
+  {
+    code: normalizeIndent`
+      import * as sx from '@adeira/sx';
+      export default function TestComponent() {
+        return <div className={styles('bbb')} />
+      }
+      const styles = sx.create({
+        aaa: { color: blue }
+      });
+    `,
+    errors: [
+      {
+        message: 'Unknown stylesheet used: bbb (not defined anywhere)',
+        line: 4,
+        column: 33,
+        endLine: 4,
+        endColumn: 38,
+      },
+      {
+        message: 'Unused stylesheet: aaa (defined via "styles" variable)',
+        line: 7,
+        column: 3,
+        endLine: 7,
+        endColumn: 23,
+      },
+    ],
+  },
+];
+
+ruleTester.run('no-unused-stylesheet', rule, {
+  valid: [],
+  invalid: invalidTests,
+});
+
+test.each(invalidTests)('reports correct lines and columns', (test) => {
+  for (const error of test.errors) {
+    expect(
+      codeFrameColumns(test.code, {
+        start: { line: error.line, column: error.column },
+        end: { line: error.endLine, column: error.endColumn },
+      }),
+    ).toMatchSnapshot(error.message);
+  }
 });

--- a/src/eslint-plugin-sx/src/rules/__tests__/normalizeIndent.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/normalizeIndent.js
@@ -1,0 +1,7 @@
+// @flow strict
+
+export default function normalizeIndent(strings: $ReadOnlyArray<string>): string {
+  const codeLines = strings[0].split('\n');
+  const leftPadding = codeLines[1].match(/\s+/)?.[0] ?? '';
+  return codeLines.map((line) => line.substr(leftPadding.length)).join('\n');
+}

--- a/src/eslint-plugin-sx/src/rules/__tests__/normalizeIndent.test.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/normalizeIndent.test.js
@@ -1,0 +1,14 @@
+// @flow strict
+
+import normalizeIndent from './normalizeIndent';
+
+it('normalizes indent correctly', () => {
+  expect(normalizeIndent`
+    import * as sx from '@adeira/sx';
+    const styles = sx.create({
+      aaa: {
+        color: blue,
+      }
+    });
+  `).toMatchSnapshot();
+});


### PR DESCRIPTION
Previously, we were reporting the errors with 'Program' node which resulted in the whole file being marked as errored. That's a bad practice since you need to go and search for the actual error location. This commit improves the behavior by reporting the errors with relevant nodes. This results in much better error location reporting.