### PR TITLE
Shipit: fix 'moveDirectories' filter escaping

### DIFF
--- a/src/monorepo-shipit/src/filters/__tests__/__snapshots__/moveDirectories.test.js.snap
+++ b/src/monorepo-shipit/src/filters/__tests__/__snapshots__/moveDirectories.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`handles complex filenames requiring regexp escaping correctly 1`] = `
+Changeset {
+  "author": undefined,
+  "description": "MOCKED_HEADER",
+  "diffs": Set {
+    Object {
+      "body": "new file mode 100644
+index 0000000000000000000000000000000000000000..fb7887c2e2ec937f47e9a58a22ffc8fd705379ff
+--- /dev/null
++++ b/react-native/ios/YaComiste/Images.xcassets/Logo (no background).imageset/Contents.json
+@@ -0,0 +1,21 @@
++{
++  \\"images\\" : [
++    {
++      \\"idiom\\" : \\"universal\\",
++      \\"scale\\" : \\"1x\\"
++    },
++    {
++      \\"idiom\\" : \\"universal\\",
++      \\"scale\\" : \\"2x\\"
++    },
++    {
++      \\"filename\\" : \\"100.png\\",
++      \\"idiom\\" : \\"universal\\",
++      \\"scale\\" : \\"3x\\"
++    }
++  ],
++  \\"info\\" : {
++    \\"author\\" : \\"xcode\\",
++    \\"version\\" : 1
++  }
++}
+",
+      "path": "react-native/ios/YaComiste/Images.xcassets/Logo (no background).imageset/Contents.json",
+    },
+  },
+  "id": undefined,
+  "subject": undefined,
+  "timestamp": undefined,
+}
+`;

--- a/src/monorepo-shipit/src/filters/__tests__/_esc.test.js
+++ b/src/monorepo-shipit/src/filters/__tests__/_esc.test.js
@@ -1,0 +1,14 @@
+// @flow strict
+
+import _esc from '../_esc';
+
+const ESCAPED = '\\^\\$\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\\\';
+const UNESCAPED = '^$.*+?()[]{}|\\';
+
+it('should escape values', function () {
+  expect(_esc(UNESCAPED + UNESCAPED)).toStrictEqual(ESCAPED + ESCAPED);
+});
+
+it('should handle strings with nothing to escape', function () {
+  expect(_esc('abc')).toStrictEqual('abc');
+});

--- a/src/monorepo-shipit/src/filters/__tests__/fixtures/new-file-complex.patch
+++ b/src/monorepo-shipit/src/filters/__tests__/fixtures/new-file-complex.patch
@@ -1,0 +1,30 @@
+diff --git a/src/ya-comiste-react-native/ios/YaComiste/Images.xcassets/Logo (no background).imageset/Contents.json b/src/ya-comiste-react-native/ios/YaComiste/Images.xcassets/Logo (no background).imageset/Contents.json
+new file mode 100644
+index 0000000000000000000000000000000000000000..fb7887c2e2ec937f47e9a58a22ffc8fd705379ff
+--- /dev/null
++++ b/src/ya-comiste-react-native/ios/YaComiste/Images.xcassets/Logo (no background).imageset/Contents.json
+@@ -0,0 +1,21 @@
++{
++  "images" : [
++    {
++      "idiom" : "universal",
++      "scale" : "1x"
++    },
++    {
++      "idiom" : "universal",
++      "scale" : "2x"
++    },
++    {
++      "filename" : "100.png",
++      "idiom" : "universal",
++      "scale" : "3x"
++    }
++  ],
++  "info" : {
++    "author" : "xcode",
++    "version" : 1
++  }
++}
+--
+2.9.3
+

--- a/src/monorepo-shipit/src/filters/_esc.js
+++ b/src/monorepo-shipit/src/filters/_esc.js
@@ -1,0 +1,12 @@
+// @flow strict
+
+/**
+ * Escapes the `RegExp` special characters "^", "$", "\", ".", "*", "+",
+ * "?", "(", ")", "[", "]", "{", "}", and "|" in `string`.
+ *
+ * @see https://github.com/lodash/lodash/blob/e0029485ab4d97adea0cb34292afb6700309cf16/escapeRegExp.js
+ */
+export default function _esc(s: string): string {
+  // RegExp.escape substitute
+  return s.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+}

