### PR TITLE
YCR: save selected POS items into DB

### DIFF
--- a/src/ya-comiste-backoffice/src/pos/Checkout.js
+++ b/src/ya-comiste-backoffice/src/pos/Checkout.js
@@ -15,10 +15,22 @@ export default function Checkout(): Node {
   const { stats } = useSelectedItemsApi();
   const router = useRouter();
 
+  // TODO:
   const [checkout, isCheckoutPending] = useMutation<CheckoutMutation>(graphql`
     mutation CheckoutMutation {
       pos {
-        checkout {
+        checkout(
+          input: {
+            selectedProducts: [
+              {
+                productKey: "TODO"
+                productUnits: -1
+                productPriceUnitAmount: -1
+                productPriceUnitAmountCurrency: MXN
+              }
+            ]
+          }
+        ) {
           __typename
           ... on PosCheckoutPayload {
             id

--- a/src/ya-comiste-backoffice/src/pos/__generated__/CheckoutMutation.graphql.js
+++ b/src/ya-comiste-backoffice/src/pos/__generated__/CheckoutMutation.graphql.js
@@ -29,7 +29,7 @@ export type CheckoutMutation = {|
 /*
 mutation CheckoutMutation {
   pos {
-    checkout {
+    checkout(input: {selectedProducts: [{productKey: "TODO", productUnits: -1, productPriceUnitAmount: -1, productPriceUnitAmountCurrency: MXN}]}) {
       __typename
       ... on PosCheckoutPayload {
         id
@@ -54,7 +54,22 @@ var v0 = [
     "selections": [
       {
         "alias": null,
-        "args": null,
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "input",
+            "value": {
+              "selectedProducts": [
+                {
+                  "productKey": "TODO",
+                  "productPriceUnitAmount": -1,
+                  "productPriceUnitAmountCurrency": "MXN",
+                  "productUnits": -1
+                }
+              ]
+            }
+          }
+        ],
         "concreteType": null,
         "kind": "LinkedField",
         "name": "checkout",
@@ -96,7 +111,7 @@ var v0 = [
             "abstractKey": null
           }
         ],
-        "storageKey": null
+        "storageKey": "checkout(input:{\"selectedProducts\":[{\"productKey\":\"TODO\",\"productPriceUnitAmount\":-1,\"productPriceUnitAmountCurrency\":\"MXN\",\"productUnits\":-1}]})"
       }
     ],
     "storageKey": null
@@ -120,15 +135,15 @@ return {
     "selections": (v0/*: any*/)
   },
   "params": {
-    "cacheID": "dcd642327774268176dc053cf6f9a86f",
+    "cacheID": "bc360b2c5e647b142630180dc27dc732",
     "id": null,
     "metadata": {},
     "name": "CheckoutMutation",
     "operationKind": "mutation",
-    "text": "mutation CheckoutMutation {\n  pos {\n    checkout {\n      __typename\n      ... on PosCheckoutPayload {\n        id\n      }\n      ... on PosCheckoutError {\n        message\n      }\n    }\n  }\n}\n"
+    "text": "mutation CheckoutMutation {\n  pos {\n    checkout(input: {selectedProducts: [{productKey: \"TODO\", productUnits: -1, productPriceUnitAmount: -1, productPriceUnitAmountCurrency: MXN}]}) {\n      __typename\n      ... on PosCheckoutPayload {\n        id\n      }\n      ... on PosCheckoutError {\n        message\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 // prettier-ignore
-(node: any).hash = '2de5122ab060dbd431dcbaf413ddc81b';
+(node: any).hash = '6c707919d3ece4d282b66a69c80ead5d';
 export default node;

--- a/src/ya-comiste-rust/schema.graphql
+++ b/src/ya-comiste-rust/schema.graphql
@@ -1,4 +1,4 @@
-# @generated SignedSource<<c2a696d3d4ab0f76a1367af227c8c01b>>
+# @generated SignedSource<<d846366855b7052f9995db6387d87d9e>>
 
 enum PriceSortDirection {
   LOW_TO_HIGH
@@ -11,6 +11,13 @@ type POSQuery {
     POS after logging in.
   """
   listPublishedProducts: [Product]
+}
+
+input PosCheckoutProductInput {
+  productKey: ID!
+  productUnits: Int!
+  productPriceUnitAmount: Int!
+  productPriceUnitAmountCurrency: SupportedCurrency!
 }
 
 type DeauthorizePayload {
@@ -109,7 +116,7 @@ type POSMutation {
     price adjustments (customers would be angry if we would say "oh, actually it just got more
     expensive").
   """
-  checkout: PosCheckoutPayloadOrError!
+  checkout(input: PosCheckoutInput!): PosCheckoutPayloadOrError!
 }
 
 union ProductOrError = Product | ProductError
@@ -169,6 +176,10 @@ input ProductMultilingualInputTranslations {
   locale: SupportedLocale!
   name: String!
   description: String
+}
+
+input PosCheckoutInput {
+  selectedProducts: [PosCheckoutProductInput!]!
 }
 
 type Product {

--- a/src/ya-comiste-rust/src/commerce/api/mod.rs
+++ b/src/ya-comiste-rust/src/commerce/api/mod.rs
@@ -2,6 +2,7 @@ pub use crate::commerce::model::products::PriceSortDirection;
 pub use crate::commerce::model::products::Product;
 pub use crate::commerce::model::products::ProductMultilingualInput;
 pub use crate::commerce::model::products::ProductMultilingualInputVisibility;
+pub use crate::commerce::model::products::SupportedCurrency;
 pub use crate::commerce::model::products::SupportedLocale;
 
 use crate::graphql_context::Context;

--- a/src/ya-comiste-rust/src/commerce/model/products.rs
+++ b/src/ya-comiste-rust/src/commerce/model/products.rs
@@ -144,7 +144,7 @@ impl Product {
     }
 }
 
-#[derive(juniper::GraphQLEnum, Clone, Deserialize, Debug)]
+#[derive(juniper::GraphQLEnum, Clone, Serialize, Deserialize, Debug)]
 pub enum SupportedCurrency {
     MXN,
 }

--- a/src/ya-comiste-rust/src/pos/api/dal.rs
+++ b/src/ya-comiste-rust/src/pos/api/dal.rs
@@ -1,6 +1,8 @@
 use crate::arangodb::ConnectionPool;
+use crate::commerce::api::SupportedCurrency;
 use arangors::AqlQuery;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 #[derive(Debug)]
 pub enum Error {
@@ -36,6 +38,24 @@ impl PosCheckout {
     }
 }
 
+#[derive(Serialize, Deserialize)]
+pub(in crate::pos) struct PosCheckoutProductInput {
+    // Original product ID just in case it's needed one day (even though it might be already
+    // deleted). Already deleted product should not be a big deal since we copy here all the
+    // necessary product info at the time of the checkout (so current edited product might be
+    // completely different and that's OK).
+    pub(crate) product_id: String,
+    pub(crate) product_name: String,
+    pub(crate) product_units: i32,
+    pub(crate) product_price_unit_amount: i32,
+    pub(crate) product_price_unit_amount_currency: SupportedCurrency,
+}
+
+#[derive(Serialize, Deserialize)]
+pub(in crate::pos) struct PosCheckoutInput {
+    pub(crate) selected_products: Vec<PosCheckoutProductInput>,
+}
+
 /// Saves checkout information into database so we know what sales are happening via POS and we can
 /// make further decisions based on that. Specifically, we record the following information:
 ///
@@ -43,19 +63,121 @@ impl PosCheckout {
 /// - products sold (not only IDs but the whole expanded products so future changes of these
 ///   products don't affect this POS history)
 /// - price for each product at the time of the sale (again, preserving historic state)
-pub(in crate::pos) async fn create_checkout(pool: &ConnectionPool) -> Result<PosCheckout, Error> {
-    // TODO: save other POS checkout information
-
+pub(in crate::pos) async fn create_checkout(
+    pool: &ConnectionPool,
+    input: &PosCheckoutInput,
+) -> Result<PosCheckout, Error> {
     let insert_aql = arangors::AqlQuery::builder()
         .query(
             r#"
             INSERT {
               created_date: DATE_ISO8601(DATE_NOW()),
+              selected_products: @selected_products
             } INTO pos_checkouts
             RETURN NEW
             "#,
         )
+        .bind_var("selected_products", json!(&input.selected_products))
         .build();
 
     resolve_aql::<PosCheckout>(&pool, insert_aql).await
+}
+
+#[cfg(test)]
+#[derive(Deserialize, Clone)]
+pub(in crate::pos) struct PosCheckoutTotalStats {
+    total_checkouts: u32,
+    total_sold_units: u32,
+    total_sold_unit_amount: u32, // TODO: be careful when calling SUM(…) on different currencies!
+}
+
+#[cfg(test)]
+pub(in crate::pos) async fn get_total_checkout_stats(
+    pool: &ConnectionPool,
+) -> Result<PosCheckoutTotalStats, Error> {
+    let stats_aql = arangors::AqlQuery::builder()
+        .query(
+            r#"
+            LET stats_per_checkout = (
+              FOR checkout IN pos_checkouts
+                LET products = checkout.selected_products
+                RETURN {
+                  total_checkouts: COUNT(1),
+                  total_sold_units: SUM(products[*].product_units),
+                  total_sold_unit_amount: SUM(FOR p IN products RETURN (p.product_units * p.product_price_unit_amount)),
+                }
+            )
+
+            RETURN {
+              total_checkouts: SUM(stats_per_checkout[*].total_checkouts),
+              total_sold_units: SUM(stats_per_checkout[*].total_sold_units),
+              total_sold_unit_amount: SUM(stats_per_checkout[*].total_sold_unit_amount),
+            }
+            "#,
+        )
+        .build();
+
+    resolve_aql::<PosCheckoutTotalStats>(&pool, stats_aql).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arangodb::{cleanup_test_database, prepare_empty_test_database};
+
+    #[ignore]
+    #[tokio::test]
+    async fn create_checkout_test() {
+        let db_name = "create_checkout_test";
+        let pool = prepare_empty_test_database(&db_name).await;
+
+        // 1) create first checkout
+        create_checkout(
+            &pool,
+            &PosCheckoutInput {
+                selected_products: vec![
+                    PosCheckoutProductInput {
+                        product_id: String::from("products/1"),
+                        product_name: String::from("Product name 1"),
+                        product_units: 1,
+                        product_price_unit_amount: 120,
+                        product_price_unit_amount_currency: SupportedCurrency::MXN,
+                    },
+                    PosCheckoutProductInput {
+                        product_id: String::from("products/2"),
+                        product_name: String::from("Product name 2"),
+                        product_units: 2,
+                        product_price_unit_amount: 150,
+                        product_price_unit_amount_currency: SupportedCurrency::MXN,
+                    },
+                ],
+            },
+        )
+        .await
+        .unwrap();
+
+        // 2) create second checkout
+        create_checkout(
+            &pool,
+            &PosCheckoutInput {
+                selected_products: vec![PosCheckoutProductInput {
+                    product_id: String::from("products/3"),
+                    product_name: String::from("Product name 3"),
+                    product_units: 5,
+                    product_price_unit_amount: 200,
+                    product_price_unit_amount_currency: SupportedCurrency::MXN,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+
+        // 3) return the checkout stats
+        let checkout_stats = get_total_checkout_stats(&pool).await.unwrap();
+        assert_eq!(checkout_stats.total_checkouts, 2); // first and second
+        assert_eq!(checkout_stats.total_sold_units, 8); // 1 + 2 + 5
+        assert_eq!(checkout_stats.total_sold_unit_amount, 1420); // (120 + 2*150 + 5*200)
+
+        cleanup_test_database(&db_name).await;
+    }
 }


### PR DESCRIPTION
Missing pieces:

- accept product keys in GraphQL input and expand them for the DB layer
- send selected product keys and prices from FE