### PR TITLE
NPM Publisher: Proper workflow failure status

### DIFF
--- a/src/monorepo-npm-publisher/src/index.js
+++ b/src/monorepo-npm-publisher/src/index.js
@@ -110,6 +110,7 @@ export default async function publish(options: Options) {
           }
         }
       } catch (e) {
+        process.exitCode = 1;
         log('❌ Skipping %s because of NPM error: %s', chalkPackageName, e.message);
       }
     }


### PR DESCRIPTION
Let the workflow die correctly in case of NPM API error

Fix #1671