### PR TITLE
SX: change imports/exports to allow composability

### DIFF
--- a/src/babel-plugin-transform-sx-tailwind/README.md
+++ b/src/babel-plugin-transform-sx-tailwind/README.md
@@ -7,7 +7,7 @@ This has a positive impact on the final bundle size because the huge Tailwind de
 ```diff
 import React from 'react';
 - import { tailwind } from '@adeira/sx-tailwind';
-+ import * as sx from '@adeira/sx';
++ import sx from '@adeira/sx';
 
 export default function Example() {
   return (

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/__snapshots__/index.test.js.snap
@@ -24,7 +24,7 @@ export default function Example(): Node {
 
 // @flow
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Node {
   return (
     <span className={__styles_3xIUAp('flex', 'h-3', 'w-3')}>
@@ -127,7 +127,7 @@ export default function Example(): Node {
 
 // @flow
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Node {
   return (
     <>
@@ -186,7 +186,7 @@ export default function Example(): Node {
 
 // @flow
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Node {
   return (
     <div className={__styles_BKbxA('text-white', 'bg-black')}>
@@ -272,7 +272,7 @@ const styles = 'Here I am';
 
 // @flow
 import type { Element } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Element<'button'> {
   return (
     <button
@@ -315,7 +315,7 @@ exports[`transform SX Tailwind sx-already-imported.js: sx-already-imported.js 1`
 
 import type { Node } from 'react';
 import { tailwind } from '@adeira/sx-tailwind';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function Example(): Node {
   return (
@@ -341,7 +341,7 @@ const styles = sx.create({
 
 // @flow
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Node {
   return (
     <div>
@@ -416,7 +416,7 @@ const styles = create({
 
 // @flow
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 import { create } from '@adeira/sx';
 export default function Example(): Node {
   return (
@@ -490,7 +490,7 @@ export default function Example(): Element<'button'> {
 
 // @flow
 import type { Element } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Element<'button'> {
   return (
     <button
@@ -574,7 +574,7 @@ export default function Example(): Element<'button'> {
 
 // @flow
 import type { Element } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Element<'button'> {
   return (
     <button
@@ -659,7 +659,7 @@ export default function Example(): Node {
 
 // @flow
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Node {
   return (
     <>
@@ -742,7 +742,7 @@ export default function Example(): Element<'button'> {
 
 // @flow
 import type { Element } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Element<'button'> {
   return (
     <button
@@ -799,7 +799,7 @@ export default function Example(): Element<'button'> {
 
 // @flow
 import type { Element } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Element<'button'> {
   return (
     <button
@@ -849,7 +849,7 @@ export default function Example(): Node {
 
 // @flow
 import React, { type Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Node {
   return <div className={__styles_3noU6Y('text-black', 'bg-white')}>Lorem lipsum</div>;
 }
@@ -892,7 +892,7 @@ export default function Example(): Node {
 
 // @flow
 import React, { type Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Node {
   const darkMode = true;
   return (
@@ -947,7 +947,7 @@ exports[`transform SX Tailwind template-literal-expression.js: template-literal-
 
 import React, { type Node } from 'react';
 import { tailwind } from '@adeira/sx-tailwind';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function Example(): Node {
   return <div className={\`\${tailwind('px-4')} \${styles('customStyle')}\`}>Lorem lipsum</div>;
@@ -961,7 +961,7 @@ const styles = sx.create({
 
 // @flow
 import React, { type Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Node {
   return <div className={\`\${__styles_4ozVnl('px-4')} \${styles('customStyle')}\`}>Lorem lipsum</div>;
 }

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/sx-already-imported.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/sx-already-imported.js
@@ -2,7 +2,7 @@
 
 import type { Node } from 'react';
 import { tailwind } from '@adeira/sx-tailwind';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function Example(): Node {
   return (

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal-expression.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal-expression.js
@@ -2,7 +2,7 @@
 
 import React, { type Node } from 'react';
 import { tailwind } from '@adeira/sx-tailwind';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function Example(): Node {
   return <div className={`${tailwind('px-4')} ${styles('customStyle')}`}>Lorem lipsum</div>;

--- a/src/babel-plugin-transform-sx-tailwind/src/index.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/index.js
@@ -34,7 +34,7 @@ module.exports = function sxTailwindBabelPlugin() /*: any */ {
             }
           });
 
-          const sxImport = template.ast(`import * as sx from '@adeira/sx'`);
+          const sxImport = template.ast(`import sx from '@adeira/sx'`);
           path.replaceWith(sxImport);
         }
       },
@@ -100,7 +100,7 @@ module.exports = function sxTailwindBabelPlugin() /*: any */ {
               type === 'ImportDeclaration' &&
               source.value === '@adeira/sx' &&
               Array.isArray(specifiers) &&
-              specifiers[0].type === 'ImportNamespaceSpecifier'
+              specifiers[0].type === 'ImportDefaultSpecifier'
             ) {
               a.push(index);
             }

--- a/src/eslint-plugin-sx/docs/rules/no-unused-stylesheet.md
+++ b/src/eslint-plugin-sx/docs/rules/no-unused-stylesheet.md
@@ -7,7 +7,7 @@ This rule aims to find unused SX stylesheet definitions.
 Examples of **incorrect** code for this rule:
 
 ```jsx
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent() {
   return null;
@@ -20,7 +20,7 @@ const styles = sx.create({
 ```
 
 ```jsx
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent() {
   return <div className={styles('aaa')} />;
@@ -36,7 +36,7 @@ const styles = sx.create({
 Examples of **correct** code for this rule:
 
 ```jsx
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent() {
   return <div className={styles('aaa')} />;

--- a/src/eslint-plugin-sx/package.json
+++ b/src/eslint-plugin-sx/package.json
@@ -23,6 +23,6 @@
     "jest-docblock": "^26.0.0"
   },
   "peerDependencies": {
-    "@adeira/sx": "^0.20.0"
+    "@adeira/sx": "^0.21.0"
   }
 }

--- a/src/eslint-plugin-sx/src/rules/__tests__/__snapshots__/no-unused-stylesheet.test.js.snap
+++ b/src/eslint-plugin-sx/src/rules/__tests__/__snapshots__/no-unused-stylesheet.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`reports correct lines and columns: SX function "styles" was not used anywhere in the "className" JSX attribute. 1`] = `
 "  1 | 
-  2 | import * as sx from '@adeira/sx';
+  2 | import sx from '@adeira/sx';
 > 3 | const styles = sx.create({
     |       ^^^^^^^^^^^^^^^^^^^^
 > 4 |   aaa: {
@@ -17,7 +17,7 @@ exports[`reports correct lines and columns: SX function "styles" was not used an
 `;
 
 exports[`reports correct lines and columns: Unknown stylesheet used: bbb (not defined anywhere) 1`] = `
-"  2 | import * as sx from '@adeira/sx';
+"  2 | import sx from '@adeira/sx';
   3 | export default function TestComponent() {
 > 4 |   return <div className={styles('bbb')} />
     |                                 ^^^^^
@@ -27,7 +27,7 @@ exports[`reports correct lines and columns: Unknown stylesheet used: bbb (not de
 `;
 
 exports[`reports correct lines and columns: Unused stylesheet: aaa (defined via "styles" variable) 1`] = `
-"  2 | import * as sx from '@adeira/sx';
+"  2 | import sx from '@adeira/sx';
   3 | const styles = sx.create({
 > 4 |   aaa: {
     |   ^^^^^^

--- a/src/eslint-plugin-sx/src/rules/__tests__/__snapshots__/normalizeIndent.test.js.snap
+++ b/src/eslint-plugin-sx/src/rules/__tests__/__snapshots__/normalizeIndent.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`normalizes indent correctly 1`] = `
 "
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 const styles = sx.create({
   aaa: {
     color: blue,

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-concatenated-classes/invalid/custom-sx-names.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-concatenated-classes/invalid/custom-sx-names.js
@@ -4,7 +4,7 @@
  */
 
 import type { Node } from 'react';
-import * as tada from '@adeira/sx';
+import tada from '@adeira/sx';
 
 export default function MyComponent(): Node {
   // Should be:

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/issue-1323.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/issue-1323.js
@@ -6,7 +6,7 @@
  * @see https://github.com/adeira/universe/pull/1323
  */
 
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 import type { Node } from 'react'; // keep the import order exactly like this (first SX, second React)
 
 export default function Navbar(): Node {

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/unknown-stylesheet.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/unknown-stylesheet.js
@@ -5,7 +5,7 @@
  */
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent(): Node {
   // $FlowExpectedError[incompatible-call] - yadada is not defined in the stylesheet below

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/unused-stylesheet.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/unused-stylesheet.js
@@ -5,7 +5,7 @@
  */
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent(): Node {
   return <div className={styles('aaa')} />;

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/unused-sx-multiple.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/unused-sx-multiple.js
@@ -7,7 +7,7 @@
  */
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent(): Node {
   return <div className={styles2('bbb')} />;

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/unused-sx-not-className.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/unused-sx-not-className.js
@@ -5,7 +5,7 @@
  */
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function Navbar(): Node {
   // "styles" is essentially unused here since it's not used in "className"

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/unused-sx.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/invalid/unused-sx.js
@@ -5,7 +5,7 @@
  */
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent(): Node {
   return null;

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/valid/react-component-unused-sx.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/valid/react-component-unused-sx.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { Node } from 'react';
-import * as tada from '@adeira/sx'; // eslint-disable-line no-unused-vars
+import tada from '@adeira/sx'; // eslint-disable-line no-unused-vars
 
 export default function MyComponent(): Node {
   return styles('ok');

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/valid/sx-namespace-import.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/valid/sx-namespace-import.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { Node } from 'react';
-import * as tada from '@adeira/sx';
+import tada from '@adeira/sx';
 
 export default function MyComponent(): Node {
   return <div className={styles('aaa')} />;

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-empty-argument.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-empty-argument.js
@@ -4,7 +4,7 @@
  */
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent(): Node {
   // $FlowExpectedError[incompatible-call] wrong on purpose (see below)

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-invalid-argument.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-invalid-argument.js
@@ -4,7 +4,7 @@
  */
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent(): Node {
   // $FlowExpectedError[incompatible-call] for testing purposes

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-invalid-stylesheet-type.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-invalid-stylesheet-type.js
@@ -4,7 +4,7 @@
  */
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent(): Node {
   return <div className={styles('aaa')} />;

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-keyframes-empty-argument.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-keyframes-empty-argument.js
@@ -4,7 +4,7 @@
  */
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent(): Node {
   return <div className={styles('aaa')} />;

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-keyframes-invalid-argument.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-keyframes-invalid-argument.js
@@ -4,7 +4,7 @@
  */
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent(): Node {
   return <div className={styles('aaa')} />;

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-keyframes-invalid-stylesheet-type.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-keyframes-invalid-stylesheet-type.js
@@ -4,7 +4,7 @@
  */
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent(): Node {
   return <div className={styles('aaa')} />;

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-keyframes-too-many-arguments.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-keyframes-too-many-arguments.js
@@ -4,7 +4,7 @@
  */
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent(): Node {
   return <div className={styles('aaa')} />;

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-too-many-arguments.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/invalid/sx-too-many-arguments.js
@@ -4,7 +4,7 @@
  */
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent(): Node {
   return <div className={styles('aaa')} />;

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/valid/basic.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/valid/basic.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function MyComponent(): Node {
   return <div className={styles('aaa')} />;

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/valid/sx-keyframes.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/valid-usage/valid/sx-keyframes.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export function AnimatedComponent(): Node {
   return (

--- a/src/eslint-plugin-sx/src/rules/__tests__/no-unused-stylesheet.test.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/no-unused-stylesheet.test.js
@@ -27,7 +27,7 @@ const ruleTester = new RuleTester({
 const invalidTests = [
   {
     code: normalizeIndent`
-      import * as sx from '@adeira/sx';
+      import sx from '@adeira/sx';
       const styles = sx.create({
         aaa: {
           color: blue,
@@ -53,7 +53,7 @@ const invalidTests = [
   },
   {
     code: normalizeIndent`
-      import * as sx from '@adeira/sx';
+      import sx from '@adeira/sx';
       export default function TestComponent() {
         return <div className={styles('bbb')} />
       }

--- a/src/eslint-plugin-sx/src/rules/__tests__/normalizeIndent.test.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/normalizeIndent.test.js
@@ -4,7 +4,7 @@ import normalizeIndent from './normalizeIndent';
 
 it('normalizes indent correctly', () => {
   expect(normalizeIndent`
-    import * as sx from '@adeira/sx';
+    import sx from '@adeira/sx';
     const styles = sx.create({
       aaa: {
         color: blue,

--- a/src/eslint-plugin-sx/src/rules/no-concatenated-classes.js
+++ b/src/eslint-plugin-sx/src/rules/no-concatenated-classes.js
@@ -25,9 +25,9 @@ const isSXVariableDeclarator = require('./utils/isSXVariableDeclarator');
  */
 module.exports = ({
   create: function (context) {
-    // import * as sx from '@adeira/sx'
-    //             ^^
-    let importNamespaceSpecifier = null;
+    // import sx from '@adeira/sx'
+    //        ^^
+    let importDefaultSpecifier = null;
 
     // import { create as sxCreate } from '@adeira/sx';
     //                    ^^^^^^^^
@@ -43,17 +43,17 @@ module.exports = ({
       'ImportDeclaration'(node) {
         const importSpecifiers = getSXImportSpecifiers(node);
         if (importSpecifiers !== null) {
-          importNamespaceSpecifier = importSpecifiers.importNamespaceSpecifier;
+          importDefaultSpecifier = importSpecifiers.importDefaultSpecifier;
           importSpecifierCreate = importSpecifiers.importSpecifierCreate;
         }
       },
       'VariableDeclarator'(node) {
-        if (isSXVariableDeclarator(node, importNamespaceSpecifier, importSpecifierCreate)) {
+        if (isSXVariableDeclarator(node, importDefaultSpecifier, importSpecifierCreate)) {
           sxFunctionName = node.id.name;
         }
       },
       'JSXExpressionContainer'(node) {
-        if (importNamespaceSpecifier == null && importSpecifierCreate == null) {
+        if (importDefaultSpecifier == null && importSpecifierCreate == null) {
           // not in an @adeira/sx scope, early exit
           return;
         }

--- a/src/eslint-plugin-sx/src/rules/no-unused-stylesheet.js
+++ b/src/eslint-plugin-sx/src/rules/no-unused-stylesheet.js
@@ -12,9 +12,9 @@ const isSXVariableDeclarator = require('./utils/isSXVariableDeclarator');
  */
 module.exports = ({
   create: function (context) {
-    // import * as sx from '@adeira/sx'
-    //             ^^
-    let importNamespaceSpecifier = null;
+    // import sx from '@adeira/sx'
+    //        ^^
+    let importDefaultSpecifier = null;
 
     // import { create as sxCreate } from '@adeira/sx';
     //                    ^^^^^^^^
@@ -37,7 +37,7 @@ module.exports = ({
       'ImportDeclaration'(node) {
         const importSpecifiers = getSXImportSpecifiers(node);
         if (importSpecifiers !== null) {
-          importNamespaceSpecifier = importSpecifiers.importNamespaceSpecifier;
+          importDefaultSpecifier = importSpecifiers.importDefaultSpecifier;
           importSpecifierCreate = importSpecifiers.importSpecifierCreate;
         }
       },
@@ -46,7 +46,7 @@ module.exports = ({
       //       ^^^^^^^^^^^^^^^^^^^^^^
       //       | id |
       'VariableDeclarator'(node) {
-        if (isSXVariableDeclarator(node, importNamespaceSpecifier, importSpecifierCreate)) {
+        if (isSXVariableDeclarator(node, importDefaultSpecifier, importSpecifierCreate)) {
           const initArguments = (node.init && node.init.arguments) || [];
           const firstArgument = initArguments[0];
           const firstArgumentProperties = (firstArgument && firstArgument.properties) || [];

--- a/src/eslint-plugin-sx/src/rules/utils/getSXImportSpecifiers.js
+++ b/src/eslint-plugin-sx/src/rules/utils/getSXImportSpecifiers.js
@@ -5,7 +5,7 @@
 import type { ImportDeclaration } from '@adeira/flow-types-eslint';
 
 type ReturnType = {|
-  +importNamespaceSpecifier: null | string,
+  +importDefaultSpecifier: null | string,
   +importSpecifierCreate: null | string,
   +importSpecifierKeyframes: null | string,
 |};
@@ -15,9 +15,9 @@ type ReturnType = {|
 module.exports = function getSXImportSpecifiers(
   node /*: ImportDeclaration */,
 ) /*: ReturnType | null */ {
-  // import * as sx from '@adeira/sx'
-  //             ^^
-  let importNamespaceSpecifier = null;
+  // import sx from '@adeira/sx'
+  //        ^^
+  let importDefaultSpecifier = null;
 
   // import { create as sxCreate } from '@adeira/sx';
   //                    ^^^^^^^^
@@ -32,10 +32,10 @@ module.exports = function getSXImportSpecifiers(
   }
 
   for (const specifier of node.specifiers) {
-    if (specifier.type === 'ImportNamespaceSpecifier') {
-      // import * as sx from '@adeira/sx'
-      // import * as tada from '@adeira/sx'
-      importNamespaceSpecifier = specifier.local.name; // "sx" or "tada"
+    if (specifier.type === 'ImportDefaultSpecifier') {
+      // import sx from '@adeira/sx'
+      // import tada from '@adeira/sx'
+      importDefaultSpecifier = specifier.local.name; // "sx" or "tada"
     } else if (specifier.type === 'ImportSpecifier' && specifier.imported.name === 'create') {
       // import { create } from '@adeira/sx';
       // import { create as sxCreate } from '@adeira/sx';
@@ -48,7 +48,7 @@ module.exports = function getSXImportSpecifiers(
   }
 
   return {
-    importNamespaceSpecifier,
+    importDefaultSpecifier,
     importSpecifierCreate,
     importSpecifierKeyframes,
   };

--- a/src/eslint-plugin-sx/src/rules/utils/getVariableDeclaratorCalleeName.js
+++ b/src/eslint-plugin-sx/src/rules/utils/getVariableDeclaratorCalleeName.js
@@ -6,12 +6,12 @@ import type { VariableDeclarator } from '@adeira/flow-types-eslint';
 
 module.exports = function getVariableDeclaratorCalleeName(
   node /*: VariableDeclarator */,
-  importNamespaceSpecifier /*: string | null */,
+  importDefaultSpecifier /*: string | null */,
 ) /*: string | null */ {
   if (node.init != null && node.init.type === 'CallExpression' && node.init.callee) {
     if (
       node.init.callee.object &&
-      node.init.callee.object.name === importNamespaceSpecifier // "sx" in sx.create({})
+      node.init.callee.object.name === importDefaultSpecifier // "sx" in sx.create({})
     ) {
       return node.init.callee.property.name; // "create" in sx.create({})
     }

--- a/src/eslint-plugin-sx/src/rules/utils/isSXKeyframesVariableDeclarator.js
+++ b/src/eslint-plugin-sx/src/rules/utils/isSXKeyframesVariableDeclarator.js
@@ -6,7 +6,7 @@ import type { VariableDeclarator } from '@adeira/flow-types-eslint';
 
 module.exports = function isSXKeyframesVariableDeclarator(
   node /*: VariableDeclarator */,
-  importNamespaceSpecifier /*: string | null */,
+  importDefaultSpecifier /*: string | null */,
   importSpecifier /*: string | null */,
 ) /*: boolean */ {
   return (
@@ -15,7 +15,7 @@ module.exports = function isSXKeyframesVariableDeclarator(
     node.init.callee &&
     node.init.arguments &&
     ((node.init.callee.object &&
-      node.init.callee.object.name === importNamespaceSpecifier && // "sx" in sx.keyframes({})
+      node.init.callee.object.name === importDefaultSpecifier && // "sx" in sx.keyframes({})
       node.init.callee.property &&
       node.init.callee.property.name === 'keyframes') || // "keyframes" in sx.keyframes({})
       node.init.callee.name === importSpecifier) // "sxKeyframes" in sxKeyframes({})

--- a/src/eslint-plugin-sx/src/rules/utils/isSXVariableDeclarator.js
+++ b/src/eslint-plugin-sx/src/rules/utils/isSXVariableDeclarator.js
@@ -6,7 +6,7 @@ import type { VariableDeclarator } from '@adeira/flow-types-eslint';
 
 module.exports = function isSXVariableDeclarator(
   node /*: VariableDeclarator */,
-  importNamespaceSpecifier /*: string | null */,
+  importDefaultSpecifier /*: string | null */,
   importSpecifier /*: string | null */,
 ) /*: boolean */ {
   return (
@@ -15,7 +15,7 @@ module.exports = function isSXVariableDeclarator(
     node.init.callee &&
     node.init.arguments &&
     ((node.init.callee.object &&
-      node.init.callee.object.name === importNamespaceSpecifier && // "sx" in sx.create({})
+      node.init.callee.object.name === importDefaultSpecifier && // "sx" in sx.create({})
       node.init.callee.property &&
       node.init.callee.property.name === 'create') || // "create" in sx.create({})
       node.init.callee.name === importSpecifier) // "sxCreate" in sxCreate({})

--- a/src/eslint-plugin-sx/src/rules/valid-usage.js
+++ b/src/eslint-plugin-sx/src/rules/valid-usage.js
@@ -14,9 +14,9 @@ const getVariableDeclaratorCalleeName = require('./utils/getVariableDeclaratorCa
  */
 module.exports = ({
   create: function (context) {
-    // import * as sx from '@adeira/sx'
-    //             ^^
-    let importNamespaceSpecifier = null;
+    // import sx from '@adeira/sx'
+    //        ^^
+    let importDefaultSpecifier = null;
 
     // import { create as sxCreate } from '@adeira/sx';
     //                    ^^^^^^^^
@@ -31,7 +31,7 @@ module.exports = ({
       ImportDeclaration(node) {
         const importSpecifiers = getSXImportSpecifiers(node);
         if (importSpecifiers !== null) {
-          importNamespaceSpecifier = importSpecifiers.importNamespaceSpecifier;
+          importDefaultSpecifier = importSpecifiers.importDefaultSpecifier;
           importSpecifierCreate = importSpecifiers.importSpecifierCreate;
           importSpecifierKeyframes = importSpecifiers.importSpecifierKeyframes;
         }
@@ -43,11 +43,11 @@ module.exports = ({
       VariableDeclarator(node) {
         if (
           // "sx.create" and "sx.keyframes" are essentially the same from the validation point of view
-          isSXVariableDeclarator(node, importNamespaceSpecifier, importSpecifierCreate) ||
-          isSXKeyframesVariableDeclarator(node, importNamespaceSpecifier, importSpecifierKeyframes)
+          isSXVariableDeclarator(node, importDefaultSpecifier, importSpecifierCreate) ||
+          isSXKeyframesVariableDeclarator(node, importDefaultSpecifier, importSpecifierKeyframes)
         ) {
           const initArguments = (node.init && node.init.arguments) || [];
-          const calleeName = getVariableDeclaratorCalleeName(node, importNamespaceSpecifier);
+          const calleeName = getVariableDeclaratorCalleeName(node, importDefaultSpecifier);
 
           if (initArguments.length > 1) {
             context.report({

--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -13,7 +13,7 @@
     "@adeira/relay": "^2.1.0",
     "@adeira/relay-runtime": "^0.17.0",
     "@adeira/relay-utils": "0.11.0",
-    "@adeira/sx": "^0.20.0",
+    "@adeira/sx": "^0.21.0",
     "@adeira/test-utils": "^0.6.0",
     "@artsy/fresnel": "^1.3.0",
     "apollo-server-micro": "^2.19.0",

--- a/src/example-relay/src/Homepage/index.js
+++ b/src/example-relay/src/Homepage/index.js
@@ -2,7 +2,7 @@
 
 import type { Node } from 'react';
 import { graphql, QueryRenderer } from '@adeira/relay';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 import LocationsPaginatedBidirectional from './locations/LocationsPaginatedBidirectional';
 import LocationsPaginatedRefetch from './locations/LocationsPaginatedRefetch';

--- a/src/example-relay/src/Homepage/locations/Location.js
+++ b/src/example-relay/src/Homepage/locations/Location.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { createFragmentContainer, graphql, type FragmentContainerType } from '@adeira/relay';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 import Image from 'next/image';
 
 import type { Location_location as LocationDataType } from './__generated__/Location_location.graphql';

--- a/src/example-relay/src/Homepage/locations/LocationsList.js
+++ b/src/example-relay/src/Homepage/locations/LocationsList.js
@@ -1,7 +1,7 @@
 // @flow strict-local
 
 import { Children, cloneElement, type Element, type ChildrenArray, type Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 import Location from './Location';
 

--- a/src/example-relay/src/Homepage/locations/LocationsPaginatedBidirectional.js
+++ b/src/example-relay/src/Homepage/locations/LocationsPaginatedBidirectional.js
@@ -8,7 +8,7 @@ import {
   type RefetchContainerType,
 } from '@adeira/relay';
 import { MdChevronLeft, MdChevronRight } from 'react-icons/md';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 import Location from './Location';
 import type { LocationsPaginatedBidirectional_data as LocationsDataType } from './__generated__/LocationsPaginatedBidirectional_data.graphql';

--- a/src/example-relay/src/LocalForm/index.js
+++ b/src/example-relay/src/LocalForm/index.js
@@ -9,7 +9,7 @@ import {
 } from '@adeira/relay';
 // FIXME:
 import { generateClientID } from 'relay-runtime'; // eslint-disable-line import/no-extraneous-dependencies
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 import type { LocalFormQueryResponse } from './__generated__/LocalFormQuery.graphql';
 import Heading from '../components/Heading';

--- a/src/example-relay/src/SSRLocations/LocationsQuery.js
+++ b/src/example-relay/src/SSRLocations/LocationsQuery.js
@@ -2,7 +2,7 @@
 
 import type { Node } from 'react';
 import { graphql, type RecordMap, type GraphQLTaggedNode } from '@adeira/relay';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 import QueryRenderer from '../SSRQueryRenderer';
 import type { LocationsQueryResponse } from './__generated__/LocationsQuery.graphql';

--- a/src/example-relay/src/components/Button.js
+++ b/src/example-relay/src/components/Button.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 type Props = {|
   +onClick?: () => void,

--- a/src/example-relay/src/components/Heading.js
+++ b/src/example-relay/src/components/Heading.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 type Props = {|
   +level: 1 | 2 | 3 | 4 | 5 | 6,

--- a/src/example-relay/src/components/Navbar.js
+++ b/src/example-relay/src/components/Navbar.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { useState, useEffect, type ComponentType, type Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 import { MdMenu } from 'react-icons/md';
 import Link from 'next/link';
 import { CSSTransition } from 'react-transition-group';

--- a/src/example-relay/src/components/Select.js
+++ b/src/example-relay/src/components/Select.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { useState, type Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 import { MdExpandMore } from 'react-icons/md';
 
 import Text from './Text';

--- a/src/example-relay/src/components/Text.js
+++ b/src/example-relay/src/components/Text.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 type Props = {|
   +size?: 'small' | 'normal',

--- a/src/example-relay/src/components/TextInput.js
+++ b/src/example-relay/src/components/TextInput.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 import Text from './Text';
 

--- a/src/example-relay/src/mutations/LocationsList.js
+++ b/src/example-relay/src/mutations/LocationsList.js
@@ -3,7 +3,7 @@
 import type { Node } from 'react';
 import { createFragmentContainer, graphql, type FragmentContainerType } from '@adeira/relay';
 import { TransitionGroup } from 'react-transition-group';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 import type { LocationsList_data as Data } from './__generated__/LocationsList_data.graphql';
 import FadeIn from './FadeIn';

--- a/src/example-relay/src/mutations/RangeAdd/LocationsForm.js
+++ b/src/example-relay/src/mutations/RangeAdd/LocationsForm.js
@@ -4,7 +4,7 @@
 
 import { useState, type ComponentType } from 'react';
 import { graphql, useMutation } from '@adeira/relay';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 import type { LocationsFormMutation } from './__generated__/LocationsFormMutation.graphql';
 import TextInput from '../../components/TextInput';

--- a/src/example-relay/src/pages/_app.js
+++ b/src/example-relay/src/pages/_app.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { Node } from 'react';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 import App from 'next/app';
 import Head from 'next/head';
 import Router from 'next/router';

--- a/src/example-relay/src/pages/_document.js
+++ b/src/example-relay/src/pages/_document.js
@@ -2,7 +2,7 @@
 
 import type { Node, Element } from 'react';
 import Document, { Head, Main, NextScript, type DocumentContext } from 'next/document';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 import { mediaStyles } from '../components/Media';
 

--- a/src/sx-tailwind-website/package.json
+++ b/src/sx-tailwind-website/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@adeira/js": "^1.2.4",
     "@adeira/monorepo-utils": "^0.9.0",
-    "@adeira/sx": "^0.20.0",
+    "@adeira/sx": "^0.21.0",
     "@adeira/sx-tailwind": "^0.9.0",
     "hast-util-to-html": "^7.1.2",
     "next": "^10.0.2",

--- a/src/sx-tailwind-website/src/pages/_document.js
+++ b/src/sx-tailwind-website/src/pages/_document.js
@@ -2,7 +2,7 @@
 
 import type { Node, Element } from 'react';
 import Document, { Head, Main, NextScript, type DocumentContext } from 'next/document';
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 type RenderPageResult = {|
   +html: string,

--- a/src/sx-tailwind/package.json
+++ b/src/sx-tailwind/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@adeira/js": "^1.3.0",
     "@adeira/signed-source": "^1.0.0",
-    "@adeira/sx": "^0.20.0",
+    "@adeira/sx": "^0.21.0",
     "@babel/runtime": "^7.12.5",
     "change-case": "^4.1.1",
     "css-tree": "^1.1.1",

--- a/src/sx-tailwind/src/sxTailwind.js
+++ b/src/sx-tailwind/src/sxTailwind.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 import { warning } from '@adeira/js';
 import levenshtein from 'fast-levenshtein';
 

--- a/src/sx/README.md
+++ b/src/sx/README.md
@@ -6,6 +6,7 @@ In conventional applications, CSS rules are duplicated throughout the stylesheet
   - [Pseudo CSS classes and elements](#pseudo-css-classes-and-elements)
   - [`@media` and `@supports`](#media-and-supports)
   - [Keyframes](#keyframes)
+  - [Composability and customizability](#composability-and-customizability)
   - [Precise Flow types](#precise-flow-types)
 - [Production usage considerations](#production-usage-considerations)
 - [Server-side rendering](#server-side-rendering)
@@ -29,7 +30,7 @@ yarn add --dev eslint-plugin-sx
 Create a stylesheet and use it to generate `className` props for React:
 
 ```jsx
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 
 export default function Example() {
   // className={styles('example')}
@@ -266,6 +267,39 @@ const simple = sx.keyframes({
 });
 ```
 
+### Composability and customizability
+
+SX supports composability with external styles. Have a look at this base component example (uses [Flow](https://github.com/facebook/flow) types):
+
+```flow js
+import sx, { type AllCSSPropertyTypes } from '@adeira/sx';
+
+type Props = {|
+  +xstyle: {|
+    +marginTop: number, // you can restrict what styles are customizable
+  |},
+  +ystyle?: AllCSSPropertyTypes, // or allow any style
+|};
+
+const styles = sx.create({ default: { fontSize: 16 } });
+
+function MyBaseComponent(props: Props) {
+  return <div className={sx(styles.default, props.xstyle)} />;
+}
+```
+
+Now, let's say we are building a design library and we want to affect the base styles externally. Here is how would our customized (wrapper) component look like:
+
+```flow js
+const styles = sx.create({ spacing: { marginTop: 4 } });
+
+function MyCustomComponent() {
+  return <MyBaseComponent xstyle={styles.spacing} />;
+}
+```
+
+Always prefer this style of customization instead of concatenating or prop-drilling external CSS classes in your components.
+
 ### Precise Flow types
 
 SX knows about almost every property or rule which exists in CSS and tries to help with mistakes when writing the styles.
@@ -298,7 +332,7 @@ _This is an optional part, `@adeira/sx` will work even without it. However, it's
 Example for Next.js with [custom document](https://nextjs.org/docs/advanced-features/custom-document):
 
 ```jsx
-import * as sx from '@adeira/sx';
+import sx from '@adeira/sx';
 import Document from 'next/document';
 
 export default class MyDocument extends Document {

--- a/src/sx/index.js
+++ b/src/sx/index.js
@@ -1,7 +1,49 @@
-// @flow
+/**
+ * Users of SX should be able to import it as follows:
+ *
+ *    import sx from '@adeira/sx';
+ *    sx(), sx.create(), sx.keyframes(), ...
+ *
+ * Alternatively:
+ *
+ *    import { create as sxCreate } from '@adeira/sx';
+ *    sxCreate(), ...
+ *
+ * @flow
+ */
 
 import create from './src/create';
 import keyframes from './src/keyframes';
 import renderPageWithSX from './src/renderPageWithSX';
 
+/**
+ * This function allows us to compose local and external styles like so:
+ *
+ * ```
+ * import sx from '@adeira/sx';
+ *
+ * const styles = sx.create({ default: { fontSize: 16 } });
+ * const externalStyles = sx.create({ spacing: { marginTop: 4 } });
+ *
+ * <div className={sx(styles.default, externalStyles.spacing)} />;
+ * ```
+ */
+function composeStylesheets(
+  stylesheetA: Map<string, string>,
+  stylesheetB: Map<string, string>,
+): string {
+  // Should we support deeply nested styles or leave it like this and overwrite them?
+  // Note: this is very similar what `styles('aaa', 'bbb')` does internally when merging.
+  const merged = new Map([...stylesheetA, ...stylesheetB]);
+  const classes = [...merged.values()];
+  const uniqueClasses = [...new Set(classes)];
+  return uniqueClasses.join(' ');
+}
+
+composeStylesheets.create = create;
+composeStylesheets.keyframes = keyframes;
+composeStylesheets.renderPageWithSX = renderPageWithSX;
+
 export { create, keyframes, renderPageWithSX };
+export default composeStylesheets;
+export type { AllCSSPropertyTypes } from './src/css-properties/__generated__/AllCSSPropertyTypes';

--- a/src/sx/package.json
+++ b/src/sx/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/sx",
   "license": "MIT",
   "private": false,
-  "version": "0.20.0",
+  "version": "0.21.0",
   "main": "index",
   "sideEffects": false,
   "module": false,

--- a/src/sx/src/StyleCollector.js
+++ b/src/sx/src/StyleCollector.js
@@ -16,7 +16,7 @@ import { type StyleCollectorNodeInterface } from './StyleCollectorNodeInterface'
 //     "color" => "c2",
 //   },
 // },
-type HashRegistryType = Map<string, Map<string, string>>;
+export type HashRegistryType = Map<string, Map<string, string>>;
 
 // "styleBuffer": Map {
 //   "c0" => StyleCollectorNode {

--- a/src/sx/src/__tests__/SxDomTests.test.js
+++ b/src/sx/src/__tests__/SxDomTests.test.js
@@ -6,7 +6,7 @@ import { normalizeColor } from '@adeira/css-colors';
 import { render, screen } from '@testing-library/react';
 import prettier from 'prettier';
 
-import * as sx from '../../index';
+import sx from '../../index';
 import collector from '../StyleCollector';
 
 afterEach(() => {

--- a/src/sx/src/__tests__/composability.test.js
+++ b/src/sx/src/__tests__/composability.test.js
@@ -1,0 +1,92 @@
+// @flow
+
+/* global document */
+
+import prettier from 'prettier';
+import { render } from '@testing-library/react';
+
+import sx from '../../index';
+import collector from '../StyleCollector';
+
+afterEach(() => {
+  collector.reset();
+});
+
+it('allows styles to be composed with external styles', () => {
+  const styles = sx.create({ default: { fontSize: 16 } });
+  const externalStyles = sx.create({ custom: { fontSize: 20 } });
+
+  expect(sx(styles.default, externalStyles.custom)).toBe(externalStyles('custom'));
+  expect(sx(externalStyles.custom, styles.default)).toBe(styles('default'));
+});
+
+it('correctly resolves multiple styles', () => {
+  const styles = sx.create({ default: { fontSize: 16 } });
+  const externalStyles = sx.create({ custom: { color: 'red', fontSize: 20 } });
+
+  render(<div>{sx.renderPageWithSX(jest.fn()).styles}</div>);
+  expect(
+    prettier.format(document.querySelector('[data-adeira-sx="true"]')?.innerHTML, {
+      filepath: 'test.css',
+    }),
+  ).toMatchInlineSnapshot(`
+    "._39Fbhf {
+      font-size: 16px;
+    }
+    ._324Crd {
+      color: #f00;
+    }
+    ._4xrWBp {
+      font-size: 20px;
+    }
+    "
+  `);
+
+  expect(sx(styles.default, externalStyles.custom)).toMatchInlineSnapshot(`"_4xrWBp _324Crd"`);
+  expect(sx(externalStyles.custom, styles.default)).toMatchInlineSnapshot(`"_324Crd _39Fbhf"`);
+});
+
+it('merges more complex styles correctly', () => {
+  const styles = sx.create({
+    default: {
+      'fontSize': 16,
+      '@media print': {
+        fontSize: 12,
+      },
+    },
+  });
+  const externalStyles = sx.create({
+    custom: {
+      'fontSize': 20,
+      '@media print': {
+        fontSize: 15,
+      },
+    },
+  });
+
+  render(<div>{sx.renderPageWithSX(jest.fn()).styles}</div>);
+  expect(
+    prettier.format(document.querySelector('[data-adeira-sx="true"]')?.innerHTML, {
+      filepath: 'test.css',
+    }),
+  ).toMatchInlineSnapshot(`
+    "._39Fbhf {
+      font-size: 16px;
+    }
+    @media print {
+      .vovX4.vovX4 {
+        font-size: 12px;
+      }
+      ._4j9tl4._4j9tl4 {
+        font-size: 15px;
+      }
+    }
+    ._4xrWBp {
+      font-size: 20px;
+    }
+    "
+  `);
+
+  expect(sx(styles.default, externalStyles.custom)).toMatchInlineSnapshot(`"_4xrWBp _4j9tl4"`);
+  expect(sx(externalStyles.custom, styles.default)).toMatchInlineSnapshot(`"_39Fbhf vovX4"`);
+});

--- a/src/sx/src/__tests__/fixtures.test.js
+++ b/src/sx/src/__tests__/fixtures.test.js
@@ -7,7 +7,7 @@ import prettier from 'prettier';
 import TestRenderer from 'react-test-renderer';
 import { isObject, sprintf } from '@adeira/js';
 
-import * as sx from '../../index';
+import sx from '../../index';
 import StyleCollector from '../StyleCollector';
 
 const fixturesPath = path.join(__dirname, 'fixtures');

--- a/src/sx/src/__tests__/injectRuntimeStyles.test.js
+++ b/src/sx/src/__tests__/injectRuntimeStyles.test.js
@@ -4,7 +4,7 @@
 
 import { render } from '@testing-library/react';
 
-import * as sx from '../../index';
+import sx from '../../index';
 
 it('injects runtime styles', () => {
   render(<style data-adeira-sx />);

--- a/src/sx/src/__tests__/renderPageWithSX.test.js
+++ b/src/sx/src/__tests__/renderPageWithSX.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as sx from '../../index';
+import sx from '../../index';
 import StyleCollector from '../StyleCollector';
 
 afterEach(() => {


### PR DESCRIPTION
I would like to propose a change of the default export which would allow us to merge external SX stylesheets. For example, here is a base component:

```
import sx from '@adeira/sx';

type Props = {|
  +xstyle: {|
    +marginTop: number,
  |},
|};

const styles = sx.create({ default: { fontSize: 16 } });

function MyBaseComponent(props: Props) {
  return <div className={sx(styles.default, props.xstyle)} />;
}
```

And another wrapping component which is sending down some custom styles:

```
const styles = sx.create({ spacing: { marginTop: 4 } });

function MyCustomComponent() {
  return <MyBaseComponent xstyle={styles.spacing} />;
}
```

We are currently unable to achieve such behavior without this change.

This change is inspired by StyleX, see: https://youtu.be/9JZHodNR184