### PR TITLE
relay-example: Fix typo in node-version matrix.

### DIFF
--- a/src/example-relay/__github__/.github/workflows/continuous-integration.yml
+++ b/src/example-relay/__github__/.github/workflows/continuous-integration.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 15x]
+        node-version: [14.x, 15.x]
 
     # TODO: lint
     steps:


### PR DESCRIPTION
It ended up being 15x instead of 15.x