### PR TITLE
YCR: hash session tokens

### DIFF
--- a/src/ya-comiste-meta/schema.graphql
+++ b/src/ya-comiste-meta/schema.graphql
@@ -1,4 +1,4 @@
-# @generated SignedSource<<4c833b4e4ee7d0aae7abb7e38c6906e6>>
+# @generated SignedSource<<e2eabfeada964ef2bf749c41a1683663>>
 
 type SDUIScrollViewHorizontalComponent {
   id: ID!
@@ -21,12 +21,17 @@ type Mutation {
     device) and returns authorization payload. There is no concept of sign-in and sign-up
     because every user with a valid JWT ID token will be either authorized OR registered and
     authorized. Invalid tokens and disabled tokens will be rejected.
+
+    Please note: repeated calls will result in error since we cannot authorize the user twice
+    and we cannot return the previous token either (since it's hashed).
   """
   authorizeMobile(googleIdToken: String!): AuthorizeMobilePayload!
   """
     The purpose of this `deauthorize` mutation is to remove the active sessions and efectivelly
     make the mobile application unsigned. Mobile applications should remove the session token
     once deauthorized.
+
+    Repeated calls will result in failure since it's not possible to deauthorize twice.
   """
   deauthorizeMobile(sessionToken: String!): DeauthorizeMobilePayload!
 }

--- a/src/ya-comiste-rust/Cargo.lock
+++ b/src/ya-comiste-rust/Cargo.lock
@@ -2056,6 +2056,7 @@ version = "0.0.0"
 dependencies = [
  "arangors",
  "async-trait",
+ "data-encoding",
  "dataloader",
  "deadpool",
  "env_logger",
@@ -2069,6 +2070,7 @@ dependencies = [
  "proptest",
  "rand 0.8.1",
  "reqwest",
+ "ring",
  "serde",
  "serde_json",
  "signedsource",

--- a/src/ya-comiste-rust/server/Cargo.toml
+++ b/src/ya-comiste-rust/server/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dependencies]
 arangors = "0.4.5"
 async-trait = "0.1.42"
+data-encoding = "2.3.1"
 dataloader = "0.13.2"
 deadpool = { version = "0.7.0", features = ["managed"] }
 env_logger = "0.8.2"
@@ -21,6 +22,7 @@ log = "0.4.11"
 num_cpus = "1.13.0"
 rand = "0.8.1"
 reqwest = { version = "0.10.10", features = ["json", "blocking"] }
+ring = "0.16.5"
 serde = "1.0.118"
 serde_json = "1.0.61"
 signedsource = { path = "../signedsource" }

--- a/src/ya-comiste-rust/server/src/auth/error.rs
+++ b/src/ya-comiste-rust/server/src/auth/error.rs
@@ -1,8 +1,9 @@
 #[derive(Debug)]
 pub enum AuthError {
+    AlreadyAuthorized,
+    DatabaseError(crate::arangodb::errors::ModelError),
     InvalidToken(String), // unable the use the token because working with it somehow failed
     JSONWebTokenError(jsonwebtoken::errors::Error),
-    DatabaseError(crate::arangodb::errors::ModelError),
 }
 
 impl std::fmt::Display for AuthError {

--- a/src/ya-comiste-rust/server/src/auth/mod.rs
+++ b/src/ya-comiste-rust/server/src/auth/mod.rs
@@ -1,9 +1,11 @@
 use crate::auth::certs::CachedCerts;
 use crate::auth::error::AuthError;
 use crate::auth::google::verify_id_token_integrity;
-use crate::auth::session::{create_user_session, delete_user_session, find_session_by_user};
+use crate::auth::session::{
+    create_user_session, delete_user_session, derive_session_token_hash, find_session_by_user,
+};
 use crate::auth::users::{
-    create_user_by_google_claims, find_user_by_google_claims, get_user_by_session_token,
+    create_user_by_google_claims, find_user_by_google_claims, get_user_by_session_token_hash,
     AnonymousUser, User,
 };
 
@@ -19,9 +21,8 @@ mod error;
 /// This function tries to authorize the user by Google ID token (rejects otherwise).
 ///
 /// 1. validate the Google ID token (and immediately reject if not valid)
-/// 2a. retrieve the existing user
-/// 2b. create a new user (if it doesn't exist yet)
-/// 3. generate and store new sessions token for this user and return it back
+/// 2a. retrieve the existing user and throw if exists (cannot authorize twice)
+/// 2b. create a new user if it doesn't exist yet and generate and store new session token
 ///
 /// It essentially transforms Google ID token to our Session Token.
 pub async fn authorize(
@@ -35,12 +36,13 @@ pub async fn authorize(
         Some(user) => {
             // the user already exists (2a.)
             match find_session_by_user(&pool, &user).await {
-                Some(session) => Ok(session.key()), // session already exists, good (3.)
+                Some(_) => Err(error::AuthError::AlreadyAuthorized), // (2a.)
                 None => {
                     // session doesn't exist (but user does), let's create a new session
                     let session_token = session::generate_session_token();
-                    create_user_session(&pool, &session_token, &user).await?;
-                    Ok(session_token) // (3.)
+                    let session_token_hash = derive_session_token_hash(&session_token);
+                    create_user_session(&pool, &session_token_hash, &user).await?;
+                    Ok(session_token)
                 }
             }
         }
@@ -49,8 +51,9 @@ pub async fn authorize(
             match create_user_by_google_claims(&pool, &token_data.claims).await {
                 Ok(new_user) => {
                     let session_token = session::generate_session_token();
-                    create_user_session(&pool, &session_token, &new_user).await?;
-                    Ok(session_token) // (3.)
+                    let session_token_hash = derive_session_token_hash(&session_token);
+                    create_user_session(&pool, &session_token_hash, &new_user).await?;
+                    Ok(session_token)
                 }
                 Err(e) => Err(AuthError::DatabaseError(e)),
             }
@@ -64,7 +67,8 @@ pub async fn deauthorize(
     pool: &crate::arangodb::ConnectionPool,
     session_token: &str,
 ) -> Result<bool, error::AuthError> {
-    delete_user_session(&pool, &session_token).await?;
+    let session_token_hash = derive_session_token_hash(&session_token);
+    delete_user_session(&pool, &session_token_hash).await?;
     Ok(true) // success
 }
 
@@ -73,7 +77,8 @@ pub async fn resolve_user_from_session_token(
     pool: &crate::arangodb::ConnectionPool,
     session_token: &str,
 ) -> User {
-    match get_user_by_session_token(&pool, &session_token).await {
+    let session_token_hash = derive_session_token_hash(&session_token);
+    match get_user_by_session_token_hash(&pool, &session_token_hash).await {
         Ok(user) => User::AuthorizedUser(user),
         Err(_) => User::AnonymousUser(AnonymousUser::new()),
     }

--- a/src/ya-comiste-rust/server/src/auth/session.rs
+++ b/src/ya-comiste-rust/server/src/auth/session.rs
@@ -3,30 +3,28 @@ use crate::auth::users::UnauthorizedUser;
 use rand::Rng;
 use serde::Deserialize;
 
-/// Generates sessions token which is compatible with ArangoDB `_key` expectations as well as with
-/// RFC6750 - Authorization Framework: Bearer Token Usage syntax (https://tools.ietf.org/html/rfc6750).
+/// Generates sessions token which is compatible with RFC6750 - "Authorization Framework: Bearer
+/// Token Usage" syntax (https://tools.ietf.org/html/rfc6750).
 ///
 /// Session OWASP recommended requirements:
 ///
 /// 1. Session ID Length (the session ID length must be at least 128 bits (16 bytes))
-/// 2. Session ID Content (must be meaningless to prevent information disclosure attacks)
+/// 2. Session ID Entropy (?)
+/// 3. Session ID Content (must be meaningless to prevent information disclosure attacks)
+/// 4. Session ID must be unique
 ///
 /// See: https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-properties
 ///
-/// Conveniently, the charset used to generate the token follows ArangoDB conventions for `_key` so
-/// the session ID can (and should) be used as a collection key. See: https://www.arangodb.com/docs/stable/data-modeling-naming-conventions-document-keys.html
+/// Hashed version of this session token can (and should) be used as a collection key in the DB.
+/// See: https://www.arangodb.com/docs/stable/data-modeling-naming-conventions-document-keys.html
 ///
-/// On top of that, it also complies with RFC6750 so it can be used as a Bearer token, see:
+/// Raw session token version complies with RFC6750 so it can be used as a Bearer token, see:
 /// https://tools.ietf.org/html/rfc6750#section-2.1 (https://tools.ietf.org/html/rfc5234)
-///
-/// So, essentially intersection of these 2 sets (special chars only):
-/// "_" / "-" / ":" / "." / "@" / "(" / ")" / "+" / "," / "=" / ";" / "$" / "!" / "*" / "'" / "%"
-/// "-" / "." / "_" / "~" / "+" / "/"
-pub fn generate_session_token() -> String {
-    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-.+";
+pub(crate) fn generate_session_token() -> String {
+    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~+/";
 
     let mut rng = rand::thread_rng();
-    let session_token: String = (0..64)
+    let session_token: String = (0..128)
         .map(|_| {
             let idx = rng.gen_range(0..CHARSET.len());
             CHARSET[idx] as char
@@ -34,6 +32,32 @@ pub fn generate_session_token() -> String {
         .collect();
 
     session_token
+}
+
+/// Derives hash of the session token which can be securely saved in the database.
+///
+/// Note: we currently do not salt the tokens per user since we expect that every generated
+/// session/hash will be unique. This is a strong requirement since the session token uniquely
+/// identifies the user. The salt below is just to be future proof in case we change our mind with
+/// the salting (and to salt the DB).
+pub(crate) fn derive_session_token_hash(session_token: &str) -> String {
+    // We are not using PBKDF2-like derivation functions on purpose here. The reasoning is that our
+    // session token has high enough entropy and we need to have this derivation as fast as possible
+    // since it's being called with every API request (to fetch and verify the user per request).
+    // See: https://security.stackexchange.com/q/151257
+
+    // Database-unique component so that an attacker cannot crack the same session_token across
+    // databases. This value was generated from a secure PRNG.
+    // See: https://briansmith.org/rustdoc/ring/pbkdf2/index.html#password-database-example
+    let db_salt_component = "32fd09c7-82d2-47c5-8fe4-81a526d3996d";
+
+    let hash = ring::digest::digest(
+        &ring::digest::SHA256,
+        format!("{}{}", db_salt_component, session_token).as_bytes(),
+    );
+
+    // https://rust-lang-nursery.github.io/rust-cookbook/cryptography/encryption.html
+    data_encoding::HEXLOWER.encode(&hash.as_ref())
 }
 
 #[derive(Clone, Deserialize)]
@@ -89,7 +113,7 @@ pub async fn find_session_by_user(
 /// TODO(004) add integration tests
 pub async fn create_user_session(
     pool: &crate::arangodb::ConnectionPool,
-    session_token: &str,
+    session_token_hash: &str,
     user: &UnauthorizedUser,
 ) -> Result<Session, ModelError> {
     let db = pool.db().await;
@@ -100,7 +124,7 @@ pub async fn create_user_session(
             r#"
             LET new_session = FIRST(
               INSERT {
-                _key: @session_key,
+                _key: @session_token_hash,
                 last_access: DATE_ISO8601(DATE_NOW()),
               } INTO sessions
               OPTIONS {
@@ -111,9 +135,9 @@ pub async fn create_user_session(
               RETURN NEW
             )
 
-            LET session_id = CONCAT_SEPARATOR('/', 'sessions', @session_key)
+            LET session_id = CONCAT_SEPARATOR('/', 'sessions', @session_token_hash)
             INSERT {
-              _key: @session_key,
+              _key: @session_token_hash,
               _from: @user_id,
               _to: session_id,
             } INTO user_sessions
@@ -126,7 +150,7 @@ pub async fn create_user_session(
             RETURN new_session
             "#,
         )
-        .bind_var("session_key", session_token)
+        .bind_var("session_token_hash", session_token_hash)
         .bind_var("user_id", user.id())
         .build();
 
@@ -145,23 +169,23 @@ pub async fn create_user_session(
 /// TODO(004) add integration tests
 pub async fn delete_user_session(
     pool: &crate::arangodb::ConnectionPool,
-    session_token: &str,
+    session_token_hash: &str,
 ) -> Result<Session, ModelError> {
     let db = pool.db().await;
 
     let remove_sessions_aql = arangors::AqlQuery::builder()
         .query(
             r#"
-            LET session_id = CONCAT_SEPARATOR('/', 'sessions', @session_key)
+            LET session_id = CONCAT_SEPARATOR('/', 'sessions', @session_token_hash)
             LET r = (
               FOR v,e,p IN 1..1 INBOUND session_id GRAPH 'sessions'
               REMOVE e IN user_sessions
             )
-            REMOVE @session_key IN sessions
+            REMOVE @session_token_hash IN sessions
             RETURN OLD
             "#,
         )
-        .bind_var("session_key", session_token)
+        .bind_var("session_token_hash", session_token_hash)
         .build();
 
     let session_vector = db.aql_query::<Session>(remove_sessions_aql).await?;
@@ -182,10 +206,22 @@ mod tests {
         let mut previous_token = String::from("");
         for _ in 0..1000 {
             let new_token = generate_session_token();
-            assert_eq!(new_token.len(), 64);
+            assert_eq!(new_token.len(), 128);
             assert_ne!(new_token, previous_token);
             previous_token = new_token;
-            assert_eq!(previous_token.len(), 64);
+            assert_eq!(previous_token.len(), 128);
+        }
+    }
+
+    #[test]
+    fn derive_session_token_hash_test() {
+        let mut previous_hash = String::from("");
+        for _ in 0..1000 {
+            let new_hash = derive_session_token_hash(&*generate_session_token());
+            assert_eq!(new_hash.len(), 64);
+            assert_ne!(new_hash, previous_hash);
+            previous_hash = new_hash;
+            assert_eq!(previous_hash.len(), 64);
         }
     }
 }

--- a/src/ya-comiste-rust/server/src/auth/users/mod.rs
+++ b/src/ya-comiste-rust/server/src/auth/users/mod.rs
@@ -87,16 +87,16 @@ pub async fn create_user_by_google_claims(
 /// It either updates the existing sessions (last access time) or returns an error if the session
 /// doesn't exist (so the user is not logged in).
 /// TODO(004) add integration tests
-pub async fn get_user_by_session_token(
+pub async fn get_user_by_session_token_hash(
     pool: &crate::arangodb::ConnectionPool,
-    session_token: &str,
+    session_token_hash: &str,
 ) -> Result<AuthorizedUser, ModelError> {
     let db = pool.db().await;
 
     let aql = arangors::AqlQuery::builder()
         .query(
             r#"
-            LET session_key = @session_token
+            LET session_key = @session_token_hash
             LET session_id = CONCAT_SEPARATOR('/', 'sessions', session_key)
 
             FOR vertex IN 1..1 INBOUND session_id GRAPH 'sessions'
@@ -112,7 +112,7 @@ pub async fn get_user_by_session_token(
             })
             "#,
         )
-        .bind_var("session_token", session_token)
+        .bind_var("session_token_hash", session_token_hash)
         .build();
 
     let users_vector = db.aql_query::<AuthorizedUser>(aql).await?;

--- a/src/ya-comiste-rust/server/src/graphql_schema.rs
+++ b/src/ya-comiste-rust/server/src/graphql_schema.rs
@@ -51,6 +51,9 @@ impl Mutation {
     /// device) and returns authorization payload. There is no concept of sign-in and sign-up
     /// because every user with a valid JWT ID token will be either authorized OR registered and
     /// authorized. Invalid tokens and disabled tokens will be rejected.
+    ///
+    /// Please note: repeated calls will result in error since we cannot authorize the user twice
+    /// and we cannot return the previous token either (since it's hashed).
     async fn authorize_mobile(
         google_id_token: String,
         context: &Context,
@@ -76,8 +79,10 @@ impl Mutation {
     /// The purpose of this `deauthorize` mutation is to remove the active sessions and efectivelly
     /// make the mobile application unsigned. Mobile applications should remove the session token
     /// once deauthorized.
+    ///
+    /// Repeated calls will result in failure since it's not possible to deauthorize twice.
     async fn deauthorize_mobile(
-        session_token: String,
+        session_token: String, // TODO: this could be removed (?) - we can use the user from context
         context: &Context,
     ) -> DeauthorizeMobilePayload {
         let connection_pool = context.pool.to_owned();


### PR DESCRIPTION
Last missing piece for the session management. Session tokens are essentially long-time passwords and we should store them securely as well. This commits tries to find a balance between security and performance since we have to work with the hashes per API request (PBKDF2 with many iterations is too slow and unnecessary in our case).