### PR TITLE
Eslint: add new opt-in rule 'flow-use-readonly-spread'

### DIFF
--- a/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
+++ b/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
@@ -42,6 +42,7 @@ Object {
         "setWithoutGet": true,
       },
     ],
+    "adeira/flow-use-readonly-spread": 0,
     "adeira/graphql-require-object-description": 1,
     "adeira/no-duplicate-import-type-import": 2,
     "adeira/no-internal-flow-type": 2,

--- a/src/eslint-config-adeira/ourRules.js
+++ b/src/eslint-config-adeira/ourRules.js
@@ -671,14 +671,15 @@ module.exports = ({
   'eslint-comments/no-use': OFF,
 
   // Adeira custom rules
-  'adeira/only-nullable-fields': ERROR,
-  'adeira/no-invalid-flow-annotations': ERROR,
+  'adeira/flow-use-readonly-spread': OFF, // opt-in when needed
+  'adeira/graphql-require-object-description': WARN,
+  'adeira/no-duplicate-import-type-import': ERROR,
   'adeira/no-internal-flow-type': ERROR,
+  'adeira/no-invalid-flow-annotations': ERROR,
+  'adeira/only-nullable-fields': ERROR,
   'adeira/relay-import-no-values': ERROR,
   'adeira/relay-import-type-must-exist': ERROR,
   'adeira/valid-test-folder': ERROR,
-  'adeira/no-duplicate-import-type-import': ERROR,
-  'adeira/graphql-require-object-description': WARN,
 
   // Adeira SX custom rules
   'sx/no-concatenated-classes': NEXT_VERSION_ERROR,

--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "eslint-config-prettier": "^6.14.0",
-    "eslint-plugin-adeira": "^0.10.0",
+    "eslint-plugin-adeira": "^0.11.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-flowtype": "^5.2.0",

--- a/src/eslint-plugin-adeira/README.md
+++ b/src/eslint-plugin-adeira/README.md
@@ -39,6 +39,42 @@ Prefers `React.Node` over `React$Node` types.
 
 This rule disallows `@noflow` and `@flow weak` annotations. The only valid annotations are `@flow`, `@flow strict` and `@flow strict-local`.
 
+## `flow-use-readonly-spread`
+
+```flow js
+type INode = {|
+  +type: string,
+  +range: [number, number],
+  +parent: null | INode,
+|};
+
+// Error: Identifier must be $ReadOnly<…> to prevent accidental loss of readonly-ness
+type Identifier = {|
+  ...INode,
+  +name: string,
+|};
+```
+
+These types are not readonly anymore, see:
+
+```flow js
+const x: Identifier = { name: '', type: '', range: [1, 2], parent: null };
+
+x.type = 'Should not be writable!';
+x.name = 'Should not be writable!';
+```
+
+The `Identifier` type should be written like this:
+
+```flow js
+type Identifier = $ReadOnly<{|
+  ...INode,
+  +name: string,
+|}>;
+```
+
+Try it: [flow.org/try](https://flow.org/try/#0C4TwDgpgBAkgcgewCbQLxQN4B8BQUoDUokAXFAM7ABOAlgHYDmANHoVQIaMRkDadArgFsARhCpMoAkWIC6LfATDsqEOsDICANpqhZYiFCywBfANw4cAektQAsv0pRRUACQAlCOyQB5OppAAhDjE0DAoajQAZjRiUOjunj5+IAA82KwAdFnwyBDyhHTsgtwU1PTMOCYAfOY4AMYIdI4AHmRhqsBRMVRxmIXFJABEgxIhQyNQHFwkPACMTABMclBKKmokWprGFs0ZIb0A5ADKABYI-JpIkgjATtAA7rTA7MKaEAEH5rv9aFDHZxcrnQbncoI8aM9Xu9PjggA)
+
 ## `only-nullable-fields`
 
 This rule aims to remove all dangerous uses of `GraphQLNonNull` on GraphQL type fields. Why? It's a best practice to use nullable fields and not to rely on a returned value. This way every frontend implementation must handle the situation when API returns `null` because everything will break eventually. Non-nullable fields would in case of failure destroy the whole type and could bubble-up destroying the whole GraphQL response.

--- a/src/eslint-plugin-adeira/package.json
+++ b/src/eslint-plugin-adeira/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/eslint-plugin-adeira",
   "license": "MIT",
   "private": false,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "main": "src/index",
   "sideEffects": false,
   "dependencies": {

--- a/src/eslint-plugin-adeira/src/index.js
+++ b/src/eslint-plugin-adeira/src/index.js
@@ -2,13 +2,14 @@
 
 module.exports = {
   rules: {
+    'flow-use-readonly-spread': require('./rules/flow-use-readonly-spread'),
     'graphql-require-object-description': require('./rules/graphql-require-object-description'),
+    'no-duplicate-import-type-import': require('./rules/no-duplicate-import-type-import'),
     'no-internal-flow-type': require('./rules/no-internal-flow-type'),
     'no-invalid-flow-annotations': require('./rules/no-invalid-flow-annotations'),
     'only-nullable-fields': require('./rules/only-nullable-fields'),
     'relay-import-no-values': require('./rules/relay-import-no-values'),
     'relay-import-type-must-exist': require('./rules/relay-import-type-must-exist'),
     'valid-test-folder': require('./rules/valid-test-folder'),
-    'no-duplicate-import-type-import': require('./rules/no-duplicate-import-type-import'),
   },
 };

--- a/src/eslint-plugin-adeira/src/rules/__tests__/flow-use-readonly-spread.test.js
+++ b/src/eslint-plugin-adeira/src/rules/__tests__/flow-use-readonly-spread.test.js
@@ -1,0 +1,72 @@
+// @flow
+
+const RuleTester = require('eslint').RuleTester;
+
+const rule = require('../flow-use-readonly-spread');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+});
+
+ruleTester.run('flow-use-readonly-spread', rule, {
+  valid: [
+    `
+    type Identifier = $ReadOnly<{|
+      ...INode,
+      +name: string,
+    |}>;
+`,
+    `
+    type Identifier = $ReadOnly<{|
+      ...INode,
+      -name: string,
+    |}>;
+`,
+    `
+    type Identifier = $ReadOnly<{|
+      ...INode,
+      name: string,
+    |}>;
+`,
+    `
+    type Identifier = {|
+      ...INode,
+      name: string,
+    |};
+`,
+    `
+    type Identifier = {|
+      ...INode,
+      name: string,
+      +surname: string,
+    |};
+`,
+    `
+    type Identifier = {|
+      +name: string,
+    |};
+`,
+  ],
+
+  invalid: [
+    {
+      code: `
+        type Identifier = {|
+          ...INode,
+          +aaa: string,
+        |};
+      `,
+      errors: [{ messageId: 'readonlySpread' }],
+    },
+    {
+      code: `
+        type Identifier = {|
+          ...INode,
+          +aaa: string,
+          +bbb: string,
+        |};
+      `,
+      errors: [{ messageId: 'readonlySpread' }],
+    },
+  ],
+});

--- a/src/eslint-plugin-adeira/src/rules/flow-use-readonly-spread.js
+++ b/src/eslint-plugin-adeira/src/rules/flow-use-readonly-spread.js
@@ -1,0 +1,46 @@
+// @flow
+
+/*::
+import type { EslintRule } from '@adeira/flow-types-eslint';
+*/
+
+module.exports = ({
+  meta: {
+    messages: {
+      readonlySpread:
+        'Flow type with spread property and all readonly properties should be ' +
+        "wrapped in '$ReadOnly<…>' to prevent accidental loss of readonly-ness.",
+    },
+  },
+  create: function (context) {
+    return {
+      TypeAlias(node) {
+        if (node.right.type === 'GenericTypeAnnotation' && node.right.id.name === '$ReadOnly') {
+          // it's already $ReadOnly<…>, nothing to do
+        } else if (node.right.type === 'ObjectTypeAnnotation') {
+          // let's iterate all props and if everything is readonly then throw
+          let shouldThrow = false;
+          let hasSpread = false;
+          for (const property of node.right.properties) {
+            if (property.type === 'ObjectTypeProperty') {
+              if (property.variance && property.variance.kind === 'plus') {
+                shouldThrow = true;
+              } else {
+                shouldThrow = false;
+                break;
+              }
+            } else if (property.type === 'ObjectTypeSpreadProperty') {
+              hasSpread = true;
+            }
+          }
+          if (hasSpread === true && shouldThrow === true) {
+            context.report({
+              node: node.right,
+              messageId: 'readonlySpread',
+            });
+          }
+        }
+      },
+    };
+  },
+} /*: EslintRule */);

--- a/src/flow-types-eslint/.eslintrc.js
+++ b/src/flow-types-eslint/.eslintrc.js
@@ -1,0 +1,13 @@
+// @flow strict
+
+/* eslint-disable no-unused-vars */
+const OFF = 0;
+const WARN = 1;
+const ERROR = 2;
+/* eslint-enable no-unused-vars */
+
+module.exports = {
+  rules: {
+    'adeira/flow-use-readonly-spread': ERROR,
+  },
+};

--- a/src/flow-types-eslint/src/index.js
+++ b/src/flow-types-eslint/src/index.js
@@ -10,6 +10,7 @@ import type { JSXExpressionContainer } from './types/JSXExpressionContainer';
 import type { NewExpression } from './types/NewExpression';
 import type { Program } from './types/Program';
 import type { Property } from './types/Property';
+import type { TypeAlias } from './types/TypeAlias';
 import type { VariableDeclarator as _VariableDeclarator } from './types/VariableDeclarator';
 
 // Inspiration (but obviously a different tool):
@@ -47,6 +48,7 @@ type ASTNodes = {|
   +'Program:exit'?: (node: Program) => void,
   +'Property'?: (node: Property) => void,
   +'Property:exit'?: (node: Property) => void,
+  +'TypeAlias'?: (node: TypeAlias) => void,
   +'VariableDeclarator'?: (node: _VariableDeclarator) => void,
 |};
 
@@ -63,6 +65,7 @@ export type EslintRule = {|
     |},
     +fixable?: boolean,
     +schema?: $ReadOnlyArray<empty>,
+    +messages?: {| +[string]: string |},
   |},
   +create: (Context) => ASTNodes,
 |};

