### PR TITLE
Cleanup '@adeira/murmur-hash' in preparation for stable release

### DIFF
--- a/src/murmur-hash/README.md
+++ b/src/murmur-hash/README.md
@@ -8,6 +8,12 @@ Read more about MurmurHash in this Stack Overflow question: [MurmurHash - what i
 yarn add @adeira/murmur-hash
 ```
 
+Optionally, install TS types (Flow types are included by default):
+
+```text
+yarn add --dev @types/adeira__murmur-hash
+```
+
 # Basic usage
 
 ```js
@@ -17,5 +23,3 @@ const data = { arg: { count: 20, start: 0, end: 5 } };
 const hash = murmurHash(JSON.stringify(data));
 console.log(hash); // 4gykY2
 ```
-
-Flow and Typescript supported.

--- a/src/murmur-hash/src/murmurHash.d.ts
+++ b/src/murmur-hash/src/murmurHash.d.ts
@@ -1,1 +1,0 @@
-export default function murmurHash(str: string): string;


### PR DESCRIPTION
TS definitions moved to DefinitelyTyped (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49865) since we cannot maintain/test them properly. Please review that PR as well.

I'd like to release a stable version once we merge the TS types PR.