### PR TITLE
SX: fix shorthand expansion of `flex:1`

### DIFF
--- a/src/css-colors/src/isColor.js
+++ b/src/css-colors/src/isColor.js
@@ -60,7 +60,7 @@ function isHSLA(value: string): boolean %checks {
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
-export default function isColor(value: string): boolean {
+export default function isColor(value: string | number): boolean {
   if (typeof value !== 'string') {
     return false;
   }

--- a/src/sx/src/__tests__/expandShorthandProperties.test.js
+++ b/src/sx/src/__tests__/expandShorthandProperties.test.js
@@ -204,6 +204,12 @@ it('expands overflow as expected', () => {
 });
 
 it('expands flex as expected', () => {
+  expect(expandShorthandProperties('flex', 1).map(printNodes)).toMatchInlineSnapshot(`
+    Array [
+      "._1PiKJ8{flex:1}",
+    ]
+  `);
+
   // Keyword values
   expect(expandShorthandProperties('flex', 'auto').map(printNodes)).toMatchInlineSnapshot(`
     Array [

--- a/src/sx/src/expandShorthandProperties.js
+++ b/src/sx/src/expandShorthandProperties.js
@@ -41,7 +41,7 @@ import StyleCollectorNode from './StyleCollectorNode';
  */
 export default function expandShorthandProperties(
   propertyName: string,
-  propertyValue: any,
+  propertyValue: string | number,
   hashSeed: string = '',
 ): $ReadOnlyArray<StyleCollectorNode> {
   // https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#Background_Properties
@@ -138,7 +138,7 @@ export default function expandShorthandProperties(
   }
 
   // https://developer.mozilla.org/en-US/docs/Web/CSS/overflow
-  if (propertyName === 'overflow') {
+  if (propertyName === 'overflow' && typeof propertyValue === 'string') {
     // The `overflow` property is specified as one or two keywords. If two keywords are specified,
     // the first applies to `overflow-x` and the second to `overflow-y`. Otherwise, both `overflow-x`
     // and `overflow-y` are set to the same value.
@@ -156,7 +156,7 @@ export default function expandShorthandProperties(
   }
 
   // https://developer.mozilla.org/en-US/docs/Web/CSS/flex
-  if (propertyName === 'flex') {
+  if (propertyName === 'flex' && typeof propertyValue === 'string') {
     // Initial values:
     // - flex-grow: 0
     // - flex-shrink: 1


### PR DESCRIPTION
It was crashing becuase we were trying to split number into chunks. The type of the value was not accurate (`any`) so Flow could not catch it.