### PR TITLE
YCR: drop `juniper_warp` dependency

### DIFF
--- a/src/ya-comiste-rust/Cargo.lock
+++ b/src/ya-comiste-rust/Cargo.lock
@@ -16,12 +16,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
-
-[[package]]
 name = "arangors"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,22 +1121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "juniper_warp"
-version = "0.6.0"
-source = "git+https://github.com/graphql-rust/juniper#4467b291532eee851a2ab58d6d6f15e1e631cfe6"
-dependencies = [
- "anyhow",
- "bytes",
- "futures",
- "juniper",
- "serde",
- "serde_json",
- "thiserror",
- "tokio 0.2.23",
- "warp",
-]
-
-[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,10 +2057,10 @@ dependencies = [
  "dataloader",
  "deadpool",
  "env_logger",
+ "futures",
  "insta",
  "jsonwebtoken",
  "juniper",
- "juniper_warp",
  "lazy_static",
  "log",
  "num_cpus",

--- a/src/ya-comiste-rust/server/Cargo.toml
+++ b/src/ya-comiste-rust/server/Cargo.toml
@@ -13,9 +13,9 @@ async-trait = "0.1.42"
 dataloader = "0.13.2"
 deadpool = { version = "0.7.0", features = ["managed"] }
 env_logger = "0.8.2"
+futures = "0.3.8"
 jsonwebtoken = "7.2.0"
 juniper = { git = "https://github.com/graphql-rust/juniper" }
-juniper_warp = { git = "https://github.com/graphql-rust/juniper" }
 lazy_static = "1.4.0"
 log = "0.4.11"
 num_cpus = "1.13.0"

--- a/src/ya-comiste-rust/server/src/main.rs
+++ b/src/ya-comiste-rust/server/src/main.rs
@@ -1,15 +1,159 @@
-use crate::arangodb::{get_database_connection_pool, ConnectionPool};
-use crate::auth::users::{AnonymousUser, User};
-use crate::headers::parse_authorization_header;
-use crate::sdui::graphql_context::Context;
+use crate::arangodb::get_database_connection_pool;
 use crate::sdui::graphql_schema::create_graphql_schema;
-use crate::sdui::model::component_content::get_content_dataloader;
+use std::net::{Ipv4Addr, SocketAddrV4};
 use warp::Filter;
 
 mod arangodb;
 mod auth;
 mod headers;
 mod sdui;
+
+mod models {
+    use crate::arangodb::ConnectionPool;
+    use crate::auth::users::{AnonymousUser, User};
+
+    pub async fn get_current_user(pool: &ConnectionPool, session_token: &Option<String>) -> User {
+        match session_token {
+            Some(session_token) => {
+                match crate::auth::resolve_user_from_session_token(&pool, &session_token).await {
+                    // TODO: should at this point anonymous/unauthorized user be considered an error (?)
+                    User::AnonymousUser(user) => {
+                        log::info!("Using anonymous user (unmatched session token) 👊");
+                        User::AnonymousUser(user)
+                    }
+                    User::AuthorizedUser(user) => {
+                        log::info!("Using authorized user: {} 👍", user.id());
+                        User::AuthorizedUser(user)
+                    }
+                    User::UnauthorizedUser(user) => User::UnauthorizedUser(user),
+                }
+            }
+            None => {
+                log::warn!("Using anonymous user (unable to extract 'authorization' header) 👎");
+                User::AnonymousUser(AnonymousUser::new())
+            }
+        }
+    }
+}
+
+mod handlers {
+    use crate::arangodb::ConnectionPool;
+    use crate::models::get_current_user;
+    use crate::sdui::graphql_context::Context;
+    use crate::sdui::graphql_schema::Schema;
+    use crate::sdui::model::component_content::get_content_dataloader;
+    use futures::stream::TryStreamExt;
+    use juniper::http::GraphQLRequest;
+    use std::convert::Infallible;
+    use std::sync::Arc;
+    use warp::filters::multipart::{FormData, Part};
+    use warp::http::StatusCode;
+
+    pub async fn graphql_post(
+        request: GraphQLRequest,
+        pool: ConnectionPool,
+        schema: Arc<Schema>,
+        session_token: Option<String>,
+    ) -> Result<impl warp::Reply, Infallible> {
+        let user = get_current_user(&pool, &session_token).await;
+        let context = Context {
+            pool: pool.clone(),
+            content_dataloader: get_content_dataloader(&user, &pool),
+            user, // TODO: should be only authorized OR anonymous (not unathorized?)
+        };
+        let response = request.execute(&schema, &context).await;
+        Ok(warp::reply::json(&response)) // TODO: take `response.is_ok()` into account
+    }
+
+    pub async fn graphql_multipart(
+        form_data: FormData,
+        _pool: ConnectionPool,
+    ) -> Result<impl warp::Reply, Infallible> {
+        let parts: Result<Vec<Part>, warp::Error> = form_data.try_collect().await;
+        // TODO: implement (https://blog.logrocket.com/file-upload-and-download-in-rust/)
+        //  - process the query (via `graphql_post`)
+        //  - process the files (limit `content_type` and file size)
+        //  - upload to S3 and save into DB with conputed blurhash
+        Ok(StatusCode::NOT_IMPLEMENTED)
+    }
+}
+
+mod filters {
+    use crate::arangodb::ConnectionPool;
+    use crate::headers::parse_authorization_header;
+    use crate::sdui::graphql_schema::Schema;
+    use juniper::http::GraphQLRequest;
+    use std::sync::Arc;
+    use warp::Filter;
+
+    /// The 2 filters combined.
+    pub fn graphql(
+        pool: ConnectionPool,
+        schema: Schema,
+    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+        let schema = Arc::new(schema); // TODO: is this the right way?
+        let post_json_schema = schema.clone();
+        graphql_post(pool.clone(), post_json_schema).or(graphql_multipart(pool))
+    }
+
+    /// POST /graphql with JSON body
+    pub fn graphql_post(
+        pool: ConnectionPool,
+        schema: Arc<Schema>,
+    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+        warp::path!("graphql")
+            .and(warp::post())
+            .and(with_json_body())
+            .and(with_database_connection_pool(pool))
+            .and(with_graphql_schema(schema))
+            .and(with_session_token())
+            .and_then(crate::handlers::graphql_post)
+    }
+
+    /// POST /graphql-upload with form multipart
+    pub fn graphql_multipart(
+        pool: ConnectionPool,
+    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+        warp::path!("graphql-upload")
+            .and(warp::post())
+            .and(warp::multipart::form())
+            .and(with_database_connection_pool(pool))
+            .and_then(crate::handlers::graphql_multipart)
+    }
+
+    fn with_json_body() -> impl Filter<Extract = (GraphQLRequest,), Error = warp::Rejection> + Clone
+    {
+        // When accepting a body, we want a JSON body (and to reject huge payloads).
+        // TODO: improve this to some smarter validation (query whitelisting)
+        let _16kb = 1024 * 16;
+        warp::body::content_length_limit(_16kb).and(warp::body::json())
+    }
+
+    fn with_database_connection_pool(
+        pool: ConnectionPool,
+    ) -> impl Filter<Extract = (ConnectionPool,), Error = std::convert::Infallible> + Clone {
+        warp::any().map(move || pool.clone())
+    }
+
+    fn with_graphql_schema(
+        schema: Arc<Schema>,
+    ) -> impl Filter<Extract = (Arc<Schema>,), Error = std::convert::Infallible> + Clone {
+        warp::any().map(move || schema.clone())
+    }
+
+    fn with_session_token(
+    ) -> impl Filter<Extract = (Option<String>,), Error = warp::Rejection> + Clone {
+        warp::header::optional::<String>("authorization").map(|auth_header: Option<String>| {
+            match auth_header {
+                Some(auth_header) => match parse_authorization_header(&*auth_header) {
+                    Ok(session_token) => Some(session_token),
+                    Err(_) => None,
+                },
+                None => None,
+            }
+        })
+    }
+}
 
 #[tokio::main]
 async fn main() {
@@ -19,75 +163,27 @@ async fn main() {
     );
     env_logger::builder().format_timestamp(None).init();
 
-    // Create database connection wrapper only once per application lifetime so we can reuse it
+    // Create database connection pool only once per application lifetime so we can reuse it
     // for the following requests. DO NOT create it in the GraphQL context extractor!
-    let database_connection_pool = get_database_connection_pool();
-
-    fn with_database_connection_pool(
-        pool: ConnectionPool,
-    ) -> impl Filter<Extract = (ConnectionPool,), Error = std::convert::Infallible> + Clone {
-        warp::any().map(move || pool.clone())
-    }
-
-    let context_extractor = warp::any()
-        .and(with_database_connection_pool(database_connection_pool))
-        .and(warp::header::optional::<String>("authorization"))
-        .and_then(
-            |pool: ConnectionPool, auth_header: Option<String>| async move {
-                let user: User = match auth_header {
-                    Some(auth_header) => {
-                        match parse_authorization_header(&*auth_header) {
-                            Ok(session_token) => {
-                                match auth::resolve_user_from_session_token(&pool, &session_token).await {
-                                    // TODO: should at this point anonymous/unauthorized user be considered an error (?)
-                                    User::AnonymousUser(user) => {
-                                        log::info!("Using anonymous user 👊");
-                                        User::AnonymousUser(user)
-                                    }
-                                    User::AuthorizedUser(user) => {
-                                        log::info!("Using authorized user: {} 👍", user.id());
-                                        User::AuthorizedUser(user)
-                                    }
-                                    User::UnauthorizedUser(user) => {
-                                        User::UnauthorizedUser(user)
-                                    }
-                                }
-                            }
-                            Err(_) => {
-                                log::warn!("Using anonymous user (unable to extract 'authorization' header) 👎");
-                                User::AnonymousUser(AnonymousUser::new())
-                            }
-                        }
-                    }
-                    None => {
-                        log::warn!("Using anonymous user (no 'authorization' header) 👎");
-                        User::AnonymousUser(AnonymousUser::new())
-                    }
-                };
-                Ok::<Context, std::convert::Infallible>(Context {
-                    pool: pool.to_owned(),
-                    content_dataloader: get_content_dataloader(&user, &pool),
-                    user, // TODO: should be only authorized OR anonymous (not unathorized?)
-                })
-            },
-        )
-        .boxed();
+    let pool = get_database_connection_pool();
+    let schema = create_graphql_schema();
 
     let cors = warp::cors()
         .allow_any_origin() // TODO
         .allow_headers(vec!["x-client", "content-type"])
         .allow_methods(vec![warp::http::Method::POST]);
-    let log = warp::log("warp_server");
 
-    let filter = warp::post()
-        .and(warp::path("graphql"))
-        .and(juniper_warp::make_graphql_filter(
-            create_graphql_schema(),
-            context_extractor,
-        ))
-        .with(cors)
-        .with(log);
+    // This opens a possibility for other REST endpoints (webhooks for example).
+    let api = filters::graphql(pool, schema);
+    let routes = api.with(warp::log("warp_server")).with(cors);
 
-    log::info!(target: "warp_server", "Listening on 127.0.0.1:8080/graphql");
-    warp::serve(filter).run(([127, 0, 0, 1], 8080)).await
+    let socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
+    log::info!(target: "warp_server", "Listening on {}", socket);
+    // TODO: how to fetch these routes automatically (?)
+    log::info!(target: "warp_server", " - POST /graphql          (JSON)");
+    log::info!(target: "warp_server", " - POST /graphql-upload   (multipart)");
+    warp::serve(routes).run(socket).await
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/ya-comiste-rust/server/src/tests.rs
+++ b/src/ya-comiste-rust/server/src/tests.rs
@@ -1,0 +1,145 @@
+use super::filters;
+use crate::arangodb::get_database_connection_pool;
+use crate::sdui::graphql_schema::create_graphql_schema;
+use juniper::http::GraphQLRequest;
+use juniper::DefaultScalarValue;
+use warp::http::StatusCode;
+use warp::test::request;
+
+#[tokio::test]
+async fn test_graphql_post_query() {
+    let pool = get_database_connection_pool();
+    let schema = create_graphql_schema();
+    let api = filters::graphql(pool, schema);
+
+    let resp = request()
+        .method("POST")
+        .path("/graphql")
+        .json(&GraphQLRequest::<DefaultScalarValue>::new(
+            String::from("query{__typename}"),
+            None,
+            None,
+        ))
+        .reply(&api)
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.body(), r#"{"data":{"__typename":"Query"}}"#);
+}
+
+#[tokio::test]
+async fn test_graphql_post_mutation() {
+    let pool = get_database_connection_pool();
+    let schema = create_graphql_schema();
+    let api = filters::graphql(pool, schema);
+
+    let resp = request()
+        .method("POST")
+        .path("/graphql")
+        .json(&GraphQLRequest::<DefaultScalarValue>::new(
+            String::from("mutation{__typename}"),
+            None,
+            None,
+        ))
+        .reply(&api)
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.body(), r#"{"data":{"__typename":"Mutation"}}"#);
+}
+
+#[tokio::test]
+async fn test_graphql_multipart_query() {
+    let pool = get_database_connection_pool();
+    let schema = create_graphql_schema();
+    let api = filters::graphql(pool, schema);
+
+    let boundary = "--abcdef1234--";
+    let body = format!(
+        r#"
+         --{0}
+         content-disposition: form-data; name="query"
+
+         query {{ __typename }}
+         --{0}--
+         "#,
+        boundary
+    );
+
+    let resp = request()
+        .method("POST")
+        .path("/graphql-upload")
+        .header("content-length", body.len())
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={}", boundary),
+        )
+        .body(body)
+        .reply(&api)
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+}
+
+#[tokio::test]
+async fn test_graphql_post_query_fail() {
+    let pool = get_database_connection_pool();
+    let schema = create_graphql_schema();
+    let api = filters::graphql(pool, schema);
+
+    let resp = request()
+        .method("POST")
+        .path("/graphql")
+        .json(&GraphQLRequest::<DefaultScalarValue>::new(
+            String::from("query{__wtf}"),
+            None,
+            None,
+        ))
+        .reply(&api)
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.body(),
+        r#"{"errors":[{"message":"Unknown field \"__wtf\" on type \"Query\"","locations":[{"line":1,"column":7}]}]}"#
+    );
+}
+
+#[tokio::test]
+async fn test_graphql_unknown_method_get() {
+    let pool = get_database_connection_pool();
+    let schema = create_graphql_schema();
+    let api = filters::graphql(pool, schema);
+
+    let resp = request()
+        .method("GET")
+        .path("/graphql?query={__typename}")
+        .reply(&api)
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+
+#[tokio::test]
+async fn test_graphql_syntax_error() {
+    let pool = get_database_connection_pool();
+    let schema = create_graphql_schema();
+    let api = filters::graphql(pool, schema);
+
+    let resp = request()
+        .method("POST")
+        .path("/graphql")
+        .json(&GraphQLRequest::<DefaultScalarValue>::new(
+            String::from("query{syntax$"),
+            None,
+            None,
+        ))
+        .reply(&api)
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.body(),
+        r#"{"errors":[{"message":"Unexpected \"$\"","locations":[{"line":1,"column":13}]}]}"#
+    );
+}


### PR DESCRIPTION
Purpose of these changes it to get rid of `juniper_warp` dependency and get more control over the accepted request methods (only POST with JSON body and POST with multipart body for GraphQL queries with file upload).