### PR TITLE
Release '@adeira/relay' version 3.1.0

### DIFF
--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -11,7 +11,7 @@
     "@adeira/graphql-relay": "^0.3.0",
     "@adeira/js": "^2.1.0",
     "@adeira/monorepo-utils": "^0.11.0",
-    "@adeira/relay": "^3.0.1",
+    "@adeira/relay": "^3.1.0",
     "@adeira/sx": "^0.24.0",
     "@artsy/fresnel": "^1.3.1",
     "apollo-server-micro": "^2.21.1",

--- a/src/relay/CHANGELOG.md
+++ b/src/relay/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
-This release introduces Relay Hooks in a backward compatible fashion. Next major version of `@adeira/relay` will focus on removing legacy parts of Relay Modern so it's highly encouraged to upgrade as soon as possible.
+# 3.1.0
+
+This release introduces Relay Hooks in a backward compatible fashion. Next major version of `@adeira/relay` will focus on phasing out legacy parts of Relay Modern (containers API), so it's highly encouraged to upgrade as soon as possible.
 
 - Relay dependencies upgraded to version `11.0.0`, see: https://github.com/facebook/relay/releases/tag/v11.0.0
 - Additional Relay hooks were exposed: `useEntryPointLoader`, `useFragment`, `useLazyLoadQuery`, `usePaginationFragment`, `usePreloadedQuery`, `useQueryLoader`, `useRefetchableFragment`, `useSubscribeToInvalidationState` and `useSubscription` (+ some other hooks specific functions)
@@ -9,6 +11,7 @@ This release introduces Relay Hooks in a backward compatible fashion. Next major
 For more information about Relay Hooks evolution please visit the following links:
 
 - https://github.com/facebook/relay/releases/tag/v11.0.0
+- https://relay.dev/blog/2021/03/09/introducing-relay-hooks/
 - https://relay.dev/docs/ _(new)_
 - https://github.com/facebook/relay/issues/3371
 

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adeira/relay",
   "private": false,
-  "version": "3.0.1",
+  "version": "3.1.0",
   "main": "src/index",
   "module": false,
   "sideEffects": false,
@@ -41,6 +41,6 @@
   },
   "peerDependencies": {
     "graphql": "^14.5.8",
-    "react": "^16.14.0 || ^17.0.0"
+    "react": "^17.0.0"
   }
 }

--- a/src/ya-comiste-backoffice/package.json
+++ b/src/ya-comiste-backoffice/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@adeira/js": "^2.1.0",
-    "@adeira/relay": "^3.0.1",
+    "@adeira/relay": "^3.1.0",
     "@adeira/sx": "^0.24.0",
     "@adeira/sx-design": "^0.5.0",
     "babel-plugin-fbt": "^0.17.2",


### PR DESCRIPTION
This version enables Relay Hooks in a backward compatible fashion, see:

- https://github.com/facebook/relay/releases/tag/v11.0.0
- https://relay.dev/blog/2021/03/09/introducing-relay-hooks/
- https://relay.dev/docs/ _(new)_
- https://github.com/facebook/relay/issues/3371