### PR TITLE
Update CODEOWNERS with core maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,14 +6,15 @@
 # the repo. Unless a later match takes precedence, they will
 # be requested for review when someone opens a pull request.
 
-* @mrtnzlml @tbergq @jaroslav-kubicek @michalsanger
+* @adeira/devs
 
 # Why @adeira-github-bot? GitHub doesn't allow self-approve
 # of the PRs. However, at least one approval is required by
-# any codeowner. So @adeira-github-bot helps us to approve
-# these PRs for projects with one owner.
+# any codeowner and the projects below are having only one
+# main developer. Other Adeira devs can approve these PRs if
+# they want but @adeira-github-bot helps if they don't.
 
-/src/ya-comiste-backoffice/ @mrtnzlml @adeira-github-bot
-/src/ya-comiste-meta/ @mrtnzlml @adeira-github-bot
-/src/ya-comiste-react-native/ @mrtnzlml @adeira-github-bot
-/src/ya-comiste-rust/ @mrtnzlml @adeira-github-bot
+/src/ya-comiste-backoffice/ @adeira/devs @adeira-github-bot
+/src/ya-comiste-meta/ @adeira/devs @adeira-github-bot
+/src/ya-comiste-react-native/ @adeira/devs @adeira-github-bot
+/src/ya-comiste-rust/ @adeira/devs @adeira-github-bot

--- a/src/monorepo-scanner/src/scans/Codeowners.scan.js
+++ b/src/monorepo-scanner/src/scans/Codeowners.scan.js
@@ -1,0 +1,35 @@
+// @flow
+
+import os from 'os';
+import fs from 'fs';
+import path from 'path';
+import { findRootPackageJsonPath } from '@adeira/monorepo-utils';
+
+// https://help.github.com/articles/about-codeowners/
+
+function* iterateRules() {
+  const root = path.dirname(findRootPackageJsonPath());
+  const codeownersPath = path.join(root, '.github', 'CODEOWNERS');
+  const codeowners = fs.readFileSync(codeownersPath, 'utf8');
+
+  for (const line of codeowners.split(os.EOL)) {
+    if (line === '') {
+      // empty
+      continue;
+    }
+    if (/^#(?<comment>.*)/.test(line)) {
+      continue;
+    }
+    yield line;
+  }
+}
+
+it('hast to have core maintainers for every part of the project', () => {
+  expect.hasAssertions();
+  const requiredCodeowners = ['@adeira/devs'];
+  for (const line of iterateRules()) {
+    for (const codeowner of requiredCodeowners) {
+      expect(line).toMatch(codeowner);
+    }
+  }
+});


### PR DESCRIPTION
There are 2 main changes:

- we are using GH team instead of explicit nicknames
- every team member of `@adeira/devs` can approve everything like it was before but, additionally, `@adeira-github-bot` can approve the projects with only one main maintainer (to prevent situations like this one: https://github.com/adeira/universe/pull/1600)

This commit partially reverts a2b7a0b3d804ef478ec6655235d5ba190edf5e50