### PR TITLE
SXT Website: Add babel/core

### DIFF
--- a/src/sx-tailwind-website/package.json
+++ b/src/sx-tailwind-website/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@adeira/babel-plugin-transform-sx-tailwind": "^0.14.0",
     "@adeira/babel-preset-adeira": "^2.0.0",
+    "@babel/core": "^7.12.3",
     "flow-bin": "^0.138.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7515,7 +7515,7 @@ graphql-upload@^8.0.2:
     http-errors "^1.7.3"
     object-path "^0.11.4"
 
-"graphql@^14.0.0 || ^15.0.0-rc.1", graphql@^15.0.0, graphql@^15.3.0:
+"graphql@^14.0.0 || ^15.0.0-rc.1", graphql@^15.3.0:
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.4.0.tgz#e459dea1150da5a106486ba7276518b5295a4347"
   integrity sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==


### PR DESCRIPTION
No idea why, but the build of exported project is failing with `Cannot find module '@babel/core'`:
https://vercel.com/adeira/sx-tailwind-website/a8e94qgbq