### PR TITLE
SX: handle nullable composable styles gracefully

### DIFF
--- a/src/sx/index.js
+++ b/src/sx/index.js
@@ -30,11 +30,11 @@ import renderPageWithSX from './src/renderPageWithSX';
  */
 function composeStylesheets(
   stylesheetA: Map<string, string>,
-  stylesheetB: Map<string, string>,
+  stylesheetB: ?Map<string, string>,
 ): string {
   // Should we support deeply nested styles or leave it like this and overwrite them?
   // Note: this is very similar what `styles('aaa', 'bbb')` does internally when merging.
-  const merged = new Map([...stylesheetA, ...stylesheetB]);
+  const merged = stylesheetB ? new Map([...stylesheetA, ...stylesheetB]) : stylesheetA;
   const classes = [...merged.values()];
   const uniqueClasses = [...new Set(classes)];
   return uniqueClasses.join(' ');

--- a/src/sx/src/__tests__/composability.test.js
+++ b/src/sx/src/__tests__/composability.test.js
@@ -90,3 +90,10 @@ it('merges more complex styles correctly', () => {
   expect(sx(styles.default, externalStyles.custom)).toMatchInlineSnapshot(`"_4xrWBp _4j9tl4"`);
   expect(sx(externalStyles.custom, styles.default)).toMatchInlineSnapshot(`"_39Fbhf vovX4"`);
 });
+
+it('handles nullable second argument gracefully', () => {
+  // This is convenient when the overwriting styles are optional.
+  const styles = sx.create({ default: { fontSize: 16 } });
+  expect(sx(styles.default, null)).toBe(styles('default'));
+  expect(sx(styles.default, undefined)).toBe(styles('default'));
+});


### PR DESCRIPTION
It's useful to make the second `sx(…)` argument optional because the style overwriting property might be quite often nullable as well (styles might need overwriting only sometimes).