--- a/src/flow-types-eslint/src/types/GenericTypeAnnotation.js
+++ b/src/flow-types-eslint/src/types/GenericTypeAnnotation.js
@@ -1,0 +1,11 @@
+// @flow
+
+import type { INode } from './INode';
+import type { Identifier } from './Identifier';
+
+export type GenericTypeAnnotation = $ReadOnly<{|
+  ...INode,
+  +type: 'GenericTypeAnnotation',
+  +typeParameters: any, // TODO
+  +id: Identifier,
+|}>;

--- a/src/flow-types-eslint/src/types/NumberLiteralTypeAnnotation.js
+++ b/src/flow-types-eslint/src/types/NumberLiteralTypeAnnotation.js
@@ -1,0 +1,13 @@
+// @flow strict
+
+import type { INode } from './INode';
+
+export type NumberLiteralTypeAnnotation = $ReadOnly<{|
+  ...INode,
+  +type: 'NumberLiteralTypeAnnotation',
+  +extra: {|
+    +rawValue: number,
+    +raw: string,
+  |},
+  +value: number,
+|}>;

--- a/src/flow-types-eslint/src/types/ObjectTypeAnnotation.js
+++ b/src/flow-types-eslint/src/types/ObjectTypeAnnotation.js
@@ -1,0 +1,15 @@
+// @flow
+
+import type { INode } from './INode';
+import type { ObjectTypeProperty } from './ObjectTypeProperty';
+import type { ObjectTypeSpreadProperty } from './ObjectTypeSpreadProperty';
+
+export type ObjectTypeAnnotation = $ReadOnly<{|
+  ...INode,
+  +type: 'ObjectTypeAnnotation',
+  +properties: $ReadOnlyArray<ObjectTypeProperty | ObjectTypeSpreadProperty>,
+  +indexers: $ReadOnlyArray<any>, // TODO
+  +internalSlots: $ReadOnlyArray<any>, // TODO
+  +exact: boolean,
+  +inexact: boolean,
+|}>;

