### PR TITLE
SX: Release version 0.20.0

### DIFF
--- a/src/eslint-plugin-sx/package.json
+++ b/src/eslint-plugin-sx/package.json
@@ -22,6 +22,6 @@
     "jest-docblock": "^26.0.0"
   },
   "peerDependencies": {
-    "@adeira/sx": "^0.19.0"
+    "@adeira/sx": "^0.20.0"
   }
 }

--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -13,7 +13,7 @@
     "@adeira/relay": "^2.1.0",
     "@adeira/relay-runtime": "^0.17.0",
     "@adeira/relay-utils": "0.11.0",
-    "@adeira/sx": "^0.19.0",
+    "@adeira/sx": "^0.20.0",
     "@adeira/test-utils": "^0.6.0",
     "@artsy/fresnel": "^1.3.0",
     "apollo-server-micro": "^2.19.0",

--- a/src/sx-tailwind-website/package.json
+++ b/src/sx-tailwind-website/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@adeira/js": "^1.2.4",
     "@adeira/monorepo-utils": "^0.9.0",
-    "@adeira/sx": "^0.19.0",
+    "@adeira/sx": "^0.20.0",
     "@adeira/sx-tailwind": "^0.7.0",
     "next": "^10.0.1",
     "next-plugin-custom-babel-config": "^1.0.4",

--- a/src/sx-tailwind/package.json
+++ b/src/sx-tailwind/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@adeira/js": "^1.3.0",
     "@adeira/signed-source": "^1.0.0",
-    "@adeira/sx": "^0.19.0",
+    "@adeira/sx": "^0.20.0",
     "@babel/runtime": "^7.12.5",
     "change-case": "^4.1.1",
     "css-tree": "^1.0.1",

--- a/src/sx/package.json
+++ b/src/sx/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/sx",
   "license": "MIT",
   "private": false,
-  "version": "0.19.0",
+  "version": "0.20.0",
   "main": "index",
   "sideEffects": false,
   "module": false,


### PR DESCRIPTION
I found out runtime styles for animations does not work here:
https://sx-tailwind.adeira.dev/tailwind-css/animations

Release of a new version should fix this because the website works OK in the monorepo.