### PR TITLE
CI: setup Rust cross compilation (Apple, Linux)

### DIFF
--- a/.github/workflows/continuous-integration-rust.yml
+++ b/.github/workflows/continuous-integration-rust.yml
@@ -3,29 +3,67 @@ name: Continuous Integration (Rust)
 on:
   push:
     paths:
+      - '.github/workflows/**'
       - 'src/ya-comiste-rust/**'
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
+  build-macos:
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2.3.4
 
       # https://github.com/actions-rs/toolchain
       - uses: actions-rs/toolchain@v1.0.7
         with:
+          profile: minimal
           toolchain: stable
-
-      # https://github.com/actions-rs/clippy-check
-      - uses: actions-rs/clippy-check@v1.0.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --manifest-path src/ya-comiste-rust/Cargo.toml
+          target: x86_64-apple-darwin # 64-bit OSX (10.7+, Lion+)
 
       # https://github.com/actions-rs/cargo
       - name: Run all tests
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --manifest-path src/ya-comiste-rust/Cargo.toml
+          args: >-
+            --manifest-path src/ya-comiste-rust/Cargo.toml
+            --target x86_64-apple-darwin
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      # https://github.com/actions-rs/toolchain
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          components: clippy
+          toolchain: stable
+          target: x86_64-unknown-linux-gnu # 64-bit Linux (kernel 2.6.32+, glibc 2.11+)
+
+      # https://github.com/actions-rs/clippy-check
+      - uses: actions-rs/clippy-check@v1.0.7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: >-
+            --manifest-path src/ya-comiste-rust/Cargo.toml
+            --target x86_64-unknown-linux-gnu
+
+      # https://github.com/actions-rs/cargo
+      - name: Run all tests
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+          args: >-
+            --manifest-path src/ya-comiste-rust/Cargo.toml
+            --target x86_64-unknown-linux-gnu
+
+      # https://github.com/actions-rs/cargo
+      - name: Try to build a release
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: >-
+            --manifest-path src/ya-comiste-rust/Cargo.toml
+            --target x86_64-unknown-linux-gnu
+            --release


### PR DESCRIPTION
To make sure the code works for both Apple and Linux platforms. CI for each platform is slightly different: for Apple we run only tests to make sure it works for local development whereas on Linux we run Clippy, tests and release build (the assumption is that production uses Linux). This also saves some CI time on Macos machine.