### PR TITLE
Remove 'next/babel' preset

### DIFF
--- a/src/example-relay/.babelrc.js
+++ b/src/example-relay/.babelrc.js
@@ -1,13 +1,6 @@
 // @flow strict
 
 module.exports = {
-  presets: ['@adeira/babel-preset-adeira', 'next/babel'],
-  /**
-   * test-bc script broke after upgrading some babel packages.
-   * Adding @babel/plugin-proposal-class-properties made it work, but it should not be necessary
-   * to add it here, since we already have it in @adeira/babel-preset-adeira.
-   * We need to leave it here for now for the test-bc script to work, but we should try
-   * to remove it in the future
-   */
-  plugins: ['relay', '@babel/plugin-proposal-class-properties'],
+  presets: ['@adeira/babel-preset-adeira'],
+  plugins: ['relay'],
 };

--- a/src/example-relay/__github__/babel.config.js
+++ b/src/example-relay/__github__/babel.config.js
@@ -21,7 +21,7 @@ module.exports = function (api /*: ApiType */) /*: BabelConfig */ {
   api.cache.forever();
 
   return {
-    presets: ['@adeira/babel-preset-adeira', 'next/babel'],
+    presets: ['@adeira/babel-preset-adeira'],
     plugins: ['relay'],
   };
 };

--- a/src/sx-tailwind-website/.babelrc.js
+++ b/src/sx-tailwind-website/.babelrc.js
@@ -4,7 +4,7 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 const colors = require('tailwindcss/colors');
 
 module.exports = {
-  presets: ['@adeira/babel-preset-adeira', 'next/babel'],
+  presets: ['@adeira/babel-preset-adeira'],
   plugins: [
     [
       '@adeira/babel-plugin-transform-sx-tailwind',

--- a/src/sx-tailwind-website/__github__/babel.config.js
+++ b/src/sx-tailwind-website/__github__/babel.config.js
@@ -26,7 +26,7 @@ module.exports = function (api /*: ApiType */) /*: BabelConfig */ {
   api.cache.forever();
 
   return {
-    presets: ['@adeira/babel-preset-adeira', 'next/babel'],
+    presets: ['@adeira/babel-preset-adeira'],
     plugins: [
       [
         '@adeira/babel-plugin-transform-sx-tailwind',


### PR DESCRIPTION
This partially reverts 1c5d0b46ea5f0814a6d3b3f1566c2b7d8d68e908

Something changed somewhere somehow. I faced similar issue yesterday with broken class properties plugin and Flow types so I had to do something. This seems to be fixing the issue at least for now.