### PR TITLE
CSS colors: add `isBright` and `isDark` functions

### DIFF
--- a/src/css-colors/CHANGELOG.md
+++ b/src/css-colors/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+# 1.1.0
+
+- added new functions `isBright` and `isDark`

--- a/src/css-colors/README.md
+++ b/src/css-colors/README.md
@@ -29,6 +29,20 @@ isColor('rgb(255, 255, 128)'); // true
 isColor('hsl(50, 33%, 25)'); // false (should be 25%)
 ```
 
+## Is the color bright or dark?
+
+This function can be used to detect whether the color is bright or dark so you can decide whether you should use white or black text for the color background (for example).
+
+```js
+import { isDark, isBright } from '@adeira/css-colors';
+
+isDark([0, 0, 0]); // true (it's black)
+isBright([0, 0, 0]); // false
+
+isDark([255, 255, 255]); // false (it's white)
+isBright([255, 255, 255]); // true
+```
+
 ## Normalize colors
 
 ```js

--- a/src/css-colors/package.json
+++ b/src/css-colors/package.json
@@ -2,7 +2,7 @@
   "name": "@adeira/css-colors",
   "description": "Utility functions for working with CSS/HTML colors.",
   "homepage": "https://github.com/adeira/universe/tree/master/src/css-colors",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "sideEffects": false,
   "private": false,
   "main": "src/index",

--- a/src/css-colors/src/__tests__/calculateBrightness.test.js
+++ b/src/css-colors/src/__tests__/calculateBrightness.test.js
@@ -1,0 +1,12 @@
+// @flow strict
+
+import calculateBrightness from '../calculateBrightness';
+
+// See: https://github.com/chromium/chromium/blob/15aa6bb80864a6dd89c25313dfd2839c6055724e/third_party/google-closure-library/closure/goog/color/color_test.js#L542
+it('calculates brightness correctly', () => {
+  expect(calculateBrightness([255, 255, 255])).toBe(255); // white
+  expect(calculateBrightness([0, 0, 0])).toBe(0); // black
+  expect(calculateBrightness([255, 127, 80])).toBe(160); // coral
+  expect(calculateBrightness([144, 238, 144])).toBe(199); // lightgreen
+  expect(calculateBrightness([0, 128, 0])).toBe(75); // green
+});

--- a/src/css-colors/src/__tests__/isBright.test.js
+++ b/src/css-colors/src/__tests__/isBright.test.js
@@ -1,0 +1,11 @@
+// @flow strict
+
+import isBright from '../isBright';
+
+it('detects bright color correctly', () => {
+  expect(isBright([255, 255, 255])).toBe(true); // white
+  expect(isBright([0, 0, 0])).toBe(false); // black
+  expect(isBright([255, 127, 80])).toBe(true); // coral
+  expect(isBright([144, 238, 144])).toBe(true); // lightgreen
+  expect(isBright([0, 128, 0])).toBe(false); // green
+});

--- a/src/css-colors/src/__tests__/isDark.test.js
+++ b/src/css-colors/src/__tests__/isDark.test.js
@@ -1,0 +1,11 @@
+// @flow strict
+
+import isDark from '../isDark';
+
+it('detects dark color correctly', () => {
+  expect(isDark([255, 255, 255])).toBe(false); // white
+  expect(isDark([0, 0, 0])).toBe(true); // black
+  expect(isDark([255, 127, 80])).toBe(false); // coral
+  expect(isDark([144, 238, 144])).toBe(false); // lightgreen
+  expect(isDark([0, 128, 0])).toBe(true); // green
+});

--- a/src/css-colors/src/calculateBrightness.js
+++ b/src/css-colors/src/calculateBrightness.js
@@ -1,0 +1,11 @@
+// @flow strict
+
+// Calculate brightness of a color according to YIQ formula (brightness is Y).
+//
+// Sources:
+// - https://www.w3.org/TR/AERT/#color-contrast
+// - https://en.wikipedia.org/wiki/YIQ
+// - https://github.com/chromium/chromium/blob/a11b95356a4b646f87ef8857559613bcf5dd4059/third_party/google_input_tools/third_party/closure_library/closure/goog/color/color.js#L746
+export default function calculateBrightness(rgb: [number, number, number]): number {
+  return Math.round((rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) / 1000);
+}

--- a/src/css-colors/src/index.js
+++ b/src/css-colors/src/index.js
@@ -3,5 +3,7 @@
 export { default as cssColorNames } from './cssColorNames';
 export { default as hex3ToHex6 } from './hex3ToHex6';
 export { default as hex6ToHex3 } from './hex6ToHex3';
+export { default as isBright } from './isBright';
 export { default as isColor } from './isColor';
+export { default as isDark } from './isDark';
 export { default as normalizeColor } from './normalizeColor';

--- a/src/css-colors/src/isBright.js
+++ b/src/css-colors/src/isBright.js
@@ -1,0 +1,7 @@
+// @flow strict
+
+import calculateBrightness from './calculateBrightness';
+
+export default function isBright(rgb: [number, number, number]): boolean {
+  return calculateBrightness(rgb) >= 128;
+}

--- a/src/css-colors/src/isDark.js
+++ b/src/css-colors/src/isDark.js
@@ -1,0 +1,7 @@
+// @flow strict
+
+import calculateBrightness from './calculateBrightness';
+
+export default function isDark(rgb: [number, number, number]): boolean {
+  return calculateBrightness(rgb) < 128;
+}

--- a/src/sx/package.json
+++ b/src/sx/package.json
@@ -9,7 +9,7 @@
   "sideEffects": false,
   "module": false,
   "dependencies": {
-    "@adeira/css-colors": "^1.0.0",
+    "@adeira/css-colors": "^1.1.0",
     "@adeira/js": "^1.3.0",
     "@adeira/murmur-hash": "^1.0.0",
     "@adeira/signed-source": "^1.0.0",


### PR DESCRIPTION
It would be also nice to have a utility for HEX <-> RGB array, see: https://github.com/chromium/chromium/blob/15aa6bb80864a6dd89c25313dfd2839c6055724e/third_party/google_input_tools/third_party/closure_library/closure/goog/color/color.js#L158-L193