### PR TITLE
Open-source '@adeira/flow-config-parser'

### DIFF
--- a/.flowconfig.android
+++ b/.flowconfig.android
@@ -1,0 +1,4 @@
+; https://flow.org/en/docs/config/ignore/
+[ignore]
+; React Native forks some components by platform
+.*/*[.]ios.js

--- a/.flowconfig.base
+++ b/.flowconfig.base
@@ -1,0 +1,74 @@
+; https://flow.org/en/docs/config/ignore/
+[ignore]
+<PROJECT_ROOT>/\.git/.*
+.+/.+\.gzip\.js
+.+/\.next/.+
+
+; Do not use <PROJECT_ROOT> for Bazel, see: https://github.com/facebook/flow/issues/2250
+.+/bazel-bin/.+
+.+/bazel-out/.+
+.+/bazel-testlogs/.+
+.+/bazel-universe/.+
+
+
+; https://flow.org/en/docs/config/untyped/
+[untyped]
+
+
+; https://flow.org/en/docs/config/declarations/
+[declarations]
+.+/node_modules/.+
+
+
+; https://flow.org/en/docs/config/libs/
+[libs]
+./flow-typed/
+
+; Please note: one disadvantage of these libs is that it's gonna be available for every JS file even though
+; it should be defined only for one workspace.
+./src/monorepo-scanner/src/flow/
+
+
+; These lints are enabled in normal mode. Consult [strict] mode to see what additional lints
+; are enabled in strict mode. Only disabled rules in normal mode should be added to strict mode.
+;
+; https://flow.org/en/docs/config/lints/
+[lints]
+all=error
+ambiguous-object-type=off
+sketchy-null-bool=off
+unclear-type=off
+untyped-import=off
+
+
+; This setting complements [lints] section: all the enabled lints still throw errors + these
+; additional lints are enabled only in strict mode (no need to list here every lint). Local
+; strict mode behaves the same like strict mode except it turns off 'nonstrict-import' rule.
+;
+; https://flow.org/en/docs/strict/
+[strict]
+ambiguous-object-type
+sketchy-null-bool
+unclear-type
+untyped-import
+
+
+; https://flow.org/en/docs/config/options/
+[options]
+emoji=true
+exact_by_default=true
+include_warnings=true
+facebook.fbt=FbtWithoutString
+
+; This enables new react JSX transforms in flow
+react.runtime=automatic
+
+; Allow dynamic `require(path.join(__dirname, 'myFile.json'))`
+module.ignore_non_literal_requires=true
+
+; This option lets you alias 'any' with a given string - useful for explaining why you’re using 'any'.
+suppress_type=$FlowFixMe
+
+; This option is always ON in the strict mode. We are enabling it even for the classic mode.
+; Function parameters are considered const (i.e., treated as if they were declared with const rather than let).
+experimental.const_params=true

--- a/.flowconfig.ios
+++ b/.flowconfig.ios
@@ -1,0 +1,4 @@
+; https://flow.org/en/docs/config/ignore/
+[ignore]
+; React Native forks some components by platform
+.*/*[.]android.js

--- a/scripts/generateFlow.js
+++ b/scripts/generateFlow.js
@@ -1,0 +1,26 @@
+// @flow
+
+import fs from 'fs';
+import path from 'path';
+import { merge } from '@adeira/flow-config-parser';
+import SignedSource from '@adeira/signed-source';
+
+// yarn monorepo-babel-node scripts/generateFlow.js
+
+const mergedConfig = merge(
+  fs.readFileSync(path.join(__dirname, '..', '.flowconfig.base'), 'utf8'),
+  fs.readFileSync(path.join(__dirname, '..', '.flowconfig.ios'), 'utf8'),
+);
+
+// TODO: generate and run Flow even for Android part
+// TODO: collect and merge .flowconfig(s) from all around the monorepo
+
+const template = SignedSource.signFile(`# ${SignedSource.getSigningToken()}
+#
+# To regenerate run:
+# yarn monorepo-babel-node scripts/generateFlow.js
+#
+${mergedConfig}
+`);
+
+fs.writeFileSync(path.join(__dirname, '..', '.flowconfig'), template);

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,10 +4,12 @@
   "version": "0.0.0",
   "license": "UNLICENSED",
   "dependencies": {
+    "@adeira/flow-config-parser": "^0.1.0",
     "@adeira/js": "^1.2.4",
     "@adeira/logger": "^0.3.0",
     "@adeira/monorepo-npm-publisher": "^1.0.0",
     "@adeira/monorepo-utils": "^0.9.0",
+    "@adeira/signed-source": "^1.0.0",
     "chalk": "^4.1.0"
   }
 }

--- a/scripts/publishedPackages.json
+++ b/scripts/publishedPackages.json
@@ -6,6 +6,7 @@
   "@adeira/eslint-runner",
   "@adeira/fetch",
   "@adeira/flow-bin",
+  "@adeira/flow-config-parser",
   "@adeira/graphql-bc-checker",
   "@adeira/graphql-global-id",
   "@adeira/graphql-relay",

--- a/src/flow-config-parser/.npmignore
+++ b/src/flow-config-parser/.npmignore
@@ -1,0 +1,3 @@
+__tests__
+BUILD.bazel
+BUILD

