### PR TITLE
scanner: Test that we have no @adeira package in yarn.lock

### DIFF
--- a/src/flow-config-parser/package.json
+++ b/src/flow-config-parser/package.json
@@ -7,8 +7,8 @@
   "license": "MIT",
   "main": "src/index",
   "dependencies": {
+    "@adeira/fixtures-tester": "^0.1.0",
     "@adeira/js": "^1.3.0",
-    "@adeira/test-utils": "^0.6.0",
     "@babel/runtime": "^7.12.5"
   }
 }

--- a/src/flow-config-parser/src/__tests__/parse.test.js
+++ b/src/flow-config-parser/src/__tests__/parse.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import path from 'path';
-import { generateTestsFromFixtures } from '@adeira/test-utils';
+import { generateTestsFromFixtures } from '@adeira/fixtures-tester';
 
 import parse from '../parse';
 

--- a/src/monorepo-scanner/src/scans/YarnLock.scan.js
+++ b/src/monorepo-scanner/src/scans/YarnLock.scan.js
@@ -1,0 +1,13 @@
+// @flow
+
+import fs from 'fs';
+import path from 'path';
+import { findMonorepoRoot } from '@adeira/monorepo-utils';
+
+const yarnLockPath = path.join(findMonorepoRoot(), 'yarn.lock');
+
+const yarnLockContent = fs.readFileSync(yarnLockPath, 'utf-8');
+
+test('yarn.lock does not contain adeira packages', () => {
+  expect(/@adeira/g.test(yarnLockContent)).toBe(false);
+});


### PR DESCRIPTION
If we forget to upgrade a dependency in one of our packages
We might get an old version from npm installed instead.
This should fail the CI if we don't keep our deps up to date