### PR TITLE
Release '@adeira/relay-runtime' version 0.19.0

### DIFF
--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -12,7 +12,7 @@
     "@adeira/js": "^1.3.0",
     "@adeira/monorepo-utils": "^0.11.0",
     "@adeira/relay": "^2.2.0",
-    "@adeira/relay-runtime": "^0.18.0",
+    "@adeira/relay-runtime": "^0.19.0",
     "@adeira/relay-utils": "0.11.0",
     "@adeira/sx": "^0.22.0",
     "@artsy/fresnel": "^1.3.1",

--- a/src/relay-runtime/package.json
+++ b/src/relay-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adeira/relay-runtime",
   "private": false,
-  "version": "0.18.0",
+  "version": "0.19.0",
   "main": "index",
   "module": false,
   "sideEffects": false,

--- a/src/relay-utils/package.json
+++ b/src/relay-utils/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@adeira/relay": "^2.2.0",
-    "@adeira/relay-runtime": "^0.18.0",
+    "@adeira/relay-runtime": "^0.19.0",
     "@babel/runtime": "^7.12.5"
   },
   "peerDependencies": {

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -21,7 +21,7 @@
     "@adeira/js": "^1.3.0",
     "@adeira/logger": "^0.4.0",
     "@adeira/monorepo-utils": "^0.11.0",
-    "@adeira/relay-runtime": "^0.18.0",
+    "@adeira/relay-runtime": "^0.19.0",
     "@adeira/signed-source": "^1.0.0",
     "@babel/register": "^7.12.10",
     "@babel/runtime": "^7.12.5",


### PR DESCRIPTION
This release includes support for the latest Relay 10.1.2.