### PR TITLE
YCR: reject unparseable authorization headers

### DIFF
--- a/src/ya-comiste-rust/server/src/warp_graphql/filters.rs
+++ b/src/ya-comiste-rust/server/src/warp_graphql/filters.rs
@@ -1,39 +1,46 @@
 use crate::arangodb::ConnectionPool;
 use crate::graphql_schema::Schema;
-use crate::headers::parse_authorization_header;
 use crate::warp_graphql;
 use juniper::http::GraphQLRequest;
+use std::convert::Infallible;
 use std::sync::Arc;
-use warp::Filter;
+use warp::{Filter, Rejection, Reply};
 
-/// The 2 GraphQL filters below combined.
+/// Combines our `application/json` and `multipart/form-data` GraphQL filters together.
+///
+/// Note on Warp filters implementation:
+///
+/// Rejections are meant to say a `Filter` couldn't fulfill its preconditions, but maybe another
+/// `Filter` can. If a filter is otherwise fully matched, and an error occurs in your business
+/// logic, it's probably not correct to `reject` with the error. In that case, you'd want to
+/// construct a `Reply` that describes your error. (source: https://github.com/seanmonstar/warp/issues/388#issuecomment-576453485)
 pub(crate) fn graphql(
     pool: ConnectionPool,
     schema: Schema,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     let schema = Arc::new(schema); // TODO: is this the right way?
     graphql_post(pool.clone(), schema.clone()).or(graphql_multipart(pool, schema))
 }
 
-/// POST /graphql with 'application/json' body
+/// POST /graphql with `application/json` body
 fn graphql_post(
     pool: ConnectionPool,
     schema: Arc<Schema>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::path!("graphql")
         .and(warp::post())
         .and(with_json_body())
         .and(with_database_connection_pool(pool))
         .and(with_graphql_schema(schema))
-        .and(with_session_token())
+        .and(with_authorization_header())
         .and_then(warp_graphql::handlers::graphql_post)
 }
 
