### PR TITLE
Dependabot: increase 'open-pull-requests-limit'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,7 @@ updates:
     labels:
       - 'dependencies'
       - 'automerge' # see Kodiak `merge.automerge_label`
-    ignore:
-      - dependency-name: 'react-native' # RN almost always requires manual intervention and doesn't work by default
+    open-pull-requests-limit: 10
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -23,6 +22,7 @@ updates:
     labels:
       - 'dependencies'
       - 'automerge' # see Kodiak `merge.automerge_label`
+    open-pull-requests-limit: 10
 
   - package-ecosystem: 'cargo'
     directory: '/src/ya-comiste-rust/'
@@ -31,3 +31,4 @@ updates:
     labels:
       - 'dependencies'
       - 'automerge' # see Kodiak `merge.automerge_label`
+    open-pull-requests-limit: 10


### PR DESCRIPTION
We are already receiving some errors because of this: https://github.com/adeira/universe/network/updates/86450251

Obviously, the best solution would be to resolve the PRs, however, it's a bit more challenging in a Rust world and, sometimes, it's better to deal with it more slowly.

See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#open-pull-requests-limit