### PR TITLE
CI: explicitly setup Dependabot

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -6,3 +6,5 @@ require_automerge_label = true
 method = "rebase"
 delete_branch_on_merge = true
 
+# TODO: consider `approve.auto_approve_usernames` for Dependabot
+#  see: https://kodiakhq.com/docs/recipes#adding-pull-request-approvals-to-dependabot-pull-requests

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+
+updates:
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    schedule:
+      interval: 'daily'
+    labels:
+      - 'dependencies'
+      - 'automerge' # see Kodiak `merge.automerge_label`
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    labels:
+      - 'dependencies'


### PR DESCRIPTION
Currently, we are using `dependabot-preview` which supports automatic merges but it's not configurable anymore. This commit migrates it to native GitHub Dependabot which allows us to configure other automated updates like GitHub actions. Automatic merging is done via Kodiak.

Closes: https://github.com/adeira/universe/issues/932