### PR TITLE
SX Design: expose new 'MoneyFn' function

### DIFF
--- a/src/sx-design/index.js
+++ b/src/sx-design/index.js
@@ -2,7 +2,7 @@
 
 export { default as Heading } from './src/Heading';
 export { default as Kbd } from './src/Kbd';
-export { default as Money } from './src/Money';
+export { default as Money, MoneyFn } from './src/Money';
 export { default as ProductCard } from './src/ProductCard';
 export { default as Section } from './src/Section';
 export { default as Skeleton } from './src/Skeleton';

--- a/src/sx-design/package.json
+++ b/src/sx-design/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/sx-design",
   "license": "MIT",
   "private": false,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "index",
   "sideEffects": false,
   "module": false,

--- a/src/sx-design/src/Money.js
+++ b/src/sx-design/src/Money.js
@@ -11,6 +11,12 @@ type Props = {|
 |};
 
 export default function Money(props: Props): React.Node {
+  return MoneyFn(props);
+}
+
+// This function does essentially the same like the React <Money /> component except it can be
+// called from non-React environment.
+export function MoneyFn(props: Props): string {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat
   return new Intl.NumberFormat(props.locale, {
     style: 'currency',

--- a/src/sx-design/src/__tests__/Money.test.js
+++ b/src/sx-design/src/__tests__/Money.test.js
@@ -3,20 +3,29 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 
-import Money from '../Money';
+import Money, { MoneyFn } from '../Money';
 
 test.each`
-  locale     | amount | currency | expected
-  ${'en-US'} | ${10}  | ${'MXN'} | ${'MX$10.00'}
-  ${'es-MX'} | ${10}  | ${'MXN'} | ${'$10.00'}
-  ${'en-US'} | ${20}  | ${'USD'} | ${'$20.00'}
-  ${'es-MX'} | ${20}  | ${'USD'} | ${'USD&nbsp;20.00'}
+  locale     | amount | currency | expectedReact       | expectedFn
+  ${'en-US'} | ${10}  | ${'MXN'} | ${'MX$10.00'}       | ${'MX$10.00'}
+  ${'es-MX'} | ${10}  | ${'MXN'} | ${'$10.00'}         | ${'$10.00'}
+  ${'en-US'} | ${20}  | ${'USD'} | ${'$20.00'}         | ${'$20.00'}
+  ${'es-MX'} | ${20}  | ${'USD'} | ${'USD&nbsp;20.00'} | ${'USD 20.00'}
 `(
   'renders amount "$amount" with locale "$locale" and currency "$currency" correctly ("$expected")',
-  ({ locale, amount, currency, expected }) => {
+  ({ locale, amount, currency, expectedReact, expectedFn }) => {
     const { container } = render(
       <Money locale={locale} priceUnitAmount={amount} priceUnitAmountCurrency={currency} />,
     );
-    expect(container.innerHTML).toBe(expected);
+    expect(container.innerHTML).toBe(expectedReact);
+
+    // alternative non-React function
+    expect(
+      MoneyFn({
+        locale,
+        priceUnitAmount: amount,
+        priceUnitAmountCurrency: currency,
+      }),
+    ).toBe(expectedFn);
   },
 );

--- a/src/ya-comiste-backoffice/package.json
+++ b/src/ya-comiste-backoffice/package.json
@@ -17,7 +17,7 @@
     "@adeira/js": "^2.1.0",
     "@adeira/relay": "^3.0.1",
     "@adeira/sx": "^0.24.0",
-    "@adeira/sx-design": "^0.3.0",
+    "@adeira/sx-design": "^0.4.0",
     "babel-plugin-fbt": "^0.17.1",
     "babel-plugin-fbt-runtime": "^0.9.13",
     "fbt": "^0.16.1",


### PR DESCRIPTION
It does the same as `<Money />` except it can be used in non-React context.