### PR TITLE
SXT Plugin: Migrate to sxt attribute

### DIFF
--- a/src/babel-plugin-transform-sx-tailwind/README.md
+++ b/src/babel-plugin-transform-sx-tailwind/README.md
@@ -6,13 +6,12 @@ This has a positive impact on the final bundle size because the huge Tailwind de
 
 ```diff
 import React from 'react';
-- import { tailwind } from '@adeira/sx-tailwind';
 + import sx from '@adeira/sx';
 
 export default function Example() {
   return (
     <button
--      className={tailwind('bg-blue-500 text-white font-bold')}
+-      sxt="bg-blue-500 text-white font-bold"
 +      className={__styles('bg-blue-500', 'text-white', 'font-bold')}
       type="button"
     >

--- a/src/babel-plugin-transform-sx-tailwind/package.json
+++ b/src/babel-plugin-transform-sx-tailwind/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/babel-plugin-transform-sx-tailwind",
   "license": "MIT",
   "private": false,
-  "version": "0.15.0",
+  "version": "0.16.0",
   "main": "src/index",
   "sideEffects": false,
   "module": false,

--- a/src/babel-plugin-transform-sx-tailwind/src/StringLiteralHandler.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/StringLiteralHandler.js
@@ -1,0 +1,24 @@
+// @flow
+
+const t = require('@babel/types');
+
+export default function TemplateLiteralHandler(
+  path /*: any */,
+  stylesCollector /*: any[] */,
+  stylesVarName /*: string */,
+) {
+  const styles = path.node.value.value.split(' ').filter((s) => s !== '');
+  stylesCollector.push(...styles);
+
+  path.replaceWith(
+    t.jsxAttribute(
+      t.jsxIdentifier('className'),
+      t.JSXExpressionContainer(
+        t.callExpression(
+          t.identifier(stylesVarName),
+          styles.map((style) => t.stringLiteral(style)),
+        ),
+      ),
+    ),
+  );
+}

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/__snapshots__/index.test.js.snap
@@ -5,17 +5,12 @@ exports[`transform SX Tailwind animation.js: animation.js 1`] = `
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Node {
   return (
-    <span className={tailwind('flex h-3 w-3')}>
-      <span
-        className={tailwind(
-          'animate-ping absolute inline-flex h-full w-full rounded-full bg-pink-400 opacity-75',
-        )}
-      />
-      <span className={tailwind('relative inline-flex rounded-full h-3 w-3 bg-pink-500')} />
+    <span sxt="flex h-3 w-3">
+      <span sxt="animate-ping absolute inline-flex h-full w-full rounded-full bg-pink-400 opacity-75" />
+      <span sxt="relative inline-flex rounded-full h-3 w-3 bg-pink-500" />
     </span>
   );
 }
