### PR TITLE
Babel plugin Adeira: use '@babel/eslint-parser'

### DIFF
--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "eslint-config-prettier": "^6.14.0",
-    "eslint-plugin-adeira": "^0.11.0",
+    "eslint-plugin-adeira": "^0.12.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-flowtype": "^5.2.0",

--- a/src/eslint-plugin-adeira/BUILD.bazel
+++ b/src/eslint-plugin-adeira/BUILD.bazel
@@ -9,7 +9,7 @@ build_yarn_workspace(
 test_yarn_workspace(
     name = "test",
     deps = [
-        "@npm//babel-eslint",
+        "@npm//@babel/eslint-parser",
         "@npm//eslint",
         "@npm//fast-levenshtein",
     ],

--- a/src/eslint-plugin-adeira/package.json
+++ b/src/eslint-plugin-adeira/package.json
@@ -1,10 +1,10 @@
 {
   "name": "eslint-plugin-adeira",
-  "description": "Additional Eslint rules for Adeira projects. Do not use directly - use @adeira/eslint-config instead.",
+  "description": "Additional Eslint rules for Adeira projects. Prefer to use @adeira/eslint-config instead.",
   "homepage": "https://github.com/adeira/universe/tree/master/src/eslint-plugin-adeira",
   "license": "MIT",
   "private": false,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "main": "src/index",
   "sideEffects": false,
   "dependencies": {
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@adeira/eslint-fixtures-tester": "0.0.0",
     "@adeira/flow-types-eslint": "0.0.0",
+    "@babel/eslint-parser": "^7.12.1",
     "eslint": "^7.14.0"
   },
   "peerDependencies": {

--- a/src/eslint-plugin-adeira/src/rules/__tests__/graphql-require-object-description.test.js
+++ b/src/eslint-plugin-adeira/src/rules/__tests__/graphql-require-object-description.test.js
@@ -5,7 +5,7 @@ const RuleTester = require('eslint').RuleTester;
 const rule = require('../graphql-require-object-description');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 ruleTester.run('graphql-require-object-description', rule, {

--- a/src/eslint-plugin-adeira/src/rules/__tests__/no-duplicate-import-type-import.test.js
+++ b/src/eslint-plugin-adeira/src/rules/__tests__/no-duplicate-import-type-import.test.js
@@ -5,7 +5,7 @@ const RuleTester = require('eslint').RuleTester;
 const rule = require('../no-duplicate-import-type-import');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 ruleTester.run('no-duplicate-import', rule, {

--- a/src/eslint-plugin-adeira/src/rules/__tests__/no-internal-flow-type.test.js
+++ b/src/eslint-plugin-adeira/src/rules/__tests__/no-internal-flow-type.test.js
@@ -5,7 +5,7 @@ const RuleTester = require('eslint').RuleTester;
 const rule = require('../no-internal-flow-type');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 ruleTester.run('no-internal-flow-type', rule, {

--- a/src/eslint-plugin-adeira/src/rules/__tests__/relay-import-no-values.test.js
+++ b/src/eslint-plugin-adeira/src/rules/__tests__/relay-import-no-values.test.js
@@ -5,7 +5,7 @@ const RuleTester = require('eslint').RuleTester;
 const rule = require('../relay-import-no-values');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 ruleTester.run('no-values', rule, {

--- a/src/eslint-plugin-adeira/src/rules/__tests__/relay-import-type-must-exist.test.js
+++ b/src/eslint-plugin-adeira/src/rules/__tests__/relay-import-type-must-exist.test.js
@@ -16,7 +16,7 @@ jest.mock('../../readFileSync', () => (path, options) => {
 });
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 ruleTester.run('type-must-exist', rule, {

--- a/src/eslint-plugin-adeira/src/rules/__tests__/valid-test-folder.test.js
+++ b/src/eslint-plugin-adeira/src/rules/__tests__/valid-test-folder.test.js
@@ -5,7 +5,7 @@ const RuleTester = require('eslint').RuleTester;
 const rule = require('../valid-test-folder');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 ruleTester.run('valid-test-folder', rule, {


### PR DESCRIPTION
`babel-eslint` is deprecated, see: https://github.com/adeira/universe/issues/941