### PR TITLE
Eslint runner: release version 1.0.2

### DIFF
--- a/src/eslint-runner/package.json
+++ b/src/eslint-runner/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/eslint-runner",
   "license": "MIT",
   "private": false,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "index",
   "sideEffects": false,
   "dependencies": {


### PR DESCRIPTION
There is a minor fix which I think is worth releasing since no other changes are planned (it could take a while before we release a new version naturally).