@@ -112,13 +107,12 @@ exports[`transform SX Tailwind custom-font.js: custom-font.js 1`] = `
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Node {
   return (
     <>
-      <div className={tailwind('font-sans')}>Sans text</div>
-      <div className={tailwind('font-mono')}>Monospace text</div>
+      <div sxt="font-sans">Sans text</div>
+      <div sxt="font-mono">Monospace text</div>
     </>
   );
 }
@@ -154,10 +148,9 @@ exports[`transform SX Tailwind invalid-utility-class.js: invalid-utility-class.j
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Node {
-  return <div className={tailwind('bg-bleu-500')}>Button</div>;
+  return <div sxt="bg-bleu-500">Button</div>;
 }
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -171,13 +164,12 @@ exports[`transform SX Tailwind nested.js: nested.js 1`] = `
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Node {
   return (
-    <div className={tailwind('text-white bg-black')}>
+    <div sxt="text-white bg-black">
       White on black
-      <div className={tailwind('text-black bg-white')}>Black on white</div>
+      <div sxt="text-black bg-white">Black on white</div>
     </div>
   );
 }
@@ -252,14 +244,10 @@ exports[`transform SX Tailwind styles-var-exists.js: styles-var-exists.js 1`] = 
 // @flow
 
 import type { Element } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Element<'button'> {
   return (
-    <button
-      className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold')}
-      type="button"
-    >
+    <button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold" type="button">
       Button
     </button>
   );
@@ -314,17 +302,13 @@ exports[`transform SX Tailwind sx-already-imported.js: sx-already-imported.js 1`
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 import sx from '@adeira/sx';
 
 export default function Example(): Node {
   return (
     <div>
       <div className={styles('text-red')}>Red text</div>
-      <button
-        className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold')}
-        type="button"
-      >
+      <button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold" type="button">
         Button
       </button>
     </div>
@@ -389,17 +373,13 @@ exports[`transform SX Tailwind sx-imported-alias.js: sx-imported-alias.js 1`] = 
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 import { create } from '@adeira/sx';
 
 export default function Example(): Node {
   return (
     <>
       <div className={styles('text-red')}>Red text</div>
-      <button
-        className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold')}
-        type="button"
-      >
+      <button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold" type="button">
         Button
       </button>
     </>
@@ -416,8 +396,8 @@ const styles = create({
 
 // @flow
 import type { Node } from 'react';
-import sx from '@adeira/sx';
 import { create } from '@adeira/sx';
+import sx from '@adeira/sx';
 export default function Example(): Node {
   return (
     <>
@@ -465,14 +445,10 @@ exports[`transform SX Tailwind tailwind.js: tailwind.js 1`] = `
 // @flow
 
 import type { Element } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Element<'button'> {
   return (
-    <button
-      className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold')}
-      type="button"
-    >
+    <button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold" type="button">
       Button
     </button>
   );
@@ -522,14 +498,10 @@ exports[`transform SX Tailwind tailwind-aliased.js: tailwind-aliased.js 1`] = `
 // @flow
 
 import type { Element } from 'react';
-import { tailwind as myTailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Element<'button'> {
   return (
-    <button
-      className={myTailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold')}
-      type="button"
-    >
+    <button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold" type="button">
       Button
     </button>
   );
@@ -579,10 +551,9 @@ exports[`transform SX Tailwind template-literal.js: template-literal.js 1`] = `
 // @flow
 
 import React, { type Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Node {
-  return <div className={tailwind(\`text-black bg-white\`)}>Lorem lipsum</div>;
+  return <div sxt={\`text-black bg-white\`}>Lorem lipsum</div>;
 }
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -613,16 +584,11 @@ exports[`transform SX Tailwind template-literal-condition.js: template-literal-c
 // @flow
 
 import React, { type Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Node {
   const darkMode = true;
   return (
-    <div
-      className={tailwind(
-        \`px-4 font-bold \${darkMode ? \`text-white bg-black\` : 'text-black bg-white'} rounded\`,
-      )}
-    >
+    <div sxt={\`px-4 font-bold \${darkMode ? \`text-white bg-black\` : 'text-black bg-white'} rounded\`}>
       Lorem lipsum
     </div>
   );
@@ -686,11 +652,10 @@ exports[`transform SX Tailwind template-literal-expression.js: template-literal-
 // @flow
 
 import React, { type Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 import sx from '@adeira/sx';
 
 export default function Example(): Node {
-  return <div className={\`\${tailwind('px-4')} \${styles('customStyle')}\`}>Lorem lipsum</div>;
+  return <div sxt={\`px-4 \${styles('customStyle')}\`}>Lorem lipsum</div>;
 }
 
 const styles = sx.create({

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/animation.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/animation.js
@@ -1,17 +1,12 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Node {
   return (
-    <span className={tailwind('flex h-3 w-3')}>
-      <span
-        className={tailwind(
-          'animate-ping absolute inline-flex h-full w-full rounded-full bg-pink-400 opacity-75',
-        )}
-      />
-      <span className={tailwind('relative inline-flex rounded-full h-3 w-3 bg-pink-500')} />
+    <span sxt="flex h-3 w-3">
+      <span sxt="animate-ping absolute inline-flex h-full w-full rounded-full bg-pink-400 opacity-75" />
+      <span sxt="relative inline-flex rounded-full h-3 w-3 bg-pink-500" />
     </span>
   );
 }

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/custom-font.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/custom-font.js
@@ -1,13 +1,12 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Node {
   return (
     <>
-      <div className={tailwind('font-sans')}>Sans text</div>
-      <div className={tailwind('font-mono')}>Monospace text</div>
+      <div sxt="font-sans">Sans text</div>
+      <div sxt="font-mono">Monospace text</div>
     </>
   );
 }

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/error/invalid-utility-class.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/error/invalid-utility-class.js
@@ -1,8 +1,7 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Node {
-  return <div className={tailwind('bg-bleu-500')}>Button</div>;
+  return <div sxt="bg-bleu-500">Button</div>;
 }

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/nested.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/nested.js
@@ -1,13 +1,12 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Node {
   return (
-    <div className={tailwind('text-white bg-black')}>
+    <div sxt="text-white bg-black">
       White on black
-      <div className={tailwind('text-black bg-white')}>Black on white</div>
+      <div sxt="text-black bg-white">Black on white</div>
     </div>
   );
 }

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/styles-var-exists.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/styles-var-exists.js
@@ -1,14 +1,10 @@
 // @flow
 
 import type { Element } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Element<'button'> {
   return (
-    <button
-      className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold')}
-      type="button"
-    >
+    <button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold" type="button">
       Button
     </button>
   );

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/sx-already-imported.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/sx-already-imported.js
@@ -1,17 +1,13 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 import sx from '@adeira/sx';
 
 export default function Example(): Node {
   return (
     <div>
       <div className={styles('text-red')}>Red text</div>
-      <button
-        className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold')}
-        type="button"
-      >
+      <button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold" type="button">
         Button
       </button>
     </div>

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/sx-imported-alias.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/sx-imported-alias.js
@@ -1,17 +1,13 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 import { create } from '@adeira/sx';
 
 export default function Example(): Node {
   return (
     <>
       <div className={styles('text-red')}>Red text</div>
-      <button
-        className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold')}
-        type="button"
-      >
+      <button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold" type="button">
         Button
       </button>
     </>

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/tailwind-aliased.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/tailwind-aliased.js
@@ -1,14 +1,10 @@
 // @flow
 
 import type { Element } from 'react';
-import { tailwind as myTailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Element<'button'> {
   return (
-    <button
-      className={myTailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold')}
-      type="button"
-    >
+    <button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold" type="button">
       Button
     </button>
   );

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/tailwind.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/tailwind.js
@@ -1,14 +1,10 @@
 // @flow
 
 import type { Element } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Element<'button'> {
   return (
-    <button
-      className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold')}
-      type="button"
-    >
+    <button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold" type="button">
       Button
     </button>
   );

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal-condition.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal-condition.js
@@ -1,16 +1,11 @@
 // @flow
 
 import React, { type Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Node {
   const darkMode = true;
   return (
-    <div
-      className={tailwind(
-        `px-4 font-bold ${darkMode ? `text-white bg-black` : 'text-black bg-white'} rounded`,
-      )}
-    >
+    <div sxt={`px-4 font-bold ${darkMode ? `text-white bg-black` : 'text-black bg-white'} rounded`}>
       Lorem lipsum
     </div>
   );

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal-expression.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal-expression.js
@@ -1,11 +1,10 @@
 // @flow
 
 import React, { type Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 import sx from '@adeira/sx';
 
 export default function Example(): Node {
-  return <div className={`${tailwind('px-4')} ${styles('customStyle')}`}>Lorem lipsum</div>;
+  return <div sxt={`px-4 ${styles('customStyle')}`}>Lorem lipsum</div>;
 }
 
 const styles = sx.create({

--- a/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/__tests__/fixtures/template-literal.js
@@ -1,8 +1,7 @@
 // @flow
 
 import React, { type Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Example(): Node {
-  return <div className={tailwind(`text-black bg-white`)}>Lorem lipsum</div>;
+  return <div sxt={`text-black bg-white`}>Lorem lipsum</div>;
 }

--- a/src/babel-plugin-transform-sx-tailwind/src/index.js
+++ b/src/babel-plugin-transform-sx-tailwind/src/index.js
@@ -8,7 +8,6 @@ require('@babel/register')({
 // END-ADEIRA-UNIVERSE-INTERNAL
 
 const template = require('@babel/template').default;
-const t = require('@babel/types');
 const murmurHash = require('@adeira/murmur-hash').default;
 const childProcess = require('child_process');
 const findCacheDir = require('find-cache-dir');
@@ -18,15 +17,17 @@ const hash = require('object-hash');
 
 const getCssDeclarations = require('./getCssDeclarations').default;
 const TemplateLiteralHandler = require('./TemplateLiteralHandler').default;
+const StringLiteralHandler = require('./StringLiteralHandler').default;
 
 const PLUGIN_NAME = 'sx-tailwind-babel-transform';
 
 module.exports = function sxTailwindBabelPlugin() /*: any */ {
   let stylesCollector = [];
-  let tailwindCallee = '';
   let stylesVarName = 'styles';
   let styles = {};
   let keyframes = {};
+  let lastImportPointer;
+  let sxImported = false;
 
   return {
     name: PLUGIN_NAME,
@@ -51,41 +52,35 @@ module.exports = function sxTailwindBabelPlugin() /*: any */ {
       styles = cache.styles;
     },
     visitor: {
-      ImportDeclaration(path) {
-        if (path.node.source.value === '@adeira/sx-tailwind') {
-          path.node.specifiers.forEach(({ imported, local }) => {
-            if (imported.name === 'tailwind') {
-              tailwindCallee = local.name;
-            }
-          });
+      JSXAttribute(path) {
+        if (path.node.name.name !== 'sxt') {
+          return;
+        }
 
-          const sxImport = template.ast(`import sx from '@adeira/sx'`);
-          path.replaceWith(sxImport);
+        path.traverse({
+          TemplateLiteral(path) {
+            TemplateLiteralHandler(path, stylesCollector, stylesVarName);
+          },
+        });
+
+        if (path.node.value.type === 'StringLiteral') {
+          StringLiteralHandler(path, stylesCollector, stylesVarName);
         }
       },
-      CallExpression(path) {
-        if (path.node.callee.name === tailwindCallee) {
-          path.traverse({
-            TemplateLiteral(path) {
-              TemplateLiteralHandler(path, stylesCollector, stylesVarName);
-            },
-          });
-
-          if (path.node.arguments.length === 1 && path.node.arguments[0].type === 'StringLiteral') {
-            const styles = path.node.arguments[0].value.split(' ').filter((s) => s !== '');
-            stylesCollector.push(...styles);
-
-            path.replaceWith(
-              t.callExpression(
-                t.identifier(stylesVarName),
-                styles.map((style) => t.stringLiteral(style)),
-              ),
-            );
-          }
+      ImportDeclaration(path) {
+        if (
+          path.node.source.value === '@adeira/sx' &&
+          path.node.specifiers.find(
+            (s) => s.type === 'ImportDefaultSpecifier' && s.local.name === 'sx',
+          )
+        ) {
+          sxImported = true;
         }
+        lastImportPointer = path;
       },
       Program: {
         enter(path, state) {
+          sxImported = false;
           stylesCollector = [];
           const filename = state.file.opts.filename.split('/').slice(-2).join('/');
           stylesVarName = `__styles_${murmurHash(filename)}`;
@@ -95,40 +90,30 @@ module.exports = function sxTailwindBabelPlugin() /*: any */ {
             stylesCollector.map((style) => [style, getCssDeclarations(style, keyframes, styles)]),
           );
 
-          if (Object.keys(declarations).length > 0) {
-            path.node.body.push(
-              template.ast(`const ${stylesVarName} = sx.create(${JSON.stringify(declarations)})`),
-            );
-            // if animation is used, transform "sx.keyframe" string into call expression
-            path.traverse({
-              ObjectProperty(path) {
-                if (
-                  typeof path.node.key.value !== 'string' ||
-                  !path.node.key.value.startsWith('--animation-name-')
-                ) {
-                  return;
-                }
-                const sxKeyframe = template.ast(path.node.value.value);
-                path.node.value = sxKeyframe.expression;
-              },
-            });
+          if (Object.keys(declarations).length === 0) {
+            return;
           }
 
-          // is there SX imported twice?
-          const sxImports = path.node.body.reduce((a, { type, source, specifiers }, index) => {
-            if (
-              type === 'ImportDeclaration' &&
-              source.value === '@adeira/sx' &&
-              Array.isArray(specifiers) &&
-              specifiers[0].type === 'ImportDefaultSpecifier'
-            ) {
-              a.push(index);
-            }
-            return a;
-          }, []);
-          if (sxImports.length > 1) {
-            delete path.node.body[sxImports[0]];
+          if (sxImported === false) {
+            lastImportPointer.insertAfter(template.ast(`import sx from '@adeira/sx'`));
           }
+
+          path.node.body.push(
+            template.ast(`const ${stylesVarName} = sx.create(${JSON.stringify(declarations)})`),
+          );
+          // if animation is used, transform "sx.keyframe" string into call expression
+          path.traverse({
+            ObjectProperty(path) {
+              if (
+                typeof path.node.key.value !== 'string' ||
+                !path.node.key.value.startsWith('--animation-name-')
+              ) {
+                return;
+              }
+              const sxKeyframe = template.ast(path.node.value.value);
+              path.node.value = sxKeyframe.expression;
+            },
+          });
         },
       },
     },

--- a/src/sx-tailwind-website/.babelrc.js
+++ b/src/sx-tailwind-website/.babelrc.js
@@ -1,6 +1,7 @@
 // @flow strict
 
-const colors = require('tailwindcss/colors')
+const defaultTheme = require('tailwindcss/defaultTheme');
+const colors = require('tailwindcss/colors');
 
 module.exports = {
   presets: ['@adeira/babel-preset-adeira', 'next/babel'],
@@ -8,9 +9,9 @@ module.exports = {
     [
       '@adeira/babel-plugin-transform-sx-tailwind',
       {
-        "theme": {
+        theme: {
           colors: {
-            white: '#fff',
+            white: colors.white,
             transparent: 'transparent',
             blue: colors.blue,
             gray: colors.trueGray,
@@ -21,28 +22,13 @@ module.exports = {
             red: colors.rose,
             teal: colors.teal,
           },
-          "extend": {
-            "fontFamily": {
-              "sans": [
-                'Inter',
-                'system-ui',
-                '-apple-system',
-                'BlinkMacSystemFont',
-                '"Segoe UI"',
-                'Roboto',
-                '"Helvetica Neue"',
-                'Arial',
-                '"Noto Sans"',
-                'sans-serif',
-                '"Apple Color Emoji"',
-                '"Segoe UI Emoji"',
-                '"Segoe UI Symbol"',
-                '"Noto Color Emoji"',
-              ]
-            }
-          }
-        }
-      }
-    ]
+          extend: {
+            fontFamily: {
+              sans: ['Inter', ...defaultTheme.fontFamily.sans],
+            },
+          },
+        },
+      },
+    ],
   ],
 };

--- a/src/sx-tailwind-website/__github__/babel.config.js
+++ b/src/sx-tailwind-website/__github__/babel.config.js
@@ -1,5 +1,7 @@
 // @flow
 
+/* eslint-disable import/no-extraneous-dependencies */
+
 const defaultTheme = require('tailwindcss/defaultTheme');
 const colors = require('tailwindcss/colors');
 
@@ -31,7 +33,7 @@ module.exports = function (api /*: ApiType */) /*: BabelConfig */ {
         {
           theme: {
             colors: {
-              white: '#fff',
+              white: colors.white,
               transparent: 'transparent',
               blue: colors.blue,
               gray: colors.trueGray,

--- a/src/sx-tailwind-website/next.config.js
+++ b/src/sx-tailwind-website/next.config.js
@@ -5,14 +5,7 @@ const withTranspileModules = require('next-transpile-modules');
 const withCustomBabelConfigFile = require('next-plugin-custom-babel-config');
 
 module.exports = (withCustomBabelConfigFile(
-  withTranspileModules([
-    '@adeira/css-colors',
-    '@adeira/js',
-    '@adeira/monorepo-utils',
-    '@adeira/murmur-hash',
-    '@adeira/sx',
-    '@adeira/sx-tailwind',
-  ])({
+  withTranspileModules(['@adeira/css-colors', '@adeira/js', '@adeira/murmur-hash', '@adeira/sx'])({
     babelConfigFile: path.join(__dirname, '.babelrc.js'),
     webpack: (config) => {
       config.module.rules.push({

--- a/src/sx-tailwind-website/package.json
+++ b/src/sx-tailwind-website/package.json
@@ -4,25 +4,22 @@
   "license": "UNLICENSED",
   "private": true,
   "dependencies": {
-    "@adeira/js": "^1.2.4",
-    "@adeira/monorepo-utils": "^0.11.0",
     "@adeira/sx": "^0.22.0",
-    "@adeira/sx-tailwind": "^0.11.0",
     "hast-util-to-html": "^7.1.2",
     "next": "^10.0.3",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "refractor": "^3.2.0"
+  },
+  "devDependencies": {
+    "@adeira/babel-plugin-transform-sx-tailwind": "^0.16.0",
+    "@adeira/babel-preset-adeira": "^2.0.0",
+    "@babel/core": "^7.12.10",
+    "flow-bin": "^0.141.0",
     "next-plugin-custom-babel-config": "^1.0.4",
     "next-transpile-modules": "^6.0.0",
     "postcss": "^8.2.1",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "refractor": "^3.2.0",
     "tailwindcss": "^2.0.2"
-  },
-  "devDependencies": {
-    "@adeira/babel-plugin-transform-sx-tailwind": "^0.15.0",
-    "@adeira/babel-preset-adeira": "^2.0.0",
-    "@babel/core": "^7.12.10",
-    "flow-bin": "^0.141.0"
   },
   "scripts": {
     "dev": "next",

--- a/src/sx-tailwind-website/src/Homepage/index.js
+++ b/src/sx-tailwind-website/src/Homepage/index.js
@@ -35,7 +35,7 @@ export default function Homepage(): Node {
       <P>
         There&apos;s no need to learn anything new if you already know Tailwind CSS and React. Where
         in HTML you wrote <Code>{`class="text-gray-900"`}</Code> you&apos;ll write{' '}
-        <Code>{`className={tailwind('text-gray-900')}`}</Code> in React.
+        <Code>{`sxt="text-gray-900"`}</Code> in React.
       </P>
       <P>
         See for yourself in the{' '}

--- a/src/sx-tailwind-website/src/TailwindCss/Documentation.js
+++ b/src/sx-tailwind-website/src/TailwindCss/Documentation.js
@@ -11,8 +11,7 @@ export default function Documentation(): Node {
     <Layout title="Documentation">
       <H2>Install</H2>
       <CodeBlock language="bash">
-        {`yarn add @adeira/sx-tailwind
-yarn add --dev @adeira/babel-plugin-transform-sx-tailwind`}
+        {`yarn add --dev @adeira/babel-plugin-transform-sx-tailwind`}
       </CodeBlock>
 
       <H2>Babel config</H2>
@@ -24,13 +23,9 @@ yarn add --dev @adeira/babel-plugin-transform-sx-tailwind`}
 
       <H2>Usage</H2>
       <CodeBlock>
-        {`import { tailwind } from '@adeira/sx-tailwind';
-
-export default function Button() {
+        {`export default function Button() {
   return (
-    <button
-      className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded')}
-    >
+    <button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
       Button
     </button>
   );

--- a/src/sx-tailwind-website/src/TailwindCss/alerts/Banner.js
+++ b/src/sx-tailwind-website/src/TailwindCss/alerts/Banner.js
@@ -1,16 +1,12 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Banner(): Node {
   return (
-    <div
-      className={tailwind('bg-blue-100 border-t border-b border-blue-500 text-blue-700 px-4 py-3')}
-      role="alert"
-    >
-      <p className={tailwind('font-bold')}>Informational message</p>
-      <p className={tailwind('text-sm')}>Some additional text to explain said message.</p>
+    <div sxt="bg-blue-100 border-t border-b border-blue-500 text-blue-700 px-4 py-3" role="alert">
+      <p sxt="font-bold">Informational message</p>
+      <p sxt="text-sm">Some additional text to explain said message.</p>
     </div>
   );
 }

--- a/src/sx-tailwind-website/src/TailwindCss/alerts/LeftAccentBorder.js
+++ b/src/sx-tailwind-website/src/TailwindCss/alerts/LeftAccentBorder.js
@@ -1,15 +1,11 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function LeftAccentBorder(): Node {
   return (
-    <div
-      className={tailwind('bg-orange-100 border-l-4 border-orange-500 text-orange-700 p-4')}
-      role="alert"
-    >
-      <p className={tailwind('font-bold')}>Be Warned</p>
+    <div sxt="bg-orange-100 border-l-4 border-orange-500 text-orange-700 p-4" role="alert">
+      <p sxt="font-bold">Be Warned</p>
       <p>Something not ideal might be happening.</p>
     </div>
   );

--- a/src/sx-tailwind-website/src/TailwindCss/alerts/ModernWithBadge.js
+++ b/src/sx-tailwind-website/src/TailwindCss/alerts/ModernWithBadge.js
@@ -1,29 +1,22 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function ModernWithBadge(): Node {
   return (
-    <div className={tailwind('bg-indigo-900 text-center py-4 lg:px-4')}>
+    <div sxt="bg-indigo-900 text-center py-4 lg:px-4">
       <div
-        className={tailwind(
-          'p-2 bg-indigo-800 items-center text-indigo-100 leading-none lg:rounded-full flex lg:inline-flex',
-        )}
+        sxt="p-2 bg-indigo-800 items-center text-indigo-100 leading-none lg:rounded-full flex lg:inline-flex"
         role="alert"
       >
-        <span
-          className={tailwind(
-            'flex rounded-full bg-indigo-500 uppercase px-2 py-1 text-xs font-bold mr-3',
-          )}
-        >
+        <span sxt="flex rounded-full bg-indigo-500 uppercase px-2 py-1 text-xs font-bold mr-3">
           New
         </span>
-        <span className={tailwind('font-semibold mr-2 text-left flex-auto')}>
+        <span sxt="font-semibold mr-2 text-left flex-auto">
           Get the coolest t-shirts from our brand new store
         </span>
         <svg
-          className={tailwind('fill-current opacity-75 h-4 w-4')}
+          sxt="fill-current opacity-75 h-4 w-4"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
         >

--- a/src/sx-tailwind-website/src/TailwindCss/alerts/Solid.js
+++ b/src/sx-tailwind-website/src/TailwindCss/alerts/Solid.js
@@ -1,19 +1,11 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Solid(): Node {
   return (
-    <div
-      className={tailwind('flex items-center bg-blue-500 text-white text-sm font-bold px-4 py-3')}
-      role="alert"
-    >
-      <svg
-        className={tailwind('fill-current w-4 h-4 mr-2')}
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 20 20"
-      >
+    <div sxt="flex items-center bg-blue-500 text-white text-sm font-bold px-4 py-3" role="alert">
+      <svg sxt="fill-current w-4 h-4 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
         <path d="M12.432 0c1.34 0 2.01.912 2.01 1.957 0 1.305-1.164 2.512-2.679 2.512-1.269 0-2.009-.75-1.974-1.99C9.789 1.436 10.67 0 12.432 0zM8.309 20c-1.058 0-1.833-.652-1.093-3.524l1.214-5.092c.211-.814.246-1.141 0-1.141-.317 0-1.689.562-2.502 1.117l-.528-.88c2.572-2.186 5.531-3.467 6.801-3.467 1.057 0 1.233 1.273.705 3.23l-1.391 5.352c-.246.945-.141 1.271.106 1.271.317 0 1.357-.392 2.379-1.207l.6.814C12.098 19.02 9.365 20 8.309 20z" />
       </svg>
       <p>Something happened that you should know about.</p>

--- a/src/sx-tailwind-website/src/TailwindCss/alerts/Titled.js
+++ b/src/sx-tailwind-website/src/TailwindCss/alerts/Titled.js
@@ -1,17 +1,12 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Titled(): Node {
   return (
     <div role="alert">
-      <div className={tailwind('bg-red-500 text-white font-bold rounded-t px-4 py-2')}>Danger</div>
-      <div
-        className={tailwind(
-          'border border-t-0 border-red-400 rounded-b bg-red-100 px-4 py-3 text-red-700',
-        )}
-      >
+      <div sxt="bg-red-500 text-white font-bold rounded-t px-4 py-2">Danger</div>
+      <div sxt="border border-t-0 border-red-400 rounded-b bg-red-100 px-4 py-3 text-red-700">
         <p>Something not ideal might be happening.</p>
       </div>
     </div>

--- a/src/sx-tailwind-website/src/TailwindCss/alerts/TopAccentBorder.js
+++ b/src/sx-tailwind-website/src/TailwindCss/alerts/TopAccentBorder.js
@@ -1,20 +1,17 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function TopAccentBorder(): Node {
   return (
     <div
-      className={tailwind(
-        'bg-teal-100 border-t-4 border-teal-500 rounded-b text-teal-900 px-4 py-3 shadow-md',
-      )}
+      sxt="bg-teal-100 border-t-4 border-teal-500 rounded-b text-teal-900 px-4 py-3 shadow-md"
       role="alert"
     >
-      <div className={tailwind('flex')}>
-        <div className={tailwind('py-1')}>
+      <div sxt="flex">
+        <div sxt="py-1">
           <svg
-            className={tailwind('fill-current h-6 w-6 text-teal-500 mr-4')}
+            sxt="fill-current h-6 w-6 text-teal-500 mr-4"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 20 20"
           >
@@ -22,8 +19,8 @@ export default function TopAccentBorder(): Node {
           </svg>
         </div>
         <div>
-          <p className={tailwind('font-bold')}>Our privacy policy has changed</p>
-          <p className={tailwind('text-sm')}>Make sure you know how these changes affect you.</p>
+          <p sxt="font-bold">Our privacy policy has changed</p>
+          <p sxt="text-sm">Make sure you know how these changes affect you.</p>
         </div>
       </div>
     </div>

--- a/src/sx-tailwind-website/src/TailwindCss/alerts/Traditional.js
+++ b/src/sx-tailwind-website/src/TailwindCss/alerts/Traditional.js
@@ -1,21 +1,18 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Traditional(): Node {
   return (
     <div
-      className={tailwind(
-        'bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative',
-      )}
+      sxt="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative"
       role="alert"
     >
-      <strong className={tailwind('font-bold')}>Holy smokes! </strong>
-      <span className={tailwind('block sm:inline')}>Something seriously bad happened.</span>
-      <span className={tailwind('absolute top-0 bottom-0 right-0 px-4 py-3')}>
+      <strong sxt="font-bold">Holy smokes! </strong>
+      <span sxt="block sm:inline">Something seriously bad happened.</span>
+      <span sxt="absolute top-0 bottom-0 right-0 px-4 py-3">
         <svg
-          className={tailwind('fill-current h-6 w-6 text-red-500')}
+          sxt="fill-current h-6 w-6 text-red-500"
           role="button"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"

--- a/src/sx-tailwind-website/src/TailwindCss/animations/Bounce.js
+++ b/src/sx-tailwind-website/src/TailwindCss/animations/Bounce.js
@@ -1,12 +1,11 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Bounce(): Node {
   return (
     <svg
-      className={tailwind('animate-bounce w-6 h-6 text-gray-900 mx-auto')}
+      sxt="animate-bounce w-6 h-6 text-gray-900 mx-auto"
       fill="none"
       strokeLinecap="round"
       strokeLinejoin="round"
@@ -19,7 +18,7 @@ export default function Bounce(): Node {
   );
 }
 
-export const code = `<svg className={tailwind('animate-bounce w-6 h-6 text-gray-900 mx-auto')} fill="none" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" stroke="currentColor">
+export const code = `<svg sxt="animate-bounce w-6 h-6 text-gray-900 mx-auto" fill="none" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" stroke="currentColor">
   <path d="M19 14l-7 7m0 0l-7-7m7 7V3" />
 </svg>
 `;

--- a/src/sx-tailwind-website/src/TailwindCss/animations/Ping.js
+++ b/src/sx-tailwind-website/src/TailwindCss/animations/Ping.js
@@ -1,33 +1,26 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Ping(): Node {
   return (
-    <span className={tailwind('relative inline-flex rounded-md shadow-sm')}>
+    <span sxt="relative inline-flex rounded-md shadow-sm">
       <button
         type="button"
-        className={tailwind(
-          'inline-flex items-center px-4 py-2 border border-gray-400 text-base leading-6 font-medium rounded-md text-gray-800 bg-white hover:text-gray-700 focus:outline-none focus:border-blue-300',
-        )}
+        sxt="inline-flex items-center px-4 py-2 border border-gray-400 text-base leading-6 font-medium rounded-md text-gray-800 bg-white hover:text-gray-700 focus:outline-none focus:border-blue-300"
       >
         Transactions
       </button>
-      <span className={tailwind('flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1')}>
-        <span
-          className={tailwind(
-            'animate-ping absolute inline-flex h-full w-full rounded-full bg-pink-400 opacity-75',
-          )}
-        />
-        <span className={tailwind('relative inline-flex rounded-full h-3 w-3 bg-pink-500')} />
+      <span sxt="flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1">
+        <span sxt="animate-ping absolute inline-flex h-full w-full rounded-full bg-pink-400 opacity-75" />
+        <span sxt="relative inline-flex rounded-full h-3 w-3 bg-pink-500" />
       </span>
     </span>
   );
 }
 
-export const code = `<span className={tailwind('flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1')}>
-  <span className={tailwind('animate-ping absolute inline-flex h-full w-full rounded-full bg-pink-400 opacity-75')} />
-  <span className={tailwind('relative inline-flex rounded-full h-3 w-3 bg-pink-500')} />
+export const code = `<span sxt="flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1">
+  <span sxt="animate-ping absolute inline-flex h-full w-full rounded-full bg-pink-400 opacity-75" />
+  <span sxt="relative inline-flex rounded-full h-3 w-3 bg-pink-500" />
 </span>
 `;

--- a/src/sx-tailwind-website/src/TailwindCss/animations/Pulse.js
+++ b/src/sx-tailwind-website/src/TailwindCss/animations/Pulse.js
@@ -1,20 +1,17 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Pulse(): Node {
   return (
-    <div
-      className={tailwind('border border-gray-300 shadow rounded-md p-4 max-w-sm w-full mx-auto')}
-    >
-      <div className={tailwind('animate-pulse flex')}>
-        <div className={tailwind('rounded-full bg-gray-400 h-12 w-12 mr-4')} />
-        <div className={tailwind('flex-1 py-1')}>
-          <div className={tailwind('h-4 bg-gray-400 rounded w-3/4')} />
-          <div className={tailwind('py-4')}>
-            <div className={tailwind('h-4 mb-2 bg-gray-400 rounded')} />
-            <div className={tailwind('h-4 bg-gray-400 rounded w-5/6')} />
+    <div sxt="border border-gray-300 shadow rounded-md p-4 max-w-sm w-full mx-auto">
+      <div sxt="animate-pulse flex">
+        <div sxt="rounded-full bg-gray-400 h-12 w-12 mr-4" />
+        <div sxt="flex-1 py-1">
+          <div sxt="h-4 bg-gray-400 rounded w-3/4" />
+          <div sxt="py-4">
+            <div sxt="h-4 mb-2 bg-gray-400 rounded" />
+            <div sxt="h-4 bg-gray-400 rounded w-5/6" />
           </div>
         </div>
       </div>
@@ -22,14 +19,14 @@ export default function Pulse(): Node {
   );
 }
 
-export const code = `<div className={tailwind('border border-gray-300 shadow rounded-md p-4 max-w-sm w-full mx-auto')}>
-  <div className={tailwind('animate-pulse flex')}>
-    <div className={tailwind('rounded-full bg-gray-400 h-12 w-12 mr-4')} />
-    <div className={tailwind('flex-1 py-1')}>
-      <div className={tailwind('h-4 bg-gray-400 rounded w-3/4')} />
-      <div className={tailwind('py-4')}>
-        <div className={tailwind('h-4 mb-2 bg-gray-400 rounded')} />
-        <div className={tailwind('h-4 bg-gray-400 rounded w-5/6')} />
+export const code = `<div sxt="border border-gray-300 shadow rounded-md p-4 max-w-sm w-full mx-auto">
+  <div sxt="animate-pulse flex">
+    <div sxt="rounded-full bg-gray-400 h-12 w-12 mr-4" />
+    <div sxt="flex-1 py-1">
+      <div sxt="h-4 bg-gray-400 rounded w-3/4" />
+      <div sxt="py-4">
+        <div sxt="h-4 mb-2 bg-gray-400 rounded" />
+        <div sxt="h-4 bg-gray-400 rounded w-5/6" />
       </div>
     </div>
   </div>

--- a/src/sx-tailwind-website/src/TailwindCss/animations/Spin.js
+++ b/src/sx-tailwind-website/src/TailwindCss/animations/Spin.js
@@ -1,34 +1,24 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Sping(): Node {
   return (
-    <span className={tailwind('inline-flex rounded-md shadow-sm')}>
+    <span sxt="inline-flex rounded-md shadow-sm">
       <button
         type="button"
-        className={tailwind(
-          'inline-flex items-center px-4 py-2 border border-transparent text-base leading-6 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 transition ease-in-out duration-150 cursor-not-allowed',
-        )}
+        sxt="inline-flex items-center px-4 py-2 border border-transparent text-base leading-6 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 transition ease-in-out duration-150 cursor-not-allowed"
         disabled
       >
         <svg
-          className={tailwind('animate-spin -ml-1 mr-3 h-5 w-5 text-white')}
+          sxt="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
         >
-          <circle
-            className={tailwind('opacity-25')}
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          />
+          <circle sxt="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
           <path
-            className={tailwind('opacity-75')}
+            sxt="opacity-75"
             fill="currentColor"
             d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
           />
@@ -39,8 +29,8 @@ export default function Sping(): Node {
   );
 }
 
-export const code = `<button type="button" class={tailwind('bg-indigo-600 ...')} disabled>
-  <svg class={tailwind('animate-spin h-5 w-5 mr-3 ...')} fill="none" viewBox="0 0 24 24">
+export const code = `<button type="button" sxt="bg-indigo-600 ..." disabled>
+  <svg sxt="animate-spin h-5 w-5 mr-3 ..." fill="none" viewBox="0 0 24 24">
     {/* ... */}
   </svg>
   Processing

--- a/src/sx-tailwind-website/src/TailwindCss/buttons/Bordered.js
+++ b/src/sx-tailwind-website/src/TailwindCss/buttons/Bordered.js
@@ -1,14 +1,11 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Bordered(): Node {
   return (
     <button
-      className={tailwind(
-        'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 border border-blue-700 rounded',
-      )}
+      sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 border border-blue-700 rounded"
       type="button"
     >
       Button
@@ -16,7 +13,7 @@ export default function Bordered(): Node {
   );
 }
 
-export const code = `<button className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 border border-blue-700 rounded')}>
+export const code = `<button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 border border-blue-700 rounded">
   Button
 </button>
 `;

--- a/src/sx-tailwind-website/src/TailwindCss/buttons/Disabled.js
+++ b/src/sx-tailwind-website/src/TailwindCss/buttons/Disabled.js
@@ -1,14 +1,11 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Disabled(): Node {
   return (
     <button
-      className={tailwind(
-        'bg-blue-500 text-white font-bold py-2 px-4 rounded opacity-50 cursor-not-allowed',
-      )}
+      sxt="bg-blue-500 text-white font-bold py-2 px-4 rounded opacity-50 cursor-not-allowed"
       type="button"
     >
       Button
@@ -16,7 +13,7 @@ export default function Disabled(): Node {
   );
 }
 
-export const code = `<button className={tailwind('bg-blue-500 text-white font-bold py-2 px-4 rounded opacity-50 cursor-not-allowed')}>
+export const code = `<button sxt="bg-blue-500 text-white font-bold py-2 px-4 rounded opacity-50 cursor-not-allowed">
   Button
 </button>
 `;

--- a/src/sx-tailwind-website/src/TailwindCss/buttons/Elevated.js
+++ b/src/sx-tailwind-website/src/TailwindCss/buttons/Elevated.js
@@ -1,14 +1,11 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Elevated(): Node {
   return (
     <button
-      className={tailwind(
-        'bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow',
-      )}
+      sxt="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow"
       type="button"
     >
       Button
@@ -16,7 +13,7 @@ export default function Elevated(): Node {
   );
 }
 
-export const code = `<button className={tailwind('bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow')}>
+export const code = `<button sxt="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow">
   Button
 </button>
 `;

--- a/src/sx-tailwind-website/src/TailwindCss/buttons/Groups.js
+++ b/src/sx-tailwind-website/src/TailwindCss/buttons/Groups.js
@@ -1,23 +1,18 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Groups(): Node {
   return (
-    <div className={tailwind('inline-flex')}>
+    <div sxt="inline-flex">
       <button
-        className={tailwind(
-          'bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded-l',
-        )}
+        sxt="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded-l"
         type="button"
       >
         Prev
       </button>
       <button
-        className={tailwind(
-          'bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded-r',
-        )}
+        sxt="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded-r"
         type="button"
       >
         Next
@@ -26,11 +21,11 @@ export default function Groups(): Node {
   );
 }
 
-export const code = `<div className={tailwind('inline-flex')}>
-  <button className={tailwind('bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded-l')}>
+export const code = `<div sxt="inline-flex">
+  <button sxt="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded-l">
     Prev
   </button>
-  <button className={tailwind('bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded-r')}>
+  <button sxt="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded-r">
     Next
   </button>
 </div>

--- a/src/sx-tailwind-website/src/TailwindCss/buttons/Icons.js
+++ b/src/sx-tailwind-website/src/TailwindCss/buttons/Icons.js
@@ -1,21 +1,14 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Icons(): Node {
   return (
     <button
-      className={tailwind(
-        'bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded inline-flex items-center',
-      )}
+      sxt="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded inline-flex items-center"
       type="button"
     >
-      <svg
-        className={tailwind('fill-current w-4 h-4 mr-2')}
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 20 20"
-      >
+      <svg sxt="fill-current w-4 h-4 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
         <path d="M13 8V2H7v6H2l8 8 8-8h-5zM0 18h20v2H0v-2z" />
       </svg>
       <span>Download</span>
@@ -23,8 +16,8 @@ export default function Icons(): Node {
   );
 }
 
-export const code = `<button className={tailwind('bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded inline-flex items-center')}>
-  <svg className={tailwind('fill-current w-4 h-4 mr-2')} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+export const code = `<button sxt="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded inline-flex items-center">
+  <svg sxt="fill-current w-4 h-4 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
     <path d="M13 8V2H7v6H2l8 8 8-8h-5zM0 18h20v2H0v-2z" />
   </svg>
   <span>Download</span>

--- a/src/sx-tailwind-website/src/TailwindCss/buttons/Outline.js
+++ b/src/sx-tailwind-website/src/TailwindCss/buttons/Outline.js
@@ -1,14 +1,11 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Outline(): Node {
   return (
     <button
-      className={tailwind(
-        'bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded',
-      )}
+      sxt="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
       type="button"
     >
       Button
@@ -16,7 +13,7 @@ export default function Outline(): Node {
   );
 }
 
-export const code = `<button className={tailwind('bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded')}>
+export const code = `<button sxt="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded">
   Button
 </button>
 `;

--- a/src/sx-tailwind-website/src/TailwindCss/buttons/Pill.js
+++ b/src/sx-tailwind-website/src/TailwindCss/buttons/Pill.js
@@ -1,14 +1,11 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Pill(): Node {
   return (
     <button
-      className={tailwind(
-        'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full',
-      )}
+      sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full"
       type="button"
     >
       Button
@@ -16,7 +13,7 @@ export default function Pill(): Node {
   );
 }
 
-export const code = `<button className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full')}>
+export const code = `<button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full">
   Button
 </button>
 `;

--- a/src/sx-tailwind-website/src/TailwindCss/buttons/Plastic.js
+++ b/src/sx-tailwind-website/src/TailwindCss/buttons/Plastic.js
@@ -1,14 +1,11 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Plastic(): Node {
   return (
     <button
-      className={tailwind(
-        'bg-blue-500 hover:bg-blue-400 text-white font-bold py-2 px-4 border-b-4 border-blue-700 hover:border-blue-500 rounded',
-      )}
+      sxt="bg-blue-500 hover:bg-blue-400 text-white font-bold py-2 px-4 border-b-4 border-blue-700 hover:border-blue-500 rounded"
       type="button"
     >
       Button
@@ -16,7 +13,7 @@ export default function Plastic(): Node {
   );
 }
 
-export const code = `<button className={tailwind('bg-blue-500 hover:bg-blue-400 text-white font-bold py-2 px-4 border-b-4 border-blue-700 hover:border-blue-500 rounded')}>
+export const code = `<button sxt="bg-blue-500 hover:bg-blue-400 text-white font-bold py-2 px-4 border-b-4 border-blue-700 hover:border-blue-500 rounded">
   Button
 </button>
 `;

--- a/src/sx-tailwind-website/src/TailwindCss/buttons/Simple.js
+++ b/src/sx-tailwind-website/src/TailwindCss/buttons/Simple.js
@@ -1,12 +1,11 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Simple(): Node {
   return (
     <button
-      className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded')}
+      sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
       type="button"
     >
       Button
@@ -14,7 +13,7 @@ export default function Simple(): Node {
   );
 }
 
-export const code = `<button className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded')}>
+export const code = `<button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
   Button
 </button>
 `;

--- a/src/sx-tailwind-website/src/TailwindCss/cards/Horizontal.js
+++ b/src/sx-tailwind-website/src/TailwindCss/cards/Horizontal.js
@@ -1,27 +1,20 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Horizontal(): Node {
   return (
-    <div className={tailwind('max-w-sm w-full lg:max-w-full lg:flex')}>
+    <div sxt="max-w-sm w-full lg:max-w-full lg:flex">
       <div
-        className={tailwind(
-          'h-48 lg:h-auto lg:w-48 flex-none bg-cover rounded-t lg:rounded-t-none lg:rounded-l text-center overflow-hidden',
-        )}
+        sxt="h-48 lg:h-auto lg:w-48 flex-none bg-cover rounded-t lg:rounded-t-none lg:rounded-l text-center overflow-hidden"
         style={{ backgroundImage: "url('https://tailwindcss.com/img/card-left.jpg')" }}
         title="Woman holding a mug"
       />
-      <div
-        className={tailwind(
-          'border-r border-b border-l border-gray-400 lg:border-l-0 lg:border-t lg:border-gray-400 bg-white rounded-b lg:rounded-b-none lg:rounded-r p-4 flex flex-col justify-between leading-normal',
-        )}
-      >
-        <div className={tailwind('mb-8')}>
-          <p className={tailwind('text-sm text-gray-600 flex items-center')}>
+      <div sxt="border-r border-b border-l border-gray-400 lg:border-l-0 lg:border-t lg:border-gray-400 bg-white rounded-b lg:rounded-b-none lg:rounded-r p-4 flex flex-col justify-between leading-normal">
+        <div sxt="mb-8">
+          <p sxt="text-sm text-gray-600 flex items-center">
             <svg
-              className={tailwind('fill-current text-gray-500 w-3 h-3 mr-2')}
+              sxt="fill-current text-gray-500 w-3 h-3 mr-2"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 20 20"
             >
@@ -29,23 +22,23 @@ export default function Horizontal(): Node {
             </svg>
             Members only
           </p>
-          <div className={tailwind('text-gray-900 font-bold text-xl mb-2')}>
+          <div sxt="text-gray-900 font-bold text-xl mb-2">
             Can coffee make you a better developer?
           </div>
-          <p className={tailwind('text-gray-700 text-base')}>
+          <p sxt="text-gray-700 text-base">
             Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatibus quia, nulla!
             Maiores et perferendis eaque, exercitationem praesentium nihil.
           </p>
         </div>
-        <div className={tailwind('flex items-center')}>
+        <div sxt="flex items-center">
           <img
-            className={tailwind('w-10 h-10 rounded-full mr-4')}
+            sxt="w-10 h-10 rounded-full mr-4"
             src="https://tailwindcss.com/img/jonathan.jpg"
             alt="Avatar of Jonathan Reinink"
           />
-          <div className={tailwind('text-sm')}>
-            <p className={tailwind('text-gray-900 leading-none')}>Jonathan Reinink</p>
-            <p className={tailwind('text-gray-600')}>Aug 18</p>
+          <div sxt="text-sm">
+            <p sxt="text-gray-900 leading-none">Jonathan Reinink</p>
+            <p sxt="text-gray-600">Aug 18</p>
           </div>
         </div>
       </div>

--- a/src/sx-tailwind-website/src/TailwindCss/cards/Stacked.js
+++ b/src/sx-tailwind-website/src/TailwindCss/cards/Stacked.js
@@ -1,43 +1,30 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Stacked(): Node {
   return (
-    <div className={tailwind('max-w-sm rounded overflow-hidden shadow-lg')}>
+    <div sxt="max-w-sm rounded overflow-hidden shadow-lg">
       <img
-        className={tailwind('w-full')}
+        sxt="w-full"
         src="https://tailwindcss.com/img/card-top.jpg"
         alt="Sunset in the mountains"
       />
-      <div className={tailwind('px-6 py-4')}>
-        <div className={tailwind('font-bold text-xl mb-2')}>The Coldest Sunset</div>
-        <p className={tailwind('text-gray-700 text-base')}>
+      <div sxt="px-6 py-4">
+        <div sxt="font-bold text-xl mb-2">The Coldest Sunset</div>
+        <p sxt="text-gray-700 text-base">
           Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatibus quia, nulla!
           Maiores et perferendis eaque, exercitationem praesentium nihil.
         </p>
       </div>
-      <div className={tailwind('px-6 pt-4 pb-2')}>
-        <span
-          className={tailwind(
-            'inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2',
-          )}
-        >
+      <div sxt="px-6 pt-4 pb-2">
+        <span sxt="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">
           #photography
         </span>
-        <span
-          className={tailwind(
-            'inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2',
-          )}
-        >
+        <span sxt="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">
           #travel
         </span>
-        <span
-          className={tailwind(
-            'inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2',
-          )}
-        >
+        <span sxt="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">
           #winter
         </span>
       </div>

--- a/src/sx-tailwind-website/src/TailwindCss/forms/CustomSelect.js
+++ b/src/sx-tailwind-website/src/TailwindCss/forms/CustomSelect.js
@@ -1,30 +1,17 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function CustomSelect(): Node {
   return (
-    <div className={tailwind('inline-block relative w-64')}>
-      <select
-        className={tailwind(
-          'block appearance-none w-full bg-white border border-gray-400 hover:border-gray-500 px-4 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:ring',
-        )}
-      >
+    <div sxt="inline-block relative w-64">
+      <select sxt="block appearance-none w-full bg-white border border-gray-400 hover:border-gray-500 px-4 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:ring">
         <option>Really long option that will likely overlap the chevron</option>
         <option>Option 2</option>
         <option>Option 3</option>
       </select>
-      <div
-        className={tailwind(
-          'pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700',
-        )}
-      >
-        <svg
-          className={tailwind('fill-current h-4 w-4')}
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-        >
+      <div sxt="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
+        <svg sxt="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
           <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" />
         </svg>
       </div>

--- a/src/sx-tailwind-website/src/TailwindCss/forms/FormGrid.js
+++ b/src/sx-tailwind-website/src/TailwindCss/forms/FormGrid.js
@@ -1,119 +1,92 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function FormGrid(): Node {
   return (
-    <form className={tailwind('w-full max-w-lg')}>
-      <div className={tailwind('flex flex-wrap -mx-3 mb-6')}>
-        <div className={tailwind('w-full md:w-1/2 px-3 mb-6 md:mb-0')}>
+    <form sxt="w-full max-w-lg">
+      <div sxt="flex flex-wrap -mx-3 mb-6">
+        <div sxt="w-full md:w-1/2 px-3 mb-6 md:mb-0">
           <label
-            className={tailwind(
-              'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2',
-            )}
+            sxt="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
             htmlFor="grid-first-name"
           >
             First Name
           </label>
           <input
-            className={tailwind(
-              'appearance-none block w-full bg-gray-200 text-gray-700 border border-red-500 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white',
-            )}
+            sxt="appearance-none block w-full bg-gray-200 text-gray-700 border border-red-500 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white"
             id="grid-first-name"
             type="text"
             placeholder="Jane"
           />
-          <p className={tailwind('text-red-500 text-xs italic')}>Please fill out this field.</p>
+          <p sxt="text-red-500 text-xs italic">Please fill out this field.</p>
         </div>
-        <div className={tailwind('w-full md:w-1/2 px-3')}>
+        <div sxt="w-full md:w-1/2 px-3">
           <label
-            className={tailwind(
-              'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2',
-            )}
+            sxt="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
             htmlFor="grid-last-name"
           >
             Last Name
           </label>
           <input
-            className={tailwind(
-              'appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500',
-            )}
+            sxt="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
             id="grid-last-name"
             type="text"
             placeholder="Doe"
           />
         </div>
       </div>
-      <div className={tailwind('flex flex-wrap -mx-3 mb-6')}>
-        <div className={tailwind('w-full px-3')}>
+      <div sxt="flex flex-wrap -mx-3 mb-6">
+        <div sxt="w-full px-3">
           <label
-            className={tailwind(
-              'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2',
-            )}
+            sxt="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
             htmlFor="grid-password"
           >
             Password
           </label>
           <input
-            className={tailwind(
-              'appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500',
-            )}
+            sxt="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
             id="grid-password"
             type="password"
             placeholder="******************"
           />
-          <p className={tailwind('text-gray-600 text-xs italic')}>
-            Make it as long and as crazy as you&apos;d like
-          </p>
+          <p sxt="text-gray-600 text-xs italic">Make it as long and as crazy as you&apos;d like</p>
         </div>
       </div>
-      <div className={tailwind('flex flex-wrap -mx-3 mb-2')}>
-        <div className={tailwind('w-full md:w-1/3 px-3 mb-6 md:mb-0')}>
+      <div sxt="flex flex-wrap -mx-3 mb-2">
+        <div sxt="w-full md:w-1/3 px-3 mb-6 md:mb-0">
           <label
-            className={tailwind(
-              'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2',
-            )}
+            sxt="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
             htmlFor="grid-city"
           >
             City
           </label>
           <input
-            className={tailwind(
-              'appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500',
-            )}
+            sxt="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
             id="grid-city"
             type="text"
             placeholder="Albuquerque"
           />
         </div>
-        <div className={tailwind('w-full md:w-1/3 px-3 mb-6 md:mb-0')}>
+        <div sxt="w-full md:w-1/3 px-3 mb-6 md:mb-0">
           <label
-            className={tailwind(
-              'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2',
-            )}
+            sxt="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
             htmlFor="grid-state"
           >
             State
           </label>
-          <div className={tailwind('relative')}>
+          <div sxt="relative">
             <select
-              className={tailwind(
-                'block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-700 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-500',
-              )}
+              sxt="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-700 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
               id="grid-state"
             >
               <option>New Mexico</option>
               <option>Missouri</option>
               <option>Texas</option>
             </select>
-            <div
-              className={tailwind(
-                'absolute inset-y-0 right-0 flex items-center px-2 text-gray-700',
-              )}
-            >
+            <div sxt="absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
               <svg
-                className={tailwind('fill-current h-4 w-4')}
+                sxt="fill-current h-4 w-4"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
               >
@@ -122,19 +95,15 @@ export default function FormGrid(): Node {
             </div>
           </div>
         </div>
-        <div className={tailwind('w-full md:w-1/3 px-3 mb-6 md:mb-0')}>
+        <div sxt="w-full md:w-1/3 px-3 mb-6 md:mb-0">
           <label
-            className={tailwind(
-              'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2',
-            )}
+            sxt="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
             htmlFor="grid-zip"
           >
             Zip
           </label>
           <input
-            className={tailwind(
-              'appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500',
-            )}
+            sxt="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
             id="grid-zip"
             type="text"
             placeholder="90210"

--- a/src/sx-tailwind-website/src/TailwindCss/forms/InlineForm.js
+++ b/src/sx-tailwind-website/src/TailwindCss/forms/InlineForm.js
@@ -1,65 +1,58 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function InlineForm(): Node {
   return (
-    <form className={tailwind('w-full max-w-sm')}>
-      <div className={tailwind('md:flex md:items-center mb-6')}>
-        <div className={tailwind('md:w-1/3')}>
+    <form sxt="w-full max-w-sm">
+      <div sxt="md:flex md:items-center mb-6">
+        <div sxt="md:w-1/3">
           <label
-            className={tailwind('block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4')}
+            sxt="block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4"
             htmlFor="inline-full-name"
           >
             Full Name
           </label>
         </div>
-        <div className={tailwind('md:w-2/3')}>
+        <div sxt="md:w-2/3">
           <input
-            className={tailwind(
-              'bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500',
-            )}
+            sxt="bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"
             id="inline-full-name"
             type="text"
             value="Jane Doe"
           />
         </div>
       </div>
-      <div className={tailwind('md:flex md:items-center mb-6')}>
-        <div className={tailwind('md:w-1/3')}>
+      <div sxt="md:flex md:items-center mb-6">
+        <div sxt="md:w-1/3">
           <label
-            className={tailwind('block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4')}
+            sxt="block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4"
             htmlFor="inline-password"
           >
             Password
           </label>
         </div>
-        <div className={tailwind('md:w-2/3')}>
+        <div sxt="md:w-2/3">
           <input
-            className={tailwind(
-              'bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500',
-            )}
+            sxt="bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"
             id="inline-password"
             type="password"
             placeholder="******************"
           />
         </div>
       </div>
-      <div className={tailwind('md:flex md:items-center mb-6')}>
-        <div className={tailwind('md:w-1/3')} />
-        <label className={tailwind('md:w-2/3 block text-gray-500 font-bold')}>
-          <input className={tailwind('mr-2 leading-tight')} type="checkbox" />
-          <span className={tailwind('text-sm')}>Send me your newsletter!</span>
+      <div sxt="md:flex md:items-center mb-6">
+        <div sxt="md:w-1/3" />
+        <label sxt="md:w-2/3 block text-gray-500 font-bold">
+          <input sxt="mr-2 leading-tight" type="checkbox" />
+          <span sxt="text-sm">Send me your newsletter!</span>
         </label>
       </div>
-      <div className={tailwind('md:flex md:items-center')}>
-        <div className={tailwind('md:w-1/3')} />
-        <div className={tailwind('md:w-2/3')}>
+      <div sxt="md:flex md:items-center">
+        <div sxt="md:w-1/3" />
+        <div sxt="md:w-2/3">
           <button
-            className={tailwind(
-              'shadow bg-purple-500 hover:bg-purple-400 focus:ring focus:outline-none text-white font-bold py-2 px-4 rounded',
-            )}
+            sxt="shadow bg-purple-500 hover:bg-purple-400 focus:ring focus:outline-none text-white font-bold py-2 px-4 rounded"
             type="button"
           >
             Sign Up

--- a/src/sx-tailwind-website/src/TailwindCss/forms/LoginForm.js
+++ b/src/sx-tailwind-website/src/TailwindCss/forms/LoginForm.js
@@ -1,67 +1,50 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function LoginForm(): Node {
   return (
-    <div className={tailwind('w-full max-w-xs')}>
-      <form className={tailwind('bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4')}>
-        <div className={tailwind('mb-4')}>
-          <label
-            className={tailwind('block text-gray-700 text-sm font-bold mb-2')}
-            htmlFor="username"
-          >
+    <div sxt="w-full max-w-xs">
+      <form sxt="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+        <div sxt="mb-4">
+          <label sxt="block text-gray-700 text-sm font-bold mb-2" htmlFor="username">
             Username
           </label>
           <input
-            className={tailwind(
-              'shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:ring',
-            )}
+            sxt="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:ring"
             id="username"
             type="text"
             placeholder="Username"
           />
         </div>
-        <div className={tailwind('mb-6')}>
-          <label
-            className={tailwind('block text-gray-700 text-sm font-bold mb-2')}
-            htmlFor="password"
-          >
+        <div sxt="mb-6">
+          <label sxt="block text-gray-700 text-sm font-bold mb-2" htmlFor="password">
             Password
           </label>
           <input
-            className={tailwind(
-              'shadow appearance-none border border-red-500 rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:ring',
-            )}
+            sxt="shadow appearance-none border border-red-500 rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:ring"
             id="password"
             type="password"
             placeholder="******************"
           />
-          <p className={tailwind('text-red-500 text-xs italic')}>Please choose a password.</p>
+          <p sxt="text-red-500 text-xs italic">Please choose a password.</p>
         </div>
-        <div className={tailwind('flex items-center justify-between')}>
+        <div sxt="flex items-center justify-between">
           <button
-            className={tailwind(
-              'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:ring',
-            )}
+            sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:ring"
             type="button"
           >
             Sign In
           </button>
           <a
-            className={tailwind(
-              'inline-block align-baseline font-bold text-sm text-blue-500 hover:text-blue-800',
-            )}
+            sxt="inline-block align-baseline font-bold text-sm text-blue-500 hover:text-blue-800"
             href="/"
           >
             Forgot Password?
           </a>
         </div>
       </form>
-      <p className={tailwind('text-center text-gray-500 text-xs')}>
-        &copy;2020 Acme Corp. All rights reserved.
-      </p>
+      <p sxt="text-center text-gray-500 text-xs">&copy;2020 Acme Corp. All rights reserved.</p>
     </div>
   );
 }

--- a/src/sx-tailwind-website/src/TailwindCss/forms/UnderlineForm.js
+++ b/src/sx-tailwind-website/src/TailwindCss/forms/UnderlineForm.js
@@ -1,32 +1,25 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function UnderlineForm(): Node {
   return (
-    <form className={tailwind('w-full max-w-sm')}>
-      <div className={tailwind('flex items-center border-b border-teal-500 py-2')}>
+    <form sxt="w-full max-w-sm">
+      <div sxt="flex items-center border-b border-teal-500 py-2">
         <input
-          className={tailwind(
-            'appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none',
-          )}
+          sxt="appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none"
           type="text"
           placeholder="Jane Doe"
           aria-label="Full name"
         />
         <button
-          className={tailwind(
-            'flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded',
-          )}
+          sxt="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded"
           type="button"
         >
           Sign Up
         </button>
         <button
-          className={tailwind(
-            'flex-shrink-0 border-transparent border-4 text-teal-500 hover:text-teal-800 text-sm py-1 px-2 rounded',
-          )}
+          sxt="flex-shrink-0 border-transparent border-4 text-teal-500 hover:text-teal-800 text-sm py-1 px-2 rounded"
           type="button"
         >
           Cancel

--- a/src/sx-tailwind-website/src/TailwindCss/gradients/EndingColor.js
+++ b/src/sx-tailwind-website/src/TailwindCss/gradients/EndingColor.js
@@ -1,10 +1,9 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function EndingColor(): Node {
-  return <div className={tailwind('h-24 bg-gradient-to-r from-teal-400 to-blue-500')} />;
+  return <div sxt="h-24 bg-gradient-to-r from-teal-400 to-blue-500" />;
 }
 
-export const code = `<div className={tailwind('h-24 bg-gradient-to-r from-teal-400 to-blue-500')}></div>`;
+export const code = `<div sxt="h-24 bg-gradient-to-r from-teal-400 to-blue-500" />`;

--- a/src/sx-tailwind-website/src/TailwindCss/gradients/MiddleColor.js
+++ b/src/sx-tailwind-website/src/TailwindCss/gradients/MiddleColor.js
@@ -1,12 +1,9 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function MiddleColor(): Node {
-  return (
-    <div className={tailwind('h-24 bg-gradient-to-r from-purple-400 via-pink-500 to-red-500')} />
-  );
+  return <div sxt="h-24 bg-gradient-to-r from-purple-400 via-pink-500 to-red-500" />;
 }
 
-export const code = `<div className={tailwind('h-24 bg-gradient-to-r from-purple-400 via-pink-500 to-red-500')}></div>`;
+export const code = `<div sxt="h-24 bg-gradient-to-r from-purple-400 via-pink-500 to-red-500" />`;

--- a/src/sx-tailwind-website/src/TailwindCss/gradients/StartingColor.js
+++ b/src/sx-tailwind-website/src/TailwindCss/gradients/StartingColor.js
@@ -1,10 +1,9 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function StartingColor(): Node {
-  return <div className={tailwind('h-24 bg-gradient-to-r from-red-500')} />;
+  return <div sxt="h-24 bg-gradient-to-r from-red-500" />;
 }
 
-export const code = `<div className={tailwind('h-24 bg-gradient-to-r from-red-500')}></div>`;
+export const code = `<div sxt="h-24 bg-gradient-to-r from-red-500" />`;

--- a/src/sx-tailwind-website/src/TailwindCss/gradients/TextBackground.js
+++ b/src/sx-tailwind-website/src/TailwindCss/gradients/TextBackground.js
@@ -1,24 +1,19 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function TextBackground(): Node {
   return (
-    <h1 className={tailwind('text-6xl font-bold')}>
-      <span
-        className={tailwind(
-          'bg-clip-text text-transparent bg-gradient-to-r from-teal-400 to-blue-500',
-        )}
-      >
+    <h1 sxt="text-6xl font-bold">
+      <span sxt="bg-clip-text text-transparent bg-gradient-to-r from-teal-400 to-blue-500">
         Greetings from SX Tailwind
       </span>
     </h1>
   );
 }
 
-export const code = `<h1 className={tailwind('text-6xl font-bold')}>
-  <span className={tailwind('bg-clip-text text-transparent bg-gradient-to-r from-teal-400 to-blue-500')}>
+export const code = `<h1 sxt="text-6xl font-bold">
+  <span sxt="bg-clip-text text-transparent bg-gradient-to-r from-teal-400 to-blue-500">
     Greetings from SX Tailwind
   </span>
 </h1>`;

--- a/src/sx-tailwind-website/src/TailwindCss/transitions/Delay.js
+++ b/src/sx-tailwind-website/src/TailwindCss/transitions/Delay.js
@@ -1,33 +1,26 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Delay(): Node {
   return (
     <>
       <button
-        className={tailwind(
-          'transition delay-150 duration-300 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded',
-        )}
+        sxt="transition delay-150 duration-300 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded"
         type="button"
       >
         Hover me
       </button>
 
       <button
-        className={tailwind(
-          'transition delay-300 duration-300 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded',
-        )}
+        sxt="transition delay-300 duration-300 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded"
         type="button"
       >
         Hover me
       </button>
 
       <button
-        className={tailwind(
-          'transition delay-700 duration-300 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded',
-        )}
+        sxt="transition delay-700 duration-300 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded"
         type="button"
       >
         Hover me
@@ -36,7 +29,7 @@ export default function Delay(): Node {
   );
 }
 
-export const code = `<button className={tailwind('transition delay-150 duration-300 ease-in-out ...')}>Hover me</button>
-<button className={tailwind('transition delay-300 duration-300 ease-in-out ...')}>Hover me</button>
-<button className={tailwind('transition delay-700 duration-300 ease-in-out ...')}>Hover me</button>
+export const code = `<button sxt="transition delay-150 duration-300 ease-in-out ...">Hover me</button>
+<button sxt="transition delay-300 duration-300 ease-in-out ...">Hover me</button>
+<button sxt="transition delay-700 duration-300 ease-in-out ...">Hover me</button>
 `;

--- a/src/sx-tailwind-website/src/TailwindCss/transitions/Duration.js
+++ b/src/sx-tailwind-website/src/TailwindCss/transitions/Duration.js
@@ -1,33 +1,26 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Duration(): Node {
   return (
     <>
       <button
-        className={tailwind(
-          'transition duration-150 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded',
-        )}
+        sxt="transition duration-150 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded"
         type="button"
       >
         Hover me
       </button>
 
       <button
-        className={tailwind(
-          'transition duration-300 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded',
-        )}
+        sxt="transition duration-300 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded"
         type="button"
       >
         Hover me
       </button>
 
       <button
-        className={tailwind(
-          'transition duration-700 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded',
-        )}
+        sxt="transition duration-700 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded"
         type="button"
       >
         Hover me
@@ -36,7 +29,7 @@ export default function Duration(): Node {
   );
 }
 
-export const code = `<button className={tailwind( 'transition duration-150 ease-in-out ...')}>Hover me</button>
-<button className={tailwind( 'transition duration-300 ease-in-out ...')}>Hover me</button>
-<button className={tailwind( 'transition duration-700 ease-in-out ...')}>Hover me</button>
+export const code = `<button sxt="transition duration-150 ease-in-out ...">Hover me</button>
+<button sxt="transition duration-300 ease-in-out ...">Hover me</button>
+<button sxt="transition duration-700 ease-in-out ...">Hover me</button>
 `;

--- a/src/sx-tailwind-website/src/TailwindCss/transitions/Timing.js
+++ b/src/sx-tailwind-website/src/TailwindCss/transitions/Timing.js
@@ -1,33 +1,26 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Timing(): Node {
   return (
     <>
       <button
-        className={tailwind(
-          'transition duration-700 ease-in transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded',
-        )}
+        sxt="transition duration-700 ease-in transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded"
         type="button"
       >
         Hover me
       </button>
 
       <button
-        className={tailwind(
-          'transition duration-700 ease-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded',
-        )}
+        sxt="transition duration-700 ease-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded"
         type="button"
       >
         Hover me
       </button>
 
       <button
-        className={tailwind(
-          'transition duration-700 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded',
-        )}
+        sxt="transition duration-700 ease-in-out transform hover:scale-125 bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded"
         type="button"
       >
         Hover me
@@ -36,7 +29,7 @@ export default function Timing(): Node {
   );
 }
 
-export const code = `<button className={tailwind('transition duration-700 ease-in ...')}>Hover me</button>
-<button className={tailwind('transition duration-700 ease-out ...')}>Hover me</button>
-<button className={tailwind('transition duration-700 ease-in-out ...')}>Hover me</button>
+export const code = `<button sxt="transition duration-700 ease-in ...">Hover me</button>
+<button sxt="transition duration-700 ease-out ...">Hover me</button>
+<button sxt="transition duration-700 ease-in-out ...">Hover me</button>
 `;

--- a/src/sx-tailwind-website/src/TailwindCss/transitions/Transition.js
+++ b/src/sx-tailwind-website/src/TailwindCss/transitions/Transition.js
@@ -1,14 +1,11 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 export default function Transition(): Node {
   return (
     <button
-      className={tailwind(
-        'transition duration-500 ease-in-out bg-blue-500 hover:bg-red-500 transform hover:-translate-y-1 hover:scale-x-110 hover:scale-y-110 text-white font-bold py-2 px-4 rounded',
-      )}
+      sxt="transition duration-500 ease-in-out bg-blue-500 hover:bg-red-500 transform hover:-translate-y-1 hover:scale-x-110 hover:scale-y-110 text-white font-bold py-2 px-4 rounded"
       type="button"
     >
       Hover me
@@ -16,7 +13,7 @@ export default function Transition(): Node {
   );
 }
 
-export const code = `<button className={tailwind('transition duration-500 ease-in-out bg-blue-500 hover:bg-red-500 transform hover:-translate-y-1 hover:scale-x-110 hover:scale-y-110 ...')}>
+export const code = `<button sxt="transition duration-500 ease-in-out bg-blue-500 hover:bg-red-500 transform hover:-translate-y-1 hover:scale-x-110 hover:scale-y-110 ...">
   Hover me
 </button>
 `;

--- a/src/sx-tailwind-website/src/components/Code.js
+++ b/src/sx-tailwind-website/src/components/Code.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 type Props = {|
   +children: Node,
@@ -9,11 +8,7 @@ type Props = {|
 
 export default function Code({ children }: Props): Node {
   return (
-    <code
-      className={tailwind(
-        'font-mono text-purple-600 text-sm bg-gray-300 whitespace-pre px-2 py-1 rounded',
-      )}
-    >
+    <code sxt="font-mono text-purple-600 text-sm bg-gray-300 whitespace-pre px-2 py-1 rounded">
       {children}
     </code>
   );

--- a/src/sx-tailwind-website/src/components/CodeBlock.js
+++ b/src/sx-tailwind-website/src/components/CodeBlock.js
@@ -5,7 +5,6 @@ import refractor from 'refractor/core';
 import toHtml from 'hast-util-to-html';
 import jsx from 'refractor/lang/jsx';
 import bash from 'refractor/lang/bash';
-import { tailwind } from '@adeira/sx-tailwind';
 
 refractor.register(jsx);
 refractor.register(bash);
@@ -26,9 +25,7 @@ export default function SyntaxHighlighter({
   return (
     <pre
       data-language={language}
-      className={tailwind(
-        `text-sm bg-gray-800 whitespace-pre p-4 ${attached ? 'rounded-b-lg' : 'rounded-lg'}`,
-      )}
+      sxt={`text-sm bg-gray-800 whitespace-pre p-4 ${attached ? 'rounded-b-lg' : 'rounded-lg'}`}
       dangerouslySetInnerHTML={{
         __html: highlightedText,
       }}

--- a/src/sx-tailwind-website/src/components/H2.js
+++ b/src/sx-tailwind-website/src/components/H2.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 type Props = {|
   +children: Node,
@@ -9,10 +8,6 @@ type Props = {|
 
 export default function H2({ children }: Props): Node {
   return (
-    <h2
-      className={tailwind('text-2xl leading-4 font-normal tracking-tight text-gray-900 mt-16 mb-4')}
-    >
-      {children}
-    </h2>
+    <h2 sxt="text-2xl leading-4 font-normal tracking-tight text-gray-900 mt-16 mb-4">{children}</h2>
   );
 }

--- a/src/sx-tailwind-website/src/components/Layout.js
+++ b/src/sx-tailwind-website/src/components/Layout.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { useContext, type Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 import Sidebar from './Sidebar';
 import MainContent from './MainContent';
@@ -16,7 +15,7 @@ type Props = {|
 export default function Layout({ title, children }: Props): Node {
   const { isOpen } = useContext(SidebarContext);
   return (
-    <div className={tailwind('font-sans h-screen flex overflow-hidden bg-gray-100')}>
+    <div sxt="font-sans h-screen flex overflow-hidden bg-gray-100">
       {/* TODO: use artsy/fresnel */}
       {isOpen && (
         <Overlay>

--- a/src/sx-tailwind-website/src/components/Link.js
+++ b/src/sx-tailwind-website/src/components/Link.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 type Props = {|
   +href: string,
@@ -10,7 +9,7 @@ type Props = {|
 
 export default function Link({ href, children }: Props): Node {
   return (
-    <a href={href} className={tailwind('text-blue-500 hover:text-blue-700 font-medium underline')}>
+    <a href={href} sxt="text-blue-500 hover:text-blue-700 font-medium underline">
       {children}
     </a>
   );

--- a/src/sx-tailwind-website/src/components/MainContent.js
+++ b/src/sx-tailwind-website/src/components/MainContent.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 import Hamburger from './sidebar/Hamburger';
 
@@ -12,21 +11,15 @@ type Props = {|
 
 export default function MainContent({ title, children }: Props): Node {
   return (
-    <main className={tailwind('flex-1 relative pb-8 z-0 overflow-y-auto')}>
-      <div className={tailwind('bg-white shadow flex')}>
+    <main sxt="flex-1 relative pb-8 z-0 overflow-y-auto">
+      <div sxt="bg-white shadow flex">
         <Hamburger />
-        <div className={tailwind('px-4 py-6 sm:px-6 lg:px-8')}>
-          <h1
-            className={tailwind(
-              'text-2xl font-bold leading-7 text-gray-900 sm:leading-9 sm:truncate',
-            )}
-          >
-            {title}
-          </h1>
+        <div sxt="px-4 py-6 sm:px-6 lg:px-8">
+          <h1 sxt="text-2xl font-bold leading-7 text-gray-900 sm:leading-9 sm:truncate">{title}</h1>
         </div>
       </div>
-      <div className={tailwind('mt-8')}>
-        <div className={tailwind('max-w-4xl mr-auto px-4 sm:px-6 lg:px-8')}>{children}</div>
+      <div sxt="mt-8">
+        <div sxt="max-w-4xl mr-auto px-4 sm:px-6 lg:px-8">{children}</div>
       </div>
     </main>
   );

--- a/src/sx-tailwind-website/src/components/P.js
+++ b/src/sx-tailwind-website/src/components/P.js
@@ -1,12 +1,11 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 type Props = {|
   +children: Node,
 |};
 
 export default function P({ children }: Props): Node {
-  return <p className={tailwind('text-gray-700 mb-4')}>{children}</p>;
+  return <p sxt="text-gray-700 mb-4">{children}</p>;
 }

--- a/src/sx-tailwind-website/src/components/Showcase.js
+++ b/src/sx-tailwind-website/src/components/Showcase.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 import CodeBlock from './CodeBlock';
 
@@ -12,12 +11,8 @@ type Props = {|
 
 export default function Showcase({ children, code }: Props): Node {
   return (
-    <div className={tailwind('relative overflow-hidden mb-8')}>
-      <div
-        className={tailwind(
-          'rounded-t-lg overflow-hidden border-t border-l border-r border-gray-400 text-center p-4 py-12',
-        )}
-      >
+    <div sxt="relative overflow-hidden mb-8">
+      <div sxt="rounded-t-lg overflow-hidden border-t border-l border-r border-gray-400 text-center p-4 py-12">
         {children}
       </div>
       <CodeBlock attached={true}>{code}</CodeBlock>

--- a/src/sx-tailwind-website/src/components/Sidebar.js
+++ b/src/sx-tailwind-website/src/components/Sidebar.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 
@@ -21,15 +20,13 @@ function MenuItem({ label, href, screenSize }: MenuItemProps): Node {
     <Link href={href}>
       <a
         href={href}
-        className={tailwind(
-          `flex items-center px-2 ${
-            screenSize === 'small' ? 'py-4 text-base' : 'py-2 text-sm'
-          } leading-6 font-medium rounded-md transition ease-in-out duration-150 my-1 focus:outline-none focus:bg-teal-500 ${
-            router.pathname === href
-              ? 'text-white bg-teal-500'
-              : 'text-teal-100 hover:text-white hover:bg-teal-500'
-          }`,
-        )}
+        sxt={`flex items-center px-2 ${
+          screenSize === 'small' ? 'py-4 text-base' : 'py-2 text-sm'
+        } leading-6 font-medium rounded-md transition ease-in-out duration-150 my-1 focus:outline-none focus:bg-teal-500 ${
+          router.pathname === href
+            ? 'text-white bg-teal-500'
+            : 'text-teal-100 hover:text-white hover:bg-teal-500'
+        }`}
       >
         {label}
       </a>
@@ -40,27 +37,21 @@ function MenuItem({ label, href, screenSize }: MenuItemProps): Node {
 export default function Sidebar({ screenSize = 'large' }: Props): Node {
   return (
     <div
-      className={tailwind(
-        `${screenSize === 'small' ? 'flex flex-shrink-0' : 'hidden lg:flex lg:flex-shrink-0'}`,
-      )}
+      sxt={`${screenSize === 'small' ? 'flex flex-shrink-0' : 'hidden lg:flex lg:flex-shrink-0'}`}
     >
-      <div className={tailwind(`flex ${screenSize === 'small' ? 'w-full' : 'w-64'}`)}>
-        <div className={tailwind('flex-grow bg-teal-600 pt-5 pb-4 overflow-y-auto')}>
+      <div sxt={`flex ${screenSize === 'small' ? 'w-full' : 'w-64'}`}>
+        <div sxt="flex-grow bg-teal-600 pt-5 pb-4 overflow-y-auto">
           <Link href="/">
             <a href="/">
-              <div
-                className={tailwind(
-                  'flex items-center flex-shrink-0 px-4 text-white text-4xl font-extrabold tracking-tighter',
-                )}
-              >
+              <div sxt="flex items-center flex-shrink-0 px-4 text-white text-4xl font-extrabold tracking-tighter">
                 SX Tailwind
               </div>
             </a>
           </Link>
 
-          <div className={tailwind('mt-5 flex-1 flex flex-col overflow-y-auto')}>
-            <div className={tailwind('overflow-y-auto')}>
-              <nav className={tailwind('px-2')}>
+          <div sxt="mt-5 flex-1 flex flex-col overflow-y-auto">
+            <div sxt="overflow-y-auto">
+              <nav sxt="px-2">
                 <MenuItem label="Intro" href="/" screenSize={screenSize} />
                 <MenuItem label="Documentation" href="/tailwind-css" screenSize={screenSize} />
                 <MenuItem label="Alerts" href="/tailwind-css/alerts" screenSize={screenSize} />

--- a/src/sx-tailwind-website/src/components/sidebar/Hamburger.js
+++ b/src/sx-tailwind-website/src/components/sidebar/Hamburger.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { useContext, type Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 import { SidebarContext } from './Context';
 
@@ -9,15 +8,13 @@ export default function Hamburger(): Node {
   const { open } = useContext(SidebarContext);
   return (
     <button
-      className={tailwind(
-        'px-6 h-20 text-gray-400 focus:outline-none focus:bg-gray-100 focus:text-gray-600 lg:hidden',
-      )}
+      sxt="px-6 h-20 text-gray-400 focus:outline-none focus:bg-gray-100 focus:text-gray-600 lg:hidden"
       aria-label="Open sidebar"
       type="button"
       onClick={open}
     >
       <svg
-        className={tailwind('h-6 w-6 transition ease-in-out duration-150')}
+        sxt="h-6 w-6 transition ease-in-out duration-150"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/src/sx-tailwind-website/src/components/sidebar/Overlay.js
+++ b/src/sx-tailwind-website/src/components/sidebar/Overlay.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { useContext, type Node } from 'react';
-import { tailwind } from '@adeira/sx-tailwind';
 
 import { SidebarContext } from './Context';
 
@@ -11,16 +10,12 @@ type Props = {|
 
 export default function Overlay({ children }: Props): Node {
   return (
-    <div className={tailwind('lg:hidden fixed inset-0 flex z-40')}>
-      <div className={tailwind('fixed inset-0')}>
-        <div
-          className={tailwind(
-            'transition-opacity ease-linear duration-300 absolute inset-0 bg-gray-600 opacity-75',
-          )}
-        />
+    <div sxt="lg:hidden fixed inset-0 flex z-40">
+      <div sxt="fixed inset-0">
+        <div sxt="transition-opacity ease-linear duration-300 absolute inset-0 bg-gray-600 opacity-75" />
       </div>
-      <div className={tailwind('relative flex-1 flex flex-col max-w-xs w-full bg-teal-600')}>
-        <div className={tailwind('absolute top-0 right-0 -mr-16 p-1')}>
+      <div sxt="relative flex-1 flex flex-col max-w-xs w-full bg-teal-600">
+        <div sxt="absolute top-0 right-0 -mr-16 p-1">
           <CloseButton />
         </div>
         {children}
@@ -33,19 +28,12 @@ function CloseButton(): Node {
   const { close } = useContext(SidebarContext);
   return (
     <button
-      className={tailwind(
-        'flex items-center justify-center h-12 w-12 rounded-full focus:outline-none focus:bg-gray-600',
-      )}
+      sxt="flex items-center justify-center h-12 w-12 rounded-full focus:outline-none focus:bg-gray-600"
       aria-label="Close sidebar"
       type="button"
       onClick={close}
     >
-      <svg
-        className={tailwind('h-6 w-6 text-white')}
-        stroke="currentColor"
-        fill="none"
-        viewBox="0 0 24 24"
-      >
+      <svg sxt="h-6 w-6 text-white" stroke="currentColor" fill="none" viewBox="0 0 24 24">
         <path
           strokeLinecap="round"
           strokeLinejoin="round"

--- a/src/sx-tailwind/README.md
+++ b/src/sx-tailwind/README.md
@@ -3,15 +3,13 @@ Experimental port of [Tailwind CSS](https://tailwindcss.com/) (version 1.9.6) in
 ## Usage
 
 ```js
-import { tailwind } from '@adeira/sx-tailwind';
-
 export default function Button() {
   return (
-    <button
-      className={tailwind('bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded')}
-    >
+    <button sxt="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
       Button
-    </button>;
+    </button>
+  );
+}
 ```
 
 ## Demo
@@ -21,7 +19,6 @@ export default function Button() {
 ## Install
 
 ```
-yarn add @adeira/sx-tailwind
 yarn add --dev @adeira/babel-plugin-transform-sx-tailwind
 ```
 


### PR DESCRIPTION
Breaking change in the use of SX Tailwind. Instead of `className={tailwind(...)}` only a `sxt="..."` in JSX is now used.