--- a/src/flow-config-parser/LICENSE
+++ b/src/flow-config-parser/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-present, Adeira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/flow-config-parser/README.md
+++ b/src/flow-config-parser/README.md
@@ -1,0 +1,75 @@
+Permissive [Flow config](https://flow.org/en/docs/config/) parser.
+
+```text
+yarn add @adeira/flow-config-parser
+```
+
+## `parse`
+
+Parse function doesn't do any magic. It simply takes the `.flowconfig` as a first argument and returns object with the config values:
+
+```js
+import { parse } from '@adeira/flow-config-parser';
+
+parse(`
+[version]
+>=0.138.0 <0.140.0
+`);
+```
+
+Returns:
+
+```json
+{
+  "declarations": [],
+  "ignore": [],
+  "include": [],
+  "libs": [],
+  "lints": null,
+  "options": null,
+  "strict": [],
+  "untyped": [],
+  "version": ">=0.138.0 <0.140.0"
+}
+```
+
+## `merge`
+
+Merge functions merges two configs together and returns the final config:
+
+```js
+const configA = `
+  [options]
+  emoji=true
+  module.file_ext=.foo
+  module.file_ext=.bar
+`;
+
+const configB = `
+  [options]
+  emoji=false
+  module.file_ext=.baz
+  munge_underscores=false
+`;
+
+merge(configA, configB);
+```
+
+Returns:
+
+```text
+# ...
+
+[options]
+emoji=false
+module.file_ext=.foo
+module.file_ext=.bar
+module.file_ext=.baz
+munge_underscores=false
+
+# ...
+```
+
+## `print`
+
+TKTK

--- a/src/flow-config-parser/package.json
+++ b/src/flow-config-parser/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@adeira/flow-config-parser",
+  "description": "Permissive Flow config parser.",
+  "homepage": "https://github.com/adeira/universe/tree/master/src/flow-config-parser",
+  "version": "0.1.0",
+  "private": false,
+  "license": "MIT",
+  "main": "src/index",
+  "dependencies": {
+    "@adeira/js": "^1.3.0",
+    "@adeira/test-utils": "^0.6.0",
+    "@babel/runtime": "^7.12.5"
+  }
+}

--- a/src/flow-config-parser/src/ParsedConfig.flow.js
+++ b/src/flow-config-parser/src/ParsedConfig.flow.js
@@ -1,0 +1,15 @@
+// @flow strict
+
+type List = Array<string>;
+
+export type ParsedConfig = {|
+  declarations: List,
+  ignore: List,
+  include: List,
+  libs: List,
+  lints: $FlowFixMe,
+  options: $FlowFixMe,
+  strict: List,
+  untyped: List,
+  version: $FlowFixMe,
+|};

