### PR TITLE
YCR: decompose server root mutation

### DIFF
--- a/src/ya-comiste-meta/schema.graphql
+++ b/src/ya-comiste-meta/schema.graphql
@@ -1,4 +1,4 @@
-# @generated SignedSource<<e2eabfeada964ef2bf749c41a1683663>>
+# @generated SignedSource<<d719641901256358820623506f838a26>>
 
 type SDUIScrollViewHorizontalComponent {
   id: ID!
@@ -15,6 +15,7 @@ type SDUIDescriptionComponent {
   text: String!
 }
 
+"Root mutation of the graph."
 type Mutation {
   """
     This function accepts Google ID token (after receiving it from Google Sign-In in a mobile

--- a/src/ya-comiste-rust/server/src/auth/api/mod.rs
+++ b/src/ya-comiste-rust/server/src/auth/api/mod.rs
@@ -1,8 +1,9 @@
 use crate::auth::users::User;
 use crate::graphql_context::Context;
+use juniper::FieldResult;
 
 #[derive(juniper::GraphQLObject)]
-pub struct WhoamiPayload {
+pub(crate) struct WhoamiPayload {
     id: Option<juniper::ID>,
 
     /// Human readable type should be used only for testing purposes. The format is not guaranteed
@@ -10,7 +11,7 @@ pub struct WhoamiPayload {
     human_readable_type: Option<String>,
 }
 
-pub async fn whoami(context: &Context) -> WhoamiPayload {
+pub(crate) async fn whoami(context: &Context) -> WhoamiPayload {
     match &context.user {
         User::AdminUser(user) => WhoamiPayload {
             id: Some(juniper::ID::from(user.id())),
@@ -24,5 +25,54 @@ pub async fn whoami(context: &Context) -> WhoamiPayload {
             id: Some(juniper::ID::from(user.id())),
             human_readable_type: Some(String::from("anonymous user")),
         },
+    }
+}
+
+///// Mutations:
+
+#[derive(juniper::GraphQLObject)]
+pub(crate) struct AuthorizeMobilePayload {
+    success: bool,
+
+    /// Session token should be send with every GraphQL request which requires auth.
+    /// Returns `None` if the request was not successful.
+    session_token: Option<String>,
+}
+
+#[derive(juniper::GraphQLObject)]
+pub(crate) struct DeauthorizeMobilePayload {
+    success: bool,
+}
+
+pub(crate) async fn authorize_mobile(
+    google_id_token: &String,
+    context: &Context,
+) -> FieldResult<AuthorizeMobilePayload> {
+    let connection_pool = context.pool.to_owned();
+    let session_token = crate::auth::authorize(&connection_pool, &google_id_token).await;
+    match session_token {
+        Ok(session_token) => Ok(AuthorizeMobilePayload {
+            success: true,
+            session_token: Some(session_token),
+        }),
+        Err(e) => {
+            log::error!("{}", e);
+            Ok(AuthorizeMobilePayload {
+                success: false,
+                session_token: None,
+                // TODO: return rejection reason from AuthError as well (?)
+            })
+        }
+    }
+}
+
+pub(crate) async fn deauthorize_mobile(
+    session_token: &String, // TODO: this could be removed (?) - we can use the user from context
+    context: &Context,
+) -> DeauthorizeMobilePayload {
+    let connection_pool = context.pool.to_owned();
+    match crate::auth::deauthorize(&connection_pool, &session_token).await {
+        Ok(_) => DeauthorizeMobilePayload { success: true },
+        Err(_) => DeauthorizeMobilePayload { success: false },
     }
 }

--- a/src/ya-comiste-rust/server/src/auth/mod.rs
+++ b/src/ya-comiste-rust/server/src/auth/mod.rs
@@ -9,14 +9,14 @@ use crate::auth::session::derive_session_token_hash;
 use crate::auth::users::{AdminUser, AnonymousUser, AuthorizedUser, User};
 
 pub(crate) mod api;
-pub(crate) mod certs;
-pub(crate) mod google;
-pub(crate) mod session;
 pub(crate) mod users;
 
 mod cache_control;
+mod certs;
 mod dal;
 mod error;
+mod google;
+mod session;
 
 /// This function tries to authorize the user by Google ID token (rejects otherwise).
 ///
@@ -25,8 +25,7 @@ mod error;
 /// 2b. create a new user if it doesn't exist yet and generate and store new session token
 ///
 /// It essentially transforms Google ID token to our Session Token.
-// TODO: pub(in crate::auth)
-pub(in crate) async fn authorize(
+pub(in crate::auth) async fn authorize(
     pool: &crate::arangodb::ConnectionPool,
     google_id_token: &str,
 ) -> Result<String, error::AuthError> {
@@ -64,8 +63,7 @@ pub(in crate) async fn authorize(
 
 /// This function "deauthorizes" the user by invalidating the session in our DB (removing it).
 /// It returns `true` if the operation was successful.
-// TODO: pub(in crate::auth)
-pub(in crate) async fn deauthorize(
+pub(in crate::auth) async fn deauthorize(
     pool: &crate::arangodb::ConnectionPool,
     session_token: &str,
 ) -> Result<bool, error::AuthError> {
@@ -75,7 +73,6 @@ pub(in crate) async fn deauthorize(
 }
 
 /// This function verifies the session token and returns either authorized OR anonymous user.
-// TODO: pub(in crate::auth)
 pub(in crate) async fn resolve_user_from_session_token(
     pool: &crate::arangodb::ConnectionPool,
     session_token: &str,


### PR DESCRIPTION
Basically moves all the implementation details under `auth` where it belongs.