--- a/src/monorepo-shipit/src/filters/conditionalLines.js
+++ b/src/monorepo-shipit/src/filters/conditionalLines.js
@@ -1,12 +1,7 @@
 // @flow strict
 
 import Changeset from '../Changeset';
-
-// https://github.com/lodash/lodash/blob/f8c7064d450cc068144c4dad1d63535cba25ae6d/escapeRegExp.js
-function _e(s) {
-  // RegExp.escape substitute
-  return s.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
-}
+import _esc from './_esc';
 
 function process(changeset: Changeset, pattern: RegExp, replacement: string) {
   const diffs = new Set();
@@ -30,7 +25,9 @@ export function commentLines(
   commentEnd: null | string = null,
 ): Changeset {
   const ending = commentEnd === null ? '' : ` ${commentEnd}`;
-  const pattern = new RegExp(`^([-+ ]\\s*)(\\S.*) ${_e(commentStart)} ${_e(marker)}${_e(ending)}$`);
+  const pattern = new RegExp(
+    `^([-+ ]\\s*)(\\S.*) ${_esc(commentStart)} ${_esc(marker)}${_esc(ending)}$`,
+  );
   return process(changeset, pattern, `$1${commentStart} ${marker}: $2${ending}`);
 }
 
@@ -41,6 +38,8 @@ export function uncommentLines(
   commentEnd: null | string = null,
 ): Changeset {
   const ending = commentEnd === null ? '' : ` ${commentEnd}`;
-  const pattern = new RegExp(`^([-+ ]\\s*)${_e(commentStart)} ${_e(marker)}: (.+)${_e(ending)}$`);
+  const pattern = new RegExp(
+    `^([-+ ]\\s*)${_esc(commentStart)} ${_esc(marker)}: (.+)${_esc(ending)}$`,
+  );
   return process(changeset, pattern, `$1$2 ${commentStart} ${marker}${ending}`);
 }

--- a/src/monorepo-shipit/src/filters/moveDirectories.js
+++ b/src/monorepo-shipit/src/filters/moveDirectories.js
@@ -1,5 +1,6 @@
 // @flow strict
 
+import _esc from './_esc';
 import Changeset from '../Changeset';
 
 /**
@@ -13,10 +14,10 @@ export default function moveDirectories(
     let newPath = oldPath;
     for (const [src, dest] of mapping.entries()) {
       let matchFound = false;
-      if (new RegExp(`^${src}`).test(newPath)) {
+      if (new RegExp(`^${_esc(src)}`).test(newPath)) {
         matchFound = true;
       }
-      newPath = newPath.replace(new RegExp(`^${src}`), dest);
+      newPath = newPath.replace(new RegExp(`^${_esc(src)}`), dest);
       if (matchFound) {
         break; // only first match in the map
       }
@@ -34,8 +35,8 @@ export default function moveDirectories(
     }
 
     let body = diff.body;
-    body = body.replace(new RegExp(`^--- a/${oldPath}`, 'm'), `--- a/${newPath}`);
-    body = body.replace(new RegExp(`^\\+\\+\\+ b/${oldPath}`, 'm'), `+++ b/${newPath}`);
+    body = body.replace(new RegExp(`^--- a/${_esc(oldPath)}`, 'm'), `--- a/${newPath}`);
+    body = body.replace(new RegExp(`^\\+\\+\\+ b/${_esc(oldPath)}`, 'm'), `+++ b/${newPath}`);
 
     diffs.add({
       path: newPath,


### PR DESCRIPTION
Previously, Shipit was not able to handle complex file paths such as the following correctly:

```text
Images.xcassets/Logo (no background).imageset/Contents.json
```

This commit should fix the issue allowing it to work again for these complex paths.