### PR TITLE
Relay runtime: fix broken Flow types

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -29,7 +29,8 @@ jobs:
       - name: yarn install, build, and test
         run: |
           yarn install --frozen-lockfile
-          yarn run typecheck
+          yarn run typecheck-ios --all
+          yarn run typecheck-android --all
           yarn run lint
           yarn run test-only
           yarn workspace @adeira/example-relay test-bc

--- a/src/relay-runtime/src/RelayEagerLogger.js
+++ b/src/relay-runtime/src/RelayEagerLogger.js
@@ -56,14 +56,16 @@ export default function RelayEagerLogger(logEvent: LogEvent) {
       undefined,
       'color:red',
     );
-  } else if (
-    logEvent.name === 'execute.complete' ||
-    logEvent.name === 'execute.info' ||
-    logEvent.name === 'execute.unsubscribe'
-  ) {
+  } else if (logEvent.name === 'execute.complete' || logEvent.name === 'execute.unsubscribe') {
     logGroup(groupMessage);
   } else if (
     logEvent.name === 'entrypoint.root.consume' ||
+    logEvent.name === 'network.complete' ||
+    logEvent.name === 'network.error' ||
+    logEvent.name === 'network.info' ||
+    logEvent.name === 'network.next' ||
+    logEvent.name === 'network.start' ||
+    logEvent.name === 'network.unsubscribe' ||
     logEvent.name === 'queryresource.fetch' ||
     logEvent.name === 'queryresource.retain' ||
     logEvent.name === 'store.gc' ||

--- a/src/relay-runtime/src/RelayLazyLogger.js
+++ b/src/relay-runtime/src/RelayLazyLogger.js
@@ -61,7 +61,12 @@ export default function RelayLazyLogger(logEvent: LogEvent) {
     );
   } else if (
     logEvent.name === 'entrypoint.root.consume' ||
-    logEvent.name === 'execute.info' ||
+    logEvent.name === 'network.complete' ||
+    logEvent.name === 'network.error' ||
+    logEvent.name === 'network.info' ||
+    logEvent.name === 'network.next' ||
+    logEvent.name === 'network.start' ||
+    logEvent.name === 'network.unsubscribe' ||
     logEvent.name === 'queryresource.fetch' ||
     logEvent.name === 'queryresource.retain' ||
     logEvent.name === 'store.gc' ||

--- a/src/relay-runtime/src/__tests__/RelayEagerLogger.test.js
+++ b/src/relay-runtime/src/__tests__/RelayEagerLogger.test.js
@@ -109,7 +109,7 @@ it("calls event 'execute.error' as expected", () => {
   );
 });
 
-test.each(['execute.info', 'execute.complete', 'execute.unsubscribe'])(
+test.each(['execute.complete', 'execute.unsubscribe'])(
   "calls event '%s' as expected",
   (eventName) => {
     // $FlowExpectedError[speculation-ambiguous]: OK for testing purposes - additional props are being ignored for these events


### PR DESCRIPTION
Somehow, we merged a PR with Relay 10.1.1 without catching the Flow errors on CI. Here is what _I think_ happened:

- the PR changed only `package.json` files which we correctly written into `.flow.saved_state_file_changes`
- we started the server in a lazy FS mode which initialized with 0 changed files (also correct)
- we called `flow force-recheck` for these `package.json` files which however doesn't refocus well enough and doesn't have any effect on the typechecking -> still 0 changed files
- Flow said "OK" even though there were errors

This workflow usually works for JS files but it doesn't work when no JS files changed (in the previous scenario only JSON files changed).

I created a TODO for myself to improve the workflow, possibly to remove the lazy mode completely (or run Flow properly on CI without shortcuts).