### PR TITLE
SX remove 'AllCSSPropertyTypes' type export

### DIFF
--- a/src/sx/index.js
+++ b/src/sx/index.js
@@ -49,4 +49,3 @@ composeStylesheets.renderPageWithSX = renderPageWithSX;
 export { create, keyframes, renderPageWithSX };
 export default composeStylesheets;
 export type { AllCSSProperties } from './src/create';
-export type { AllCSSPropertyTypes } from './src/css-properties/__generated__/AllCSSPropertyTypes';


### PR DESCRIPTION
Only type `AllCSSProperties` should be used directly (at least for now) and it's confusing to export some other type which should never be used.