--- a/src/flow-config-parser/src/__tests__/__snapshots__/parse.test.js.snap
+++ b/src/flow-config-parser/src/__tests__/__snapshots__/parse.test.js.snap
@@ -1,0 +1,607 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`matches expected output: .flowconfig.declarations 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+; https://flow.org/en/docs/config/declarations/
+
+[declarations]
+.*/third_party/.*
+.*/src/\\(foo\\|bar\\)/.*
+.*\\.decl\\.js
+<PROJECT_ROOT>/third_party/.*
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "declarations": [
+    ".*/third_party/.*",
+    ".*/src/\\\\(foo\\\\|bar\\\\)/.*",
+    ".*\\\\.decl\\\\.js",
+    "<PROJECT_ROOT>/third_party/.*"
+  ],
+  "ignore": [],
+  "include": [],
+  "libs": [],
+  "lints": null,
+  "options": null,
+  "strict": [],
+  "untyped": [],
+  "version": null
+}
+`;
+
+exports[`matches expected output: .flowconfig.empty 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "declarations": [],
+  "ignore": [],
+  "include": [],
+  "libs": [],
+  "lints": null,
+  "options": null,
+  "strict": [],
+  "untyped": [],
+  "version": null
+}
+`;
+
+exports[`matches expected output: .flowconfig.empty-sections 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+[declarations]
+
+[include]
+
+[ignore]
+
+[untyped]
+
+[libs]
+
+[lints]
+
+[options]
+
+[version]
+
+[strict]
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "declarations": [],
+  "ignore": [],
+  "include": [],
+  "libs": [],
+  "lints": null,
+  "options": null,
+  "strict": [],
+  "untyped": [],
+  "version": null
+}
+`;
+
+exports[`matches expected output: .flowconfig.empty-sections-comments 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[declarations]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[include]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[ignore]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[untyped]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[libs]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[lints]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[options]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[version]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[strict]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "declarations": [],
+  "ignore": [],
+  "include": [],
+  "libs": [],
+  "lints": null,
+  "options": null,
+  "strict": [],
+  "untyped": [],
+  "version": null
+}
+`;
+
+exports[`matches expected output: .flowconfig.ignore 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+; https://flow.org/en/docs/config/ignore/
+
+[ignore]
+.*/__tests__/.*
+.*/src/\\(foo\\|bar\\)/.*
+.*\\.ignore\\.js
+<PROJECT_ROOT>/__tests__/.*
+<PROJECT_ROOT>/node_modules/.*
+!<PROJECT_ROOT>/node_modules/not-ignored-package-A/.*
+!<PROJECT_ROOT>/node_modules/not-ignored-package-B/.*
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "declarations": [],
+  "ignore": [
+    ".*/__tests__/.*",
+    ".*/src/\\\\(foo\\\\|bar\\\\)/.*",
+    ".*\\\\.ignore\\\\.js",
+    "<PROJECT_ROOT>/__tests__/.*",
+    "<PROJECT_ROOT>/node_modules/.*",
+    "!<PROJECT_ROOT>/node_modules/not-ignored-package-A/.*",
+    "!<PROJECT_ROOT>/node_modules/not-ignored-package-B/.*"
+  ],
+  "include": [],
+  "libs": [],
+  "lints": null,
+  "options": null,
+  "strict": [],
+  "untyped": [],
+  "version": null
+}
+`;
+
+exports[`matches expected output: .flowconfig.include 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+; https://flow.org/en/docs/config/include/
+
+[include]
+../externalFile.js
+../externalDir/
+../otherProject/*.js
+../otherProject/**/coolStuff/
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "declarations": [],
+  "ignore": [],
+  "include": [
+    "../externalFile.js",
+    "../externalDir/",
+    "../otherProject/*.js",
+    "../otherProject/**/coolStuff/"
+  ],
+  "libs": [],
+  "lints": null,
+  "options": null,
+  "strict": [],
+  "untyped": [],
+  "version": null
+}
+`;
+
+exports[`matches expected output: .flowconfig.invalid 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+💩 Purpose of this fixture is to see how it behaves when the config is
+💩 crazy invalid (and potentially improve the behavior).
+
+[ignore]
+<PROJECT_ROOT>/\\.git/.*
+<PROJECT_ROOT>/\\.git/.*
+<PROJECT_ROOT>/\\.git/.*
+
+[ignore]
+<PROJECT_ROOT>/\\.hg/.*
+<PROJECT_ROOT>/\\.hg/.*
+
+[IGNORE]
+<PROJECT_ROOT>
+
+[unknown]
+{
+  "what": {
+    "is": {
+      "this": -1
+    }
+  }
+}
+
+[[ignore]]
+
+[version]
+>=0.138.0 <0.140.0
+0.138.0
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "declarations": [],
+  "ignore": [
+    "<PROJECT_ROOT>/\\\\.git/.*",
+    "<PROJECT_ROOT>/\\\\.git/.*",
+    "<PROJECT_ROOT>/\\\\.git/.*",
+    "<PROJECT_ROOT>/\\\\.hg/.*",
+    "<PROJECT_ROOT>/\\\\.hg/.*",
+    "<PROJECT_ROOT>"
+  ],
+  "include": [],
+  "libs": [],
+  "lints": null,
+  "options": null,
+  "strict": [],
+  "untyped": [],
+  "version": "0.138.0"
+}
+`;
+
+exports[`matches expected output: .flowconfig.options 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+; https://flow.org/en/docs/config/options/
+
+[options]
+all=true
+babel_loose_array_spread=true
+emoji=true
+esproposal.class_instance_fields=enable
+esproposal.class_static_fields=enable
+esproposal.decorators=warn
+esproposal.export_star_as=warn
+esproposal.optional_chaining=ignore
+esproposal.nullish_coalescing=ignore
+exact_by_default=true
+experimental.const_params=true
+include_warnings=true
+lazy_mode=watchman
+log.file=/tmp/flow/yadada.log
+max_header_tokens=10
+module.file_ext=.foo
+module.file_ext=.bar
+module.ignore_non_literal_requires=true
+
+; TODO: should we expand these mappers (?)
+module.name_mapper='^image![a-zA-Z0-9$_]+$' -> 'ImageStub'
+module.name_mapper.extension='css' -> '<PROJECT_ROOT>/CSSFlowStub.js.flow'
+
+module.system=haste
+module.system.node.main_field=foo
+module.system.node.main_field=bar
+module.system.node.main_field=baz
+module.system.node.resolve_dirname=node_modules
+module.system.node.resolve_dirname=custom_node_modules
+module.use_strict=false
+munge_underscores=false
+no_flowlib=false
+react.runtime=automatic
+server.max_workers=2
+sharedmemory.dirs=/dev/shm
+sharedmemory.dirs=/tmp
+sharedmemory.minimum_available=536870912
+sharedmemory.hash_table_pow=19
+sharedmemory.heap_size=26843545600
+sharedmemory.log_level=0
+strip_root=false
+suppress_comment=\\\\(.\\\\|\\n\\\\)*\\\\$FlowFixMe1
+suppress_comment=\\\\(.\\\\|\\n\\\\)*\\\\$FlowFixMe2
+suppress_type=$FlowFixMe
+suppress_type=$FlowTODO
+temp_dir=/tmp/flow
+traces=100
+types_first=true
+well_formed_exports=true
+well_formed_exports.includes=<PROJECT_ROOT>/dirA
+well_formed_exports.includes=<PROJECT_ROOT>/dirB
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "declarations": [],
+  "ignore": [],
+  "include": [],
+  "libs": [],
+  "lints": null,
+  "options": {
+    "all": true,
+    "babel_loose_array_spread": true,
+    "emoji": true,
+    "esproposal.class_instance_fields": "enable",
+    "esproposal.class_static_fields": "enable",
+    "esproposal.decorators": "warn",
+    "esproposal.export_star_as": "warn",
+    "esproposal.optional_chaining": "ignore",
+    "esproposal.nullish_coalescing": "ignore",
+    "exact_by_default": true,
+    "experimental.const_params": true,
+    "include_warnings": true,
+    "lazy_mode": "watchman",
+    "log.file": "/tmp/flow/yadada.log",
+    "max_header_tokens": 10,
+    "module.file_ext": [
+      ".foo",
+      ".bar"
+    ],
+    "module.ignore_non_literal_requires": true,
+    "module.name_mapper": [
+      "'^image![a-zA-Z0-9$_]+$' -> 'ImageStub'"
+    ],
+    "module.name_mapper.extension": [
+      "'css' -> '<PROJECT_ROOT>/CSSFlowStub.js.flow'"
+    ],
+    "module.system": "haste",
+    "module.system.node.main_field": [
+      "foo",
+      "bar",
+      "baz"
+    ],
+    "module.system.node.resolve_dirname": [
+      "node_modules",
+      "custom_node_modules"
+    ],
+    "module.use_strict": false,
+    "munge_underscores": false,
+    "no_flowlib": false,
+    "react.runtime": "automatic",
+    "server.max_workers": 2,
+    "sharedmemory.dirs": [
+      "/dev/shm",
+      "/tmp"
+    ],
+    "sharedmemory.minimum_available": 536870912,
+    "sharedmemory.hash_table_pow": 19,
+    "sharedmemory.heap_size": 26843545600,
+    "sharedmemory.log_level": 0,
+    "strip_root": false,
+    "suppress_comment": [
+      "\\\\\\\\(.\\\\\\\\|\\\\n\\\\\\\\)*\\\\\\\\$FlowFixMe1",
+      "\\\\\\\\(.\\\\\\\\|\\\\n\\\\\\\\)*\\\\\\\\$FlowFixMe2"
+    ],
+    "suppress_type": [
+      "$FlowFixMe",
+      "$FlowTODO"
+    ],
+    "temp_dir": "/tmp/flow",
+    "traces": 100,
+    "types_first": true,
+    "well_formed_exports": true,
+    "well_formed_exports.includes": [
+      "<PROJECT_ROOT>/dirA",
+      "<PROJECT_ROOT>/dirB"
+    ]
+  },
+  "strict": [],
+  "untyped": [],
+  "version": null
+}
+`;
+
+exports[`matches expected output: .flowconfig.universe 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+; https://flow.org/en/docs/config/ignore/
+[ignore]
+<PROJECT_ROOT>/\\.git/.*
+.+/.+\\.gzip\\.js
+.+/\\.next/.+
+
+; Do not use <PROJECT_ROOT> for Bazel, see: https://github.com/facebook/flow/issues/2250
+.+/bazel-bin/.+
+.+/bazel-out/.+
+.+/bazel-testlogs/.+
+.+/bazel-universe/.+
+
+
+; https://flow.org/en/docs/config/untyped/
+[untyped]
+
+
+; https://flow.org/en/docs/config/declarations/
+[declarations]
+.+/node_modules/.+
+
+
+; https://flow.org/en/docs/config/libs/
+[libs]
+./flow-typed/
+
+; Please note: one disadvantage of these libs is that it's gonna be available for every JS file even though
+; it should be defined only for one workspace.
+./src/monorepo-scanner/src/flow/
+
+
+; These lints are enabled in normal mode. Consult [strict] mode to see what additional lints
+; are enabled in strict mode. Only disabled rules in normal mode should be added to strict mode.
+;
+; https://flow.org/en/docs/config/lints/
+[lints]
+all=error
+ambiguous-object-type=off
+sketchy-null-bool=off
+unclear-type=off
+untyped-import=off
+
+
+; This setting complements [lints] section: all the enabled lints still throw errors + these
+; additional lints are enabled only in strict mode (no need to list here every lint). Local
+; strict mode behaves the same like strict mode except it turns off 'nonstrict-import' rule.
+;
+; https://flow.org/en/docs/strict/
+[strict]
+ambiguous-object-type
+sketchy-null-bool
+unclear-type
+untyped-import
+
+
+; https://flow.org/en/docs/config/options/
+[options]
+emoji=true
+exact_by_default=true
+include_warnings=true
+facebook.fbt=FbtWithoutString
+
+; This enables new react JSX transforms in flow
+react.runtime=automatic
+
+; Allow dynamic \`require(path.join(__dirname, 'myFile.json'))\`
+module.ignore_non_literal_requires=true
+
+; This option lets you alias 'any' with a given string - useful for explaining why you’re using 'any'.
+suppress_type=$FlowFixMe
+
+; This option is always ON in the strict mode. We are enabling it even for the classic mode.
+; Function parameters are considered const (i.e., treated as if they were declared with const rather than let).
+experimental.const_params=true
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "declarations": [
+    ".+/node_modules/.+"
+  ],
+  "ignore": [
+    "<PROJECT_ROOT>/\\\\.git/.*",
+    ".+/.+\\\\.gzip\\\\.js",
+    ".+/\\\\.next/.+",
+    ".+/bazel-bin/.+",
+    ".+/bazel-out/.+",
+    ".+/bazel-testlogs/.+",
+    ".+/bazel-universe/.+"
+  ],
+  "include": [],
+  "libs": [
+    "./flow-typed/",
+    "./src/monorepo-scanner/src/flow/"
+  ],
+  "lints": {
+    "all": "error",
+    "ambiguous-object-type": "off",
+    "sketchy-null-bool": "off",
+    "unclear-type": "off",
+    "untyped-import": "off"
+  },
+  "options": {
+    "emoji": true,
+    "exact_by_default": true,
+    "include_warnings": true,
+    "facebook.fbt": "FbtWithoutString",
+    "react.runtime": "automatic",
+    "module.ignore_non_literal_requires": true,
+    "suppress_type": [
+      "$FlowFixMe"
+    ],
+    "experimental.const_params": true
+  },
+  "strict": [
+    "ambiguous-object-type",
+    "sketchy-null-bool",
+    "unclear-type",
+    "untyped-import"
+  ],
+  "untyped": [],
+  "version": null
+}
+`;
+
+exports[`matches expected output: .flowconfig.untyped 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+; https://flow.org/en/docs/config/untyped/
+
+[untyped]
+.*/third_party/.*
+.*/src/\\(foo\\|bar\\)/.*
+.*\\.untype\\.js
+<PROJECT_ROOT>/third_party/.*
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "declarations": [],
+  "ignore": [],
+  "include": [],
+  "libs": [],
+  "lints": null,
+  "options": null,
+  "strict": [],
+  "untyped": [
+    ".*/third_party/.*",
+    ".*/src/\\\\(foo\\\\|bar\\\\)/.*",
+    ".*\\\\.untype\\\\.js",
+    "<PROJECT_ROOT>/third_party/.*"
+  ],
+  "version": null
+}
+`;
+
+exports[`matches expected output: .flowconfig.version 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+; https://flow.org/en/docs/config/version/
+
+[version]
+>=0.138.0 <0.140.0
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "declarations": [],
+  "ignore": [],
+  "include": [],
+  "libs": [],
+  "lints": null,
+  "options": null,
+  "strict": [],
+  "untyped": [],
+  "version": ">=0.138.0 <0.140.0"
+}
+`;

--- a/src/flow-config-parser/src/__tests__/__snapshots__/print.test.js.snap
+++ b/src/flow-config-parser/src/__tests__/__snapshots__/print.test.js.snap
@@ -1,20 +1,17 @@
-# @generated SignedSource<<a2c6e8cf57b16e0580b189be4f5ead10>>
-#
-# To regenerate run:
-# yarn monorepo-babel-node scripts/generateFlow.js
-#
-[declarations]
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prints the config correctly 1`] = `
+"[declarations]
 .+/node_modules/.+
 
 [ignore]
-<PROJECT_ROOT>/\.git/.*
-.+/.+\.gzip\.js
-.+/\.next/.+
+<PROJECT_ROOT>/\\\\.git/.*
+.+/.+\\\\.gzip\\\\.js
+.+/\\\\.next/.+
 .+/bazel-bin/.+
 .+/bazel-out/.+
 .+/bazel-testlogs/.+
 .+/bazel-universe/.+
-.*/*[.]android.js
 
 [include]
 
@@ -50,4 +47,5 @@ untyped-import
 
 
 [version]
-
+"
+`;

--- a/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.declarations
+++ b/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.declarations
@@ -1,0 +1,7 @@
+; https://flow.org/en/docs/config/declarations/
+
+[declarations]
+.*/third_party/.*
+.*/src/\(foo\|bar\)/.*
+.*\.decl\.js
+<PROJECT_ROOT>/third_party/.*

--- a/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.empty-sections
+++ b/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.empty-sections
@@ -1,0 +1,17 @@
+[declarations]
+
+[include]
+
+[ignore]
+
+[untyped]
+
+[libs]
+
+[lints]
+
+[options]
+
+[version]
+
+[strict]

--- a/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.empty-sections-comments
+++ b/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.empty-sections-comments
@@ -1,0 +1,78 @@
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[declarations]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[include]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[ignore]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[untyped]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[libs]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[lints]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[options]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[version]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment
+
+[strict]
+# This is a comment
+  # This is a comment
+; This is a comment
+  ; This is a comment
+💩 This is a comment
+  💩 This is a comment

--- a/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.ignore
+++ b/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.ignore
@@ -1,0 +1,10 @@
+; https://flow.org/en/docs/config/ignore/
+
+[ignore]
+.*/__tests__/.*
+.*/src/\(foo\|bar\)/.*
+.*\.ignore\.js
+<PROJECT_ROOT>/__tests__/.*
+<PROJECT_ROOT>/node_modules/.*
+!<PROJECT_ROOT>/node_modules/not-ignored-package-A/.*
+!<PROJECT_ROOT>/node_modules/not-ignored-package-B/.*

--- a/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.include
+++ b/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.include
@@ -1,0 +1,7 @@
+; https://flow.org/en/docs/config/include/
+
+[include]
+../externalFile.js
+../externalDir/
+../otherProject/*.js
+../otherProject/**/coolStuff/

--- a/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.invalid
+++ b/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.invalid
@@ -1,0 +1,29 @@
+💩 Purpose of this fixture is to see how it behaves when the config is
+💩 crazy invalid (and potentially improve the behavior).
+
+[ignore]
+<PROJECT_ROOT>/\.git/.*
+<PROJECT_ROOT>/\.git/.*
+<PROJECT_ROOT>/\.git/.*
+
+[ignore]
+<PROJECT_ROOT>/\.hg/.*
+<PROJECT_ROOT>/\.hg/.*
+
+[IGNORE]
+<PROJECT_ROOT>
+
+[unknown]
+{
+  "what": {
+    "is": {
+      "this": -1
+    }
+  }
+}
+
+[[ignore]]
+
+[version]
+>=0.138.0 <0.140.0
+0.138.0

--- a/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.options
+++ b/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.options
@@ -1,0 +1,54 @@
+; https://flow.org/en/docs/config/options/
+
+[options]
+all=true
+babel_loose_array_spread=true
+emoji=true
+esproposal.class_instance_fields=enable
+esproposal.class_static_fields=enable
+esproposal.decorators=warn
+esproposal.export_star_as=warn
+esproposal.optional_chaining=ignore
+esproposal.nullish_coalescing=ignore
+exact_by_default=true
+experimental.const_params=true
+include_warnings=true
+lazy_mode=watchman
+log.file=/tmp/flow/yadada.log
+max_header_tokens=10
+module.file_ext=.foo
+module.file_ext=.bar
+module.ignore_non_literal_requires=true
+
+; TODO: should we expand these mappers (?)
+module.name_mapper='^image![a-zA-Z0-9$_]+$' -> 'ImageStub'
+module.name_mapper.extension='css' -> '<PROJECT_ROOT>/CSSFlowStub.js.flow'
+
+module.system=haste
+module.system.node.main_field=foo
+module.system.node.main_field=bar
+module.system.node.main_field=baz
+module.system.node.resolve_dirname=node_modules
+module.system.node.resolve_dirname=custom_node_modules
+module.use_strict=false
+munge_underscores=false
+no_flowlib=false
+react.runtime=automatic
+server.max_workers=2
+sharedmemory.dirs=/dev/shm
+sharedmemory.dirs=/tmp
+sharedmemory.minimum_available=536870912
+sharedmemory.hash_table_pow=19
+sharedmemory.heap_size=26843545600
+sharedmemory.log_level=0
+strip_root=false
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe1
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe2
+suppress_type=$FlowFixMe
+suppress_type=$FlowTODO
+temp_dir=/tmp/flow
+traces=100
+types_first=true
+well_formed_exports=true
+well_formed_exports.includes=<PROJECT_ROOT>/dirA
+well_formed_exports.includes=<PROJECT_ROOT>/dirB

--- a/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.universe
+++ b/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.universe
@@ -1,0 +1,74 @@
+; https://flow.org/en/docs/config/ignore/
+[ignore]
+<PROJECT_ROOT>/\.git/.*
+.+/.+\.gzip\.js
+.+/\.next/.+
+
+; Do not use <PROJECT_ROOT> for Bazel, see: https://github.com/facebook/flow/issues/2250
+.+/bazel-bin/.+
+.+/bazel-out/.+
+.+/bazel-testlogs/.+
+.+/bazel-universe/.+
+
+
+; https://flow.org/en/docs/config/untyped/
+[untyped]
+
+
+; https://flow.org/en/docs/config/declarations/
+[declarations]
+.+/node_modules/.+
+
+
+; https://flow.org/en/docs/config/libs/
+[libs]
+./flow-typed/
+
+; Please note: one disadvantage of these libs is that it's gonna be available for every JS file even though
+; it should be defined only for one workspace.
+./src/monorepo-scanner/src/flow/
+
+
+; These lints are enabled in normal mode. Consult [strict] mode to see what additional lints
+; are enabled in strict mode. Only disabled rules in normal mode should be added to strict mode.
+;
+; https://flow.org/en/docs/config/lints/
+[lints]
+all=error
+ambiguous-object-type=off
+sketchy-null-bool=off
+unclear-type=off
+untyped-import=off
+
+
+; This setting complements [lints] section: all the enabled lints still throw errors + these
+; additional lints are enabled only in strict mode (no need to list here every lint). Local
+; strict mode behaves the same like strict mode except it turns off 'nonstrict-import' rule.
+;
+; https://flow.org/en/docs/strict/
+[strict]
+ambiguous-object-type
+sketchy-null-bool
+unclear-type
+untyped-import
+
+
+; https://flow.org/en/docs/config/options/
+[options]
+emoji=true
+exact_by_default=true
+include_warnings=true
+facebook.fbt=FbtWithoutString
+
+; This enables new react JSX transforms in flow
+react.runtime=automatic
+
+; Allow dynamic `require(path.join(__dirname, 'myFile.json'))`
+module.ignore_non_literal_requires=true
+
+; This option lets you alias 'any' with a given string - useful for explaining why you’re using 'any'.
+suppress_type=$FlowFixMe
+
+; This option is always ON in the strict mode. We are enabling it even for the classic mode.
+; Function parameters are considered const (i.e., treated as if they were declared with const rather than let).
+experimental.const_params=true

--- a/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.untyped
+++ b/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.untyped
@@ -1,0 +1,7 @@
+; https://flow.org/en/docs/config/untyped/
+
+[untyped]
+.*/third_party/.*
+.*/src/\(foo\|bar\)/.*
+.*\.untype\.js
+<PROJECT_ROOT>/third_party/.*

--- a/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.version
+++ b/src/flow-config-parser/src/__tests__/fixtures/.flowconfig.version
@@ -1,0 +1,4 @@
+; https://flow.org/en/docs/config/version/
+
+[version]
+>=0.138.0 <0.140.0

--- a/src/flow-config-parser/src/__tests__/merge.test.js
+++ b/src/flow-config-parser/src/__tests__/merge.test.js
@@ -1,0 +1,134 @@
+// @flow strict
+
+import merge from '../merge';
+
+it('merges [ignore] correctly', () => {
+  const configA = `
+    [ignore]
+    <PROJECT_ROOT>/\\.git/.*
+  `;
+
+  const configB = `
+    [ignore]
+    <PROJECT_ROOT>/\\.hg/.*
+  `;
+
+  expect(merge(configA, configB)).toMatchInlineSnapshot(`
+    "[declarations]
+
+
+    [ignore]
+    <PROJECT_ROOT>/\\\\.git/.*
+    <PROJECT_ROOT>/\\\\.hg/.*
+
+    [include]
+
+
+    [libs]
+
+
+    [lints]
+
+    [options]
+
+    [strict]
+
+
+    [untyped]
+
+
+    [version]
+    "
+  `);
+});
+
+it('merges [options] correctly', () => {
+  const configA = `
+    [options]
+    emoji=true
+    module.file_ext=.foo
+    module.file_ext=.bar
+  `;
+
+  // 1) `emoji` should be overwritten
+  // 2) `module.file_ext` should be merged into the list
+  // 3) `munge_underscores` should be added
+  const configB = `
+    [options]
+    emoji=false
+    module.file_ext=.baz
+    munge_underscores=false
+  `;
+
+  expect(merge(configA, configB)).toMatchInlineSnapshot(`
+    "[declarations]
+
+
+    [ignore]
+
+
+    [include]
+
+
+    [libs]
+
+
+    [lints]
+
+    [options]
+    emoji=false
+    module.file_ext=.foo
+    module.file_ext=.bar
+    module.file_ext=.baz
+    munge_underscores=false
+
+    [strict]
+
+
+    [untyped]
+
+
+    [version]
+    "
+  `);
+});
+
+it('merges [version] correctly', () => {
+  const configA = `
+    [version]
+    0.138.0
+  `;
+
+  const configB = `
+    [version]
+    >=0.138.0 <0.140.0
+  `;
+
+  expect(merge(configA, configB)).toMatchInlineSnapshot(`
+    "[declarations]
+
+
+    [ignore]
+
+
+    [include]
+
+
+    [libs]
+
+
+    [lints]
+
+    [options]
+
+    [strict]
+
+
+    [untyped]
+
+
+    [version]
+    >=0.138.0 <0.140.0
+    "
+  `);
+});

--- a/src/flow-config-parser/src/__tests__/parse.test.js
+++ b/src/flow-config-parser/src/__tests__/parse.test.js
@@ -1,0 +1,8 @@
+// @flow
+
+import path from 'path';
+import { generateTestsFromFixtures } from '@adeira/test-utils';
+
+import parse from '../parse';
+
+generateTestsFromFixtures(path.join(__dirname, 'fixtures'), parse);

--- a/src/flow-config-parser/src/__tests__/print.test.js
+++ b/src/flow-config-parser/src/__tests__/print.test.js
@@ -1,0 +1,19 @@
+// @flow strict
+
+import fs from 'fs';
+import path from 'path';
+
+import parse from '../parse';
+import print from '../print';
+
+it('prints the config correctly', () => {
+  const parsedConfig = parse(
+    fs.readFileSync(path.join(__dirname, 'fixtures', '.flowconfig.universe'), 'utf8'),
+  );
+  const printedConfig = print(parsedConfig);
+
+  expect(printedConfig).toMatchSnapshot();
+
+  // let's parse the printed config once again and compare it with the original (it should match)
+  expect(parse(printedConfig)).toStrictEqual(parsedConfig);
+});

--- a/src/flow-config-parser/src/index.js
+++ b/src/flow-config-parser/src/index.js
@@ -1,0 +1,5 @@
+// @flow strict
+
+export { default as merge } from './merge';
+export { default as parse } from './parse';
+export { default as print } from './print';

--- a/src/flow-config-parser/src/merge.js
+++ b/src/flow-config-parser/src/merge.js
@@ -1,0 +1,35 @@
+// @flow strict
+
+import parse from './parse';
+import print from './print';
+import { KNOWN_LIST_OPTIONS } from './utils';
+
+export default function merge(flowconfigA: string, flowconfigB: string): string {
+  const configA = parse(flowconfigA);
+  const configB = parse(flowconfigB);
+
+  for (const section of Object.keys(configB)) {
+    const sectionValues = configB[section];
+    if (Array.isArray(sectionValues)) {
+      // merge lists together
+      configA[section] = configA[section].concat(sectionValues);
+    } else if (section === 'version') {
+      // special case for version
+      configA[section] = sectionValues;
+    } else if (sectionValues != null) {
+      // go through each property and either overwrite it or merge it into the list
+      for (const sectionValueKey of Object.keys(sectionValues)) {
+        const sectionValue = sectionValues[sectionValueKey];
+        if (KNOWN_LIST_OPTIONS.includes(sectionValueKey)) {
+          configA[section][sectionValueKey] = configA[section][sectionValueKey].concat(
+            sectionValue,
+          );
+        } else {
+          configA[section][sectionValueKey] = sectionValue;
+        }
+      }
+    }
+  }
+
+  return print(configA);
+}

--- a/src/flow-config-parser/src/parse.js
+++ b/src/flow-config-parser/src/parse.js
@@ -1,0 +1,80 @@
+// @flow strict
+
+import { isNumeric, invariant } from '@adeira/js';
+
+import { isListSection, KNOWN_LIST_OPTIONS } from './utils';
+import type { ParsedConfig } from './ParsedConfig.flow';
+
+export default function parse(input: string): ParsedConfig {
+  const lines = input
+    .split(/\r?\n+/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const parsedConfig = {
+    // default values
+    declarations: [],
+    ignore: [],
+    include: [],
+    libs: [],
+    lints: null,
+    options: null,
+    strict: [],
+    untyped: [],
+    version: null,
+  };
+
+  let currentSection = null;
+  for (const line of lines) {
+    const commentMatch = line.match(/[;#💩]/u);
+    if (commentMatch) {
+      continue;
+    }
+
+    const sectionMatch = line.match(/\[(?<sectionName>[a-z]+)]/i);
+    if (sectionMatch) {
+      // TODO: validate sections (?)
+      currentSection = sectionMatch.groups?.sectionName.toLowerCase();
+      continue;
+    }
+
+    invariant(currentSection != null, 'All config values must be inside some section.');
+
+    if (isListSection(currentSection)) {
+      // process it as a list
+      parsedConfig[currentSection].push(line);
+    } else if (currentSection === 'version') {
+      parsedConfig[currentSection] = line;
+    } else {
+      // process it as a key/value
+      const keyValueMatch = line.match(/(?<rawKey>.+)\s*?=\s*?(?<rawValue>.+)/);
+      if (keyValueMatch) {
+        const rawKey = keyValueMatch.groups?.rawKey;
+        const rawValue = keyValueMatch.groups?.rawValue;
+        const key = rawKey?.trim();
+        if (parsedConfig[currentSection] === null) {
+          parsedConfig[currentSection] = {};
+        }
+        if (KNOWN_LIST_OPTIONS.includes(key)) {
+          const previousValues = parsedConfig[currentSection][key] ?? [];
+          parsedConfig[currentSection][key] = previousValues.concat(rawValue);
+        } else {
+          parsedConfig[currentSection][key] = transformKeyValue(rawValue);
+        }
+      }
+    }
+  }
+
+  return parsedConfig;
+}
+
+function transformKeyValue(value) {
+  if (value?.toLowerCase() === 'true') {
+    return true;
+  } else if (value?.toLowerCase() === 'false') {
+    return false;
+  } else if (isNumeric(value)) {
+    return Number(value);
+  }
+  return value;
+}

--- a/src/flow-config-parser/src/print.js
+++ b/src/flow-config-parser/src/print.js
@@ -1,0 +1,35 @@
+// @flow strict
+
+import { KNOWN_LIST_OPTIONS } from './utils';
+import type { ParsedConfig } from './ParsedConfig.flow';
+
+export default function print(flowconfig: ParsedConfig): string {
+  let printedConfig = '';
+
+  let sep = '';
+  for (const sectionName of Object.keys(flowconfig)) {
+    const sectionValues = flowconfig[sectionName];
+    printedConfig += `${sep}[${sectionName}]\n`;
+    sep = '\n';
+
+    if (Array.isArray(sectionValues)) {
+      printedConfig += `${sectionValues.join('\n')}\n`;
+    } else if (sectionName === 'version' && sectionValues != null) {
+      printedConfig += `${sectionValues}\n`;
+    } else if (sectionValues != null) {
+      // go through the individual values and print them
+      for (const sectionValueKey of Object.keys(sectionValues)) {
+        const sectionValue = sectionValues[sectionValueKey];
+        if (KNOWN_LIST_OPTIONS.includes(sectionValueKey)) {
+          for (const value of sectionValue) {
+            printedConfig += `${sectionValueKey}=${value}\n`;
+          }
+        } else {
+          printedConfig += `${sectionValueKey}=${sectionValue}\n`;
+        }
+      }
+    }
+  }
+
+  return printedConfig;
+}

--- a/src/flow-config-parser/src/utils.js
+++ b/src/flow-config-parser/src/utils.js
@@ -1,0 +1,25 @@
+// @flow strict
+
+// https://github.com/facebook/flow/issues/6904
+export function isListSection(sectionName: string | null): boolean %checks {
+  return (
+    sectionName === 'declarations' ||
+    sectionName === 'ignore' ||
+    sectionName === 'include' ||
+    sectionName === 'libs' ||
+    sectionName === 'strict' ||
+    sectionName === 'untyped'
+  );
+}
+
+export const KNOWN_LIST_OPTIONS = [
+  'module.file_ext',
+  'module.name_mapper',
+  'module.name_mapper.extension',
+  'module.system.node.main_field',
+  'module.system.node.resolve_dirname',
+  'sharedmemory.dirs',
+  'suppress_comment',
+  'suppress_type',
+  'well_formed_exports.includes',
+];

--- a/src/monorepo-shipit/config/__tests__/flow-config-parser.test.js
+++ b/src/monorepo-shipit/config/__tests__/flow-config-parser.test.js
@@ -1,0 +1,20 @@
+// @flow strict-local
+
+import path from 'path';
+
+import testExportedPaths from './testExportedPaths';
+
+testExportedPaths(path.join(__dirname, '..', 'flow-config-parser.js'), [
+  ['src/flow-config-parser/src/__tests__/parse.test.js', 'src/__tests__/parse.test.js'],
+  ['src/flow-config-parser/src/parse.js', 'src/parse.js'],
+  ['src/flow-config-parser/src/index.js', 'src/index.js'],
+  ['src/flow-config-parser/package.json', 'package.json'],
+
+  // invalid cases:
+  ['src/packages/monorepo/outsideScope.js', undefined], // correctly deleted
+  ['src/flow-config-parser/BUILD.bazel', undefined], // correctly deleted
+  ['src/flow-config-parser/BUILD', undefined], // correctly deleted
+  ['src/flow-config-parser/WORKSPACE.bazel', undefined], // correctly deleted
+  ['src/flow-config-parser/WORKSPACE', undefined], // correctly deleted
+  ['package.json', undefined], // correctly deleted
+]);

--- a/src/monorepo-shipit/config/flow-config-parser.js
+++ b/src/monorepo-shipit/config/flow-config-parser.js
@@ -1,0 +1,14 @@
+// @flow strict
+
+import type { ConfigType } from '../ConfigType.flow';
+
+module.exports = ({
+  getStaticConfig() {
+    return {
+      repository: 'git@github.com:adeira/flow-config-parser.git',
+    };
+  },
+  getPathMappings() {
+    return new Map([['src/flow-config-parser/', '']]);
+  },
+}: ConfigType);


### PR DESCRIPTION
Purpose of this commit is to introduce new package with permissive Flow config parser. The motivation is to be able to merge several Flow configs (templates) together into the main one (since Flow doesn't support nested configs similarly to Eslint). So far, I am using only to create a single config version for React Native. However, eventually, I'd like to collect flowconfigs from any project in the monorepo and generate one large flowconfig in the root (so you don't have to specify the things there manually).

It is inspired by this project: https://github.com/gajus/flow-runtime/tree/master/packages/flow-config-parser, however, our parser is up-to-date, more benevolent and works quite differently for purposes of this project (to be able to merge the configs for example).