### PR TITLE
Release '@adeira/murmur-hash' version 2.0.0

### DIFF
--- a/src/babel-plugin-transform-sx-tailwind/package.json
+++ b/src/babel-plugin-transform-sx-tailwind/package.json
@@ -9,7 +9,7 @@
   "sideEffects": false,
   "module": false,
   "dependencies": {
-    "@adeira/murmur-hash": "^1.0.0",
+    "@adeira/murmur-hash": "^2.0.0",
     "@adeira/sx-tailwind": "^0.11.0",
     "@babel/register": "^7.12.10",
     "@babel/runtime": "^7.12.5",

--- a/src/murmur-hash/CHANGELOG.md
+++ b/src/murmur-hash/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+# 2.0.0
+
+Support for Node.js 12 has been removed. This package might continue working on older Node.js versions, however, it's highly recommended upgrading to Node.js version 14 or newer. For more details, see: https://nodejs.org/en/about/releases/, or discuss here: https://github.com/adeira/universe/discussions/1588

--- a/src/murmur-hash/package.json
+++ b/src/murmur-hash/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/murmur-hash",
   "license": "MIT",
   "private": false,
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "src/murmurHash",
   "sideEffects": false,
   "dependencies": {

--- a/src/sx/package.json
+++ b/src/sx/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@adeira/css-colors": "^1.1.0",
     "@adeira/js": "^1.3.0",
-    "@adeira/murmur-hash": "^1.0.0",
+    "@adeira/murmur-hash": "^2.0.0",
     "@adeira/signed-source": "^1.0.0",
     "@babel/runtime": "^7.12.5",
     "change-case": "^4.1.2",


### PR DESCRIPTION
See: https://github.com/adeira/universe/issues/1718