### PR TITLE
SX Design: add missing '@adeira/babel-preset-adeira' dependency

### DIFF
--- a/src/sx-design/package.json
+++ b/src/sx-design/package.json
@@ -21,6 +21,7 @@
     "react": "^17.0.1"
   },
   "devDependencies": {
+    "@adeira/babel-preset-adeira": "^3.0.0",
     "@babel/core": "^7.13.10",
     "@storybook/addon-actions": "^6.1.21",
     "@storybook/addon-essentials": "^6.1.21",


### PR DESCRIPTION
This dependency is necessary when building the Storybook statically (outside of Universe).