### PR TITLE
YCR: use fixed Juniper version

### DIFF
--- a/src/ya-comiste-rust/Cargo.lock
+++ b/src/ya-comiste-rust/Cargo.lock
@@ -1092,7 +1092,8 @@ dependencies = [
 [[package]]
 name = "juniper"
 version = "0.15.1"
-source = "git+https://github.com/graphql-rust/juniper#4467b291532eee851a2ab58d6d6f15e1e631cfe6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19309aa4fd360d59b35edf306a3e1740e9784866bf6e222767fd7217b13d885c"
 dependencies = [
  "async-trait",
  "bson",
@@ -1112,7 +1113,8 @@ dependencies = [
 [[package]]
 name = "juniper_codegen"
 version = "0.15.1"
-source = "git+https://github.com/graphql-rust/juniper#4467b291532eee851a2ab58d6d6f15e1e631cfe6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a57106f1e3bb3f7156d240f062c3eee0c83dece5e7e2ff49c4da980a10def2bf"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/src/ya-comiste-rust/server/Cargo.toml
+++ b/src/ya-comiste-rust/server/Cargo.toml
@@ -15,7 +15,7 @@ deadpool = { version = "0.7.0", features = ["managed"] }
 env_logger = "0.8.2"
 futures = "0.3.8"
 jsonwebtoken = "7.2.0"
-juniper = { git = "https://github.com/graphql-rust/juniper" }
+juniper = "0.15.1"
 lazy_static = "1.4.0"
 log = "0.4.11"
 num_cpus = "1.13.0"


### PR DESCRIPTION
Previously, we used `juniper_warp` which didn't work with the latest `warp` version. However, that's no longer the case and there is no reason to use Juniper master.