### PR TITLE
1/n: archive 'graphql-result-size'

### DIFF
--- a/src/graphql-result-size/package.json
+++ b/src/graphql-result-size/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adeira/graphql-result-size",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "This module provides an implementation of an algorithm that calculates the (exact) size of GraphQL response objects without actually producing the response.",
   "homepage": "https://github.com/adeira/universe/tree/master/src/graphql-result-size",
   "private": false,

--- a/src/monorepo-shipit/config/__tests__/graphql-result-size.test.js
+++ b/src/monorepo-shipit/config/__tests__/graphql-result-size.test.js
@@ -1,0 +1,19 @@
+// @flow strict-local
+
+import path from 'path';
+
+import testExportedPaths from './testExportedPaths';
+
+testExportedPaths(path.join(__dirname, '..', 'graphql-result-size.js'), [
+  ['src/graphql-result-size/src/__tests__/testschema.graphql', 'src/__tests__/testschema.graphql'],
+  ['src/graphql-result-size/src/index.js', 'src/index.js'],
+  ['src/graphql-result-size/package.json', 'package.json'],
+
+  // invalid cases:
+  ['src/packages/monorepo/outsideScope.js', undefined], // correctly deleted
+  ['src/js/BUILD.bazel', undefined], // correctly deleted
+  ['src/js/BUILD', undefined], // correctly deleted
+  ['src/js/WORKSPACE.bazel', undefined], // correctly deleted
+  ['src/js/WORKSPACE', undefined], // correctly deleted
+  ['package.json', undefined], // correctly deleted
+]);

--- a/src/monorepo-shipit/config/graphql-result-size.js
+++ b/src/monorepo-shipit/config/graphql-result-size.js
@@ -1,0 +1,14 @@
+// @flow strict
+
+import type { ConfigType } from '../ConfigType.flow';
+
+module.exports = ({
+  getStaticConfig() {
+    return {
+      repository: 'git@github.com:adeira/graphql-result-size.git',
+    };
+  },
+  getPathMappings() {
+    return new Map([['src/graphql-result-size/', '']]);
+  },
+}: ConfigType);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7515,7 +7515,7 @@ graphql-upload@^8.0.2:
     http-errors "^1.7.3"
     object-path "^0.11.4"
 
-"graphql@^14.0.0 || ^15.0.0-rc.1", graphql@^15.3.0:
+"graphql@^14.0.0 || ^15.0.0-rc.1", graphql@^15.0.0, graphql@^15.3.0:
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.4.0.tgz#e459dea1150da5a106486ba7276518b5295a4347"
   integrity sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==


### PR DESCRIPTION
This project is no longer maintained nor does it have a good use-case. However, I consider it an important part in my GraphQL research so I'd like to archive it following these steps:

1. open-source it via Shipit here: https://github.com/adeira/graphql-result-size
2. archive the GitHub repository
3. remove the Shipit export