### PR TITLE
Release '@adeira/monorepo-npm-publisher' version 2.0.0

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,7 +7,7 @@
     "@adeira/flow-config-parser": "^0.2.0",
     "@adeira/js": "^1.2.4",
     "@adeira/logger": "^0.4.0",
-    "@adeira/monorepo-npm-publisher": "^1.0.0",
+    "@adeira/monorepo-npm-publisher": "^2.0.0",
     "@adeira/monorepo-utils": "^0.11.0",
     "@adeira/signed-source": "^2.0.0",
     "chalk": "^4.1.0"

--- a/src/monorepo-npm-publisher/CHANGELOG.md
+++ b/src/monorepo-npm-publisher/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 2.0.0
+
 - Support for Node.js 12 has been removed. This package might continue working on older Node.js versions, however, it's highly recommended upgrading to Node.js version 14 or newer. For more details, see: https://nodejs.org/en/about/releases/, or discuss here: https://github.com/adeira/universe/discussions/1588
 - Upgrade `@adeira/babel-preset-adeira` to 2.0.0.
 - Breaking Change: Add reactRuntime option. You can set it to `automatic` to use the new [JSX transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html), or set it to `classic` to use the classical version. Note that `automatic` is the default.

--- a/src/monorepo-npm-publisher/package.json
+++ b/src/monorepo-npm-publisher/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/monorepo-npm-publisher",
   "license": "MIT",
   "private": false,
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "src/index",
   "sideEffects": false,
   "dependencies": {


### PR DESCRIPTION
See: https://github.com/adeira/universe/issues/1718