### PR TITLE
Dependabot: enable Docker package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,12 @@ updates:
       - 'dependencies'
       - 'automerge' # see Kodiak `merge.automerge_label`
     open-pull-requests-limit: 10
+
+  - package-ecosystem: 'docker'
+    directory: '/src/ya-comiste-rust/'
+    schedule:
+      interval: 'daily'
+    labels:
+      - 'dependencies'
+      - 'automerge' # see Kodiak `merge.automerge_label`
+    open-pull-requests-limit: 10


### PR DESCRIPTION
See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem