### PR TITLE
Eslint config: do not show context lines when diffing stable/strict mode

### DIFF
--- a/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
+++ b/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
@@ -976,59 +976,41 @@ Snapshot Diff:
 + Value for STRICT rules
 
 @@ --- --- @@
-      "no-new-wrappers": 1,
 -     "no-nonoctal-decimal-escape": 1,
 +     "no-nonoctal-decimal-escape": 2,
-      "no-obj-calls": 2,
 @@ --- --- @@
-      "no-unsafe-negation": 2,
 -     "no-unsafe-optional-chaining": 1,
 +     "no-unsafe-optional-chaining": 2,
-      "no-unused-expressions": 0,
 @@ --- --- @@
-      "prefer-numeric-literals": 0,
 -     "prefer-object-spread": 1,
 +     "prefer-object-spread": 2,
-      "prefer-promise-reject-errors": 1,
 @@ --- --- @@
-      "promise/no-nesting": 1,
 -     "promise/no-new-statics": 1,
 +     "promise/no-new-statics": 2,
-      "promise/no-promise-in-callback": 0,
-      "promise/no-return-in-finally": 0,
+@@ --- --- @@
 -     "promise/no-return-wrap": 1,
 -     "promise/param-names": 1,
 +     "promise/no-return-wrap": 2,
 +     "promise/param-names": 2,
-      "promise/prefer-await-to-callbacks": 0,
-      "promise/prefer-await-to-then": 0,
+@@ --- --- @@
 -     "promise/valid-params": 1,
 +     "promise/valid-params": 2,
-      "quote-props": "off",
 @@ --- --- @@
-      "react-native/no-raw-text": 0,
 -     "react-native/no-single-element-style-arrays": 1,
 -     "react-native/no-unused-styles": 1,
 +     "react-native/no-single-element-style-arrays": 2,
 +     "react-native/no-unused-styles": 2,
-      "react-native/sort-styles": 0,
 @@ --- --- @@
-      "react/jsx-no-comment-textnodes": 2,
 -     "react/jsx-no-constructed-context-values": 1,
 +     "react/jsx-no-constructed-context-values": 2,
-      "react/jsx-no-duplicate-props": 2,
 @@ --- --- @@
-      "relay/compat-uses-vars": 0,
 -     "relay/function-required-argument": 1,
 +     "relay/function-required-argument": 2,
-      "relay/generated-flow-types": 2,
 @@ --- --- @@
-      "switch-colon-spacing": "off",
 -     "sx/no-concatenated-classes": 1,
 -     "sx/no-unused-stylesheet": 1,
 -     "sx/valid-usage": 1,
 +     "sx/no-concatenated-classes": 2,
 +     "sx/no-unused-stylesheet": 2,
 +     "sx/valid-usage": 2,
-      "symbol-description": 2,
 `;

--- a/src/eslint-config-adeira/__tests__/index.test.js
+++ b/src/eslint-config-adeira/__tests__/index.test.js
@@ -82,7 +82,7 @@ test('rules snapshot', () => {
 
   expect(
     snapshotDiff(stableRules, strictRules, {
-      contextLines: 1,
+      contextLines: 0,
       stablePatchmarks: true,
       aAnnotation: 'Value for stable rules',
       bAnnotation: 'Value for STRICT rules',


### PR DESCRIPTION
We are interested only in the differences without any context when diffing stable/strict mode. This makes it much more readable and understandable.