### PR TITLE
YCR: fix DB connection recycling with custom DB name

### DIFF
--- a/src/ya-comiste-rust/server/src/commerce/model/products.rs
+++ b/src/ya-comiste-rust/server/src/commerce/model/products.rs
@@ -177,9 +177,10 @@ pub(in crate::commerce) async fn create_product(
     }
 
     // At least one name in any translation version must exist.
-    if let None = translations
+    if translations
         .iter()
         .find(|&translation| translation.name.is_some())
+        .is_none()
     {
         return Err(ModelError::LogicalError(String::from(
             "Product must have at least one name in any translation version.",

--- a/src/ya-comiste-rust/server/src/graphql_context.rs
+++ b/src/ya-comiste-rust/server/src/graphql_context.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use crate::arangodb::get_database_connection_pool;
+use crate::arangodb::get_database_connection_pool_mock;
 #[cfg(test)]
 use crate::auth::users::AnonymousUser;
 use crate::auth::users::User;
@@ -30,7 +30,7 @@ impl juniper::Context for Context {}
 impl Context {
     pub fn create_mock() -> Self {
         Self {
-            pool: get_database_connection_pool(None),
+            pool: get_database_connection_pool_mock(),
             uploadables: None,
             user: User::AnonymousUser(AnonymousUser::new()),
         }

--- a/src/ya-comiste-rust/server/src/main.rs
+++ b/src/ya-comiste-rust/server/src/main.rs
@@ -62,7 +62,7 @@ async fn main() {
 
     // Create database connection pool only once per application lifetime so we can reuse it
     // for the following requests. DO NOT create it in the GraphQL context extractor!
-    let pool = get_database_connection_pool(cli_matches.value_of("db-name"));
+    let pool = get_database_connection_pool(cli_matches.value_of("db-name").unwrap());
 
     if !cli_matches.is_present("no-migrations") {
         // Preferably, migrations would NOT be ran during the server start.

--- a/src/ya-comiste-rust/server/src/tests.rs
+++ b/src/ya-comiste-rust/server/src/tests.rs
@@ -1,4 +1,6 @@
-use crate::arangodb::{get_database_connection_pool, prepare_empty_test_database};
+use crate::arangodb::{
+    get_database_connection_pool, get_database_connection_pool_mock, prepare_empty_test_database,
+};
 use crate::graphql_schema::create_graphql_schema;
 use juniper::http::GraphQLRequest;
 use juniper::DefaultScalarValue;
@@ -8,9 +10,12 @@ use warp::test::request;
 async fn create_graphql_api_filter(
     db_name: Option<&str>,
 ) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    let pool = get_database_connection_pool(db_name);
+    let pool;
     if let Some(db_name) = db_name {
         prepare_empty_test_database(db_name).await;
+        pool = get_database_connection_pool(db_name);
+    } else {
+        pool = get_database_connection_pool_mock();
     }
 
     crate::warp_graphql::filters::graphql(pool, create_graphql_schema())

--- a/src/ya-comiste-rust/server/src/warp_graphql/models.rs
+++ b/src/ya-comiste-rust/server/src/warp_graphql/models.rs
@@ -48,11 +48,11 @@ pub(in crate::warp_graphql) async fn get_current_user(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::arangodb::get_database_connection_pool;
+    use crate::arangodb::get_database_connection_pool_mock;
 
     #[tokio::test]
     async fn get_current_user_without_authorization_header() {
-        let pool = get_database_connection_pool(None);
+        let pool = get_database_connection_pool_mock();
         assert!(matches!(
             get_current_user(&pool, &None).await.unwrap(),
             User::AnonymousUser { .. }
@@ -61,7 +61,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_current_user_with_empty_authorization_header() {
-        let pool = get_database_connection_pool(None);
+        let pool = get_database_connection_pool_mock();
         insta::assert_snapshot!(
             get_current_user(&pool, &Some(String::from("")))
             .await
@@ -73,7 +73,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_current_user_with_unparseable_authorization_header() {
-        let pool = get_database_connection_pool(None);
+        let pool = get_database_connection_pool_mock();
         insta::assert_snapshot!(
             get_current_user(&pool, &Some(String::from("XYZ")))
             .await


### PR DESCRIPTION
The previous DB name was still hardcoded in the recycling logic resulting in inability to recycle => slower app.