-/// POST /graphql with 'multipart/form-data' body (max 5MB allowed)
+/// POST /graphql with `multipart/form-data` body (max 5MB allowed)
 fn graphql_multipart(
     pool: ConnectionPool,
     schema: Arc<Schema>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::path!("graphql")
         .and(warp::post())
         .and(warp::multipart::form().max_length(
@@ -41,11 +48,11 @@ fn graphql_multipart(
         ))
         .and(with_database_connection_pool(pool))
         .and(with_graphql_schema(schema))
-        .and(with_session_token())
+        .and(with_authorization_header())
         .and_then(warp_graphql::handlers::graphql_multipart)
 }
 
-fn with_json_body() -> impl Filter<Extract = (GraphQLRequest,), Error = warp::Rejection> + Clone {
+fn with_json_body() -> impl Filter<Extract = (GraphQLRequest,), Error = Rejection> + Clone {
     // When accepting a body, we want a JSON body (and to reject huge payloads).
     // TODO: improve this to some smarter validation (query whitelisting)
     let _16kb = 1024 * 16;
@@ -54,25 +61,17 @@ fn with_json_body() -> impl Filter<Extract = (GraphQLRequest,), Error = warp::Re
 
 fn with_database_connection_pool(
     pool: ConnectionPool,
-) -> impl Filter<Extract = (ConnectionPool,), Error = std::convert::Infallible> + Clone {
+) -> impl Filter<Extract = (ConnectionPool,), Error = Infallible> + Clone {
     warp::any().map(move || pool.clone())
 }
 
 fn with_graphql_schema(
     schema: Arc<Schema>,
-) -> impl Filter<Extract = (Arc<Schema>,), Error = std::convert::Infallible> + Clone {
+) -> impl Filter<Extract = (Arc<Schema>,), Error = Infallible> + Clone {
     warp::any().map(move || schema.clone())
 }
 
-fn with_session_token() -> impl Filter<Extract = (Option<String>,), Error = warp::Rejection> + Clone
-{
-    warp::header::optional::<String>("authorization").map(|auth_header: Option<String>| {
-        match auth_header {
-            Some(auth_header) => match parse_authorization_header(&*auth_header) {
-                Ok(session_token) => Some(session_token),
-                Err(_) => None, // TODO: reject instead (?)
-            },
-            None => None,
-        }
-    })
+fn with_authorization_header(
+) -> impl Filter<Extract = (Option<String>,), Error = warp::Rejection> + Clone {
+    warp::header::optional::<String>("authorization")
 }

--- a/src/ya-comiste-rust/server/src/warp_graphql/models.rs
+++ b/src/ya-comiste-rust/server/src/warp_graphql/models.rs
@@ -1,30 +1,85 @@
 use crate::arangodb::ConnectionPool;
 use crate::auth::users::{AnonymousUser, User};
+use crate::headers::parse_authorization_header;
 
+/// Resolves a user from the authorization header value. It returns anonymous user
+/// in case there is no authorization header. Otherwise, it tries to resolve the actual
+/// user (or returns an error if auth header exists but user does not or if the header has
+/// invalid format).
 pub(in crate::warp_graphql) async fn get_current_user(
     pool: &ConnectionPool,
-    session_token: &Option<String>,
-) -> Result<User, ()> {
-    match session_token {
-        Some(session_token) => {
-            match crate::auth::resolve_user_from_session_token(&pool, &session_token).await {
-                User::AdminUser(user) => {
-                    log::info!("Using admin user: {} 👍👍", user.id());
-                    Ok(User::AdminUser(user))
+    authorization_header: &Option<String>,
+) -> Result<User, String> {
+    match authorization_header {
+        Some(authorization_header) => {
+            // auth header exists, let's try to parse it
+            match parse_authorization_header(&authorization_header) {
+                Ok(session_token) => {
+                    // auth header successfully parsed (unverified)
+                    match crate::auth::resolve_user_from_session_token(&pool, &session_token).await
+                    {
+                        User::AdminUser(user) => {
+                            log::info!("Using admin user: {} 👍👍", user.id());
+                            Ok(User::AdminUser(user))
+                        }
+                        User::AnonymousUser(_) => {
+                            log::error!("Unmatched session token 🛑");
+                            Err(String::from("Session token doesn't mach any user."))
+                        }
+                        User::AuthorizedUser(user) => {
+                            log::info!("Using authorized user: {} 👍", user.id());
+                            Ok(User::AuthorizedUser(user))
+                        }
+                    }
                 }
-                User::AnonymousUser(_) => {
-                    log::error!("Unmatched session token 🛑");
-                    Err(())
-                }
-                User::AuthorizedUser(user) => {
-                    log::info!("Using authorized user: {} 👍", user.id());
-                    Ok(User::AuthorizedUser(user))
-                }
+                Err(_) => Err(String::from(
+                    "Unable to parse 'authorization' header (should be 'Bearer XYZ').",
+                )),
             }
         }
         None => {
+            // auth header not present => anonymous user
             log::info!("Using anonymous user (no 'authorization' header) 👍");
             Ok(User::AnonymousUser(AnonymousUser::new()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arangodb::get_database_connection_pool;
+
+    #[tokio::test]
+    async fn get_current_user_without_authorization_header() {
+        let pool = get_database_connection_pool();
+        assert!(matches!(
+            get_current_user(&pool, &None).await.unwrap(),
+            User::AnonymousUser { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn get_current_user_with_empty_authorization_header() {
+        let pool = get_database_connection_pool();
+        insta::assert_snapshot!(
+            get_current_user(&pool, &Some(String::from("")))
+            .await
+            .err()
+            .unwrap(),
+             @"Unable to parse 'authorization' header (should be 'Bearer XYZ')."
+        );
+    }
+
+    #[tokio::test]
+    async fn get_current_user_with_unparseable_authorization_header() {
+        let pool = get_database_connection_pool();
+        insta::assert_snapshot!(
+            get_current_user(&pool, &Some(String::from("XYZ")))
+            .await
+            .err()
+            .unwrap(),
+             @"Unable to parse 'authorization' header (should be 'Bearer XYZ')."
+        );
     }
 }


### PR DESCRIPTION
This helps when user sends some auth value but it's invalid (for example `Bearer: XYZ` instead of `Bearer XYZ`).