### PR TITLE
SX: improve DX of conditional composability

### DIFF
--- a/src/sx/index.js
+++ b/src/sx/index.js
@@ -12,6 +12,8 @@
  * @flow
  */
 
+import { isObject } from '@adeira/js';
+
 import create, { type AllCSSProperties } from './src/create';
 import keyframes from './src/keyframes';
 import renderPageWithSX from './src/renderPageWithSX';
@@ -30,9 +32,10 @@ import renderPageWithSX from './src/renderPageWithSX';
  *
  * It does so by literally merging the 2 objects together and calling `sx.create` on the result.
  */
-function composeStylesheets(...stylesheets: $ReadOnlyArray<?AllCSSProperties>): ?string {
+function composeStylesheets(...stylesheets: $ReadOnlyArray<?AllCSSProperties | false>): ?string {
   // Should we support deeply nested styles or leave it like this and overwrite them?
-  const mergedStylesheet = Object.assign({}, ...stylesheets);
+  // $FlowIssue[not-an-object]: https://github.com/facebook/flow/issues/1414
+  const mergedStylesheet = Object.assign({}, ...stylesheets.filter(isObject));
   if (Object.keys(mergedStylesheet).length === 0) {
     // happens when composing "nothing" which is a valid input
     return undefined;

--- a/src/sx/src/__tests__/composability.test.js
+++ b/src/sx/src/__tests__/composability.test.js
@@ -125,7 +125,8 @@ it('merges more complex styles correctly', () => {
 });
 
 it('handles nullable arguments gracefully', () => {
-  // This is convenient when the overwriting styles are optional.
+  // This is convenient when the overwriting styles are optional:
+  // sx(styles.default, isActive ? props.xstyle : null)
   const styles = sx.create({ default: { fontSize: 16 } });
 
   expect(sx(styles.default, null)).toBe(styles('default'));
@@ -138,4 +139,14 @@ it('handles nullable arguments gracefully', () => {
 
   expect(sx(null, styles.default)).toBe(styles('default'));
   expect(sx(undefined, styles.default)).toBe(styles('default'));
+});
+
+it('handles conditional arguments gracefully', () => {
+  // This is convenient when the overwriting styles are optional:
+  // sx(styles.default, isActive && props.xstyle)
+  const styles = sx.create({ default: { fontSize: 16 } });
+
+  expect(sx(styles.default, false)).toBe(styles('default'));
+  expect(sx(false, styles.default)).toBe(styles('default'));
+  expect(sx(false, false)).toBeUndefined();
 });


### PR DESCRIPTION
This allows `false` values in `sx(…)` call similarly to how we allow them in `styles(…)`. Examples of where is this useful:

```
styles('button', isDisabled && 'disabled');
sx(styles.button, isDisabled && props.xstyle);
```