--- a/src/flow-types-eslint/src/types/ObjectTypeProperty.js
+++ b/src/flow-types-eslint/src/types/ObjectTypeProperty.js
@@ -1,0 +1,15 @@
+// @flow strict
+
+import type { INode } from './INode';
+import type { Variance } from './Variance';
+
+export type ObjectTypeProperty = $ReadOnly<{|
+  ...INode,
+  +type: 'ObjectTypeProperty',
+  +static: boolean,
+  +proto: boolean,
+  +kind: 'init', // TODO
+  +method: boolean,
+  +variance: Variance | null,
+  +optional: boolean,
+|}>;

--- a/src/flow-types-eslint/src/types/ObjectTypeSpreadProperty.js
+++ b/src/flow-types-eslint/src/types/ObjectTypeSpreadProperty.js
@@ -1,0 +1,10 @@
+// @flow
+
+import type { INode } from './INode';
+import type { GenericTypeAnnotation } from './GenericTypeAnnotation';
+
+export type ObjectTypeSpreadProperty = $ReadOnly<{|
+  ...INode,
+  +type: 'ObjectTypeSpreadProperty',
+  +argument: GenericTypeAnnotation,
+|}>;

--- a/src/flow-types-eslint/src/types/StringLiteralTypeAnnotation.js
+++ b/src/flow-types-eslint/src/types/StringLiteralTypeAnnotation.js
@@ -1,0 +1,13 @@
+// @flow strict
+
+import type { INode } from './INode';
+
+export type StringLiteralTypeAnnotation = $ReadOnly<{|
+  ...INode,
+  +type: 'StringLiteralTypeAnnotation',
+  +extra: {|
+    +rawValue: string,
+    +raw: string,
+  |},
+  +value: string,
+|}>;

