### PR TITLE
Codeowners: add @adeira-github-bot for yarn.lock

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,4 @@
 /src/ya-comiste-backoffice/ @adeira/devs @adeira-github-bot
 /src/ya-comiste-meta/ @adeira/devs @adeira-github-bot
 /src/ya-comiste-rust/ @adeira/devs @adeira-github-bot
+yarn.lock @adeira/devs @adeira-github-bot


### PR DESCRIPTION
It's a common situation that @adeira-github-bot cannot approve some PRs completely because they are affecting this global file (because of dependency changes). This PR should fix that.