--- a/src/flow-types-eslint/src/types/TypeAlias.js
+++ b/src/flow-types-eslint/src/types/TypeAlias.js
@@ -1,0 +1,18 @@
+// @flow
+
+import type { GenericTypeAnnotation } from './GenericTypeAnnotation';
+import type { INode } from './INode';
+import type { NumberLiteralTypeAnnotation } from './NumberLiteralTypeAnnotation';
+import type { ObjectTypeAnnotation } from './ObjectTypeAnnotation';
+import type { StringLiteralTypeAnnotation } from './StringLiteralTypeAnnotation';
+
+export type TypeAlias = $ReadOnly<{|
+  ...INode,
+  +type: 'TypeAlias',
+  +right:
+    | ObjectTypeAnnotation
+    | GenericTypeAnnotation
+    | NumberLiteralTypeAnnotation
+    | StringLiteralTypeAnnotation,
+  // possibly many others
+|}>;

--- a/src/flow-types-eslint/src/types/Variance.js
+++ b/src/flow-types-eslint/src/types/Variance.js
@@ -1,0 +1,5 @@
+// @flow strict
+
+export type Variance = {|
+  +kind: 'plus' | 'minus',
+|};


### PR DESCRIPTION
The purpose of this rule is to check types inside `flow-types-eslint` package to prevent accidental wrong Flow types breaking readonly-ness. See this example for more details: https://flow.org/try/#0C4TwDgpgBAkgcgewCbQLxQN4B8BQUoDUokAXFAM7ABOAlgHYDmANHoVQIaMRkDadArgFsARhCpMoAkWIC6LfATDsqEOsDICANpqhZYiFCywBfANw4cAektQAsv0pRRUACQAlCOyQB5OppAAhDjE0DAoajQAZjRiUOjunj5+IAA82KwAdFnwyBDyhHTsgtwU1PTMOCYAfOY4AMYIdI4AHmRhqsBRMVRxmIXFJABEgxIhQyNQHFwkPACMTABMclBKKmokWprGFs0ZIb0A5ADKABYI-JpIkgjATtAA7rTA7MKaEAEH5rv9aFDHZxcrnQbncoI8aM9Xu9PjggA