### PR TITLE
Flow: use implicit exact object types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,4 @@
-# @generated SignedSource<<ae49cb9ae55943d5887942a3c1b7b525>>
+# @generated SignedSource<<cc03860d3a8d355bd35e54f6ada88c23>>
 #
 # To regenerate run:
 # yarn monorepo-babel-node scripts/generateFlow.js
@@ -24,10 +24,10 @@
 
 [lints]
 all=error
-ambiguous-object-type=off
 sketchy-null-bool=off
 unclear-type=off
 untyped-import=off
+ambiguous-object-type=off
 
 [options]
 emoji=true
@@ -42,7 +42,6 @@ experimental.const_params=true
 [rollouts]
 
 [strict]
-ambiguous-object-type
 sketchy-null-bool
 unclear-type
 untyped-import

--- a/.flowconfig.template.base
+++ b/.flowconfig.template.base
@@ -35,10 +35,13 @@
 ; https://flow.org/en/docs/config/lints/
 [lints]
 all=error
-ambiguous-object-type=off
 sketchy-null-bool=off
 unclear-type=off
 untyped-import=off
+
+# Flow standard is now to use `{ }` for strict objects and `{ key: value, ... }` for open objects,
+# so this option should always be `off`.
+ambiguous-object-type=off
 
 
 ; This setting complements [lints] section: all the enabled lints still throw errors + these
@@ -47,7 +50,6 @@ untyped-import=off
 ;
 ; https://flow.org/en/docs/strict/
 [strict]
-ambiguous-object-type
 sketchy-null-bool
 unclear-type
 untyped-import

--- a/src/__flowtests__/ReactElement.js
+++ b/src/__flowtests__/ReactElement.js
@@ -4,30 +4,30 @@
 
 import { Component, type Element, type ChildrenArray, type Node } from 'react';
 
-class Button extends Component<{| +disabled?: boolean |}> {
+class Button extends Component<{ +disabled?: boolean }> {
   render() {
     return null;
   }
 }
 
-class DisabledButton extends Component<{||}> {
+class DisabledButton extends Component<{}> {
   // The return type is not necessary - it's here only to demonstrate what is going on.
   render(): Element<typeof Button> {
     return <Button disabled={true} />;
   }
 }
 
-class WrapperLimited extends Component<{|
+class WrapperLimited extends Component<{
   +children: ChildrenArray<
     // You have to specify every single supported component here.
     Element<typeof Button> | Element<typeof DisabledButton>,
   >,
-|}> {}
+}> {}
 
-class WrapperSmart extends Component<{|
+class WrapperSmart extends Component<{
   // Type `RestrictedElement` understands what is being rendered so it accepts even `DisabledButton`(because it returns `Button`).
   +children: ChildrenArray<RestrictedElement<typeof Button>>,
-|}> {}
+}> {}
 
 module.exports.testStupid = ((
   <WrapperLimited>

--- a/src/__flowtests__/RestrictedElement.js
+++ b/src/__flowtests__/RestrictedElement.js
@@ -5,14 +5,14 @@
 import * as React from 'react';
 
 // You can enforce compositional patterns with RestrictedElement:
-class MenuItem extends React.Component<{||}> {}
-class MenuSeparator extends React.Component<{||}> {}
-class Menu extends React.Component<{|
+class MenuItem extends React.Component<{}> {}
+class MenuSeparator extends React.Component<{}> {}
+class Menu extends React.Component<{
   +children: React.ChildrenArray<
     RestrictedElement<typeof MenuItem> | RestrictedElement<typeof MenuSeparator>,
   >,
-|}> {}
-class NotAMenuComponent extends React.Component<{||}> {}
+}> {}
+class NotAMenuComponent extends React.Component<{}> {}
 
 // All the children types allowed.
 module.exports.test1 = ((
@@ -33,7 +33,7 @@ module.exports.test2 = ((
   </Menu>
 ): React.Node);
 
-class RendersAMenuItem extends React.Component<{||}> {
+class RendersAMenuItem extends React.Component<{}> {
   render(): React.Element<typeof MenuItem> {
     return <MenuItem />;
   }
@@ -47,7 +47,7 @@ module.exports.test3 = ((
   </Menu>
 ): React.Node);
 
-class RendersSomethingThatRendersAMenuItem extends React.Component<{||}> {
+class RendersSomethingThatRendersAMenuItem extends React.Component<{}> {
   // You really should just use RestrictedElement here, but I want
   // to demonstrate the flexibility.
   render(): React.Element<typeof RendersAMenuItem> {

--- a/src/__flowtests__/lints/implicit-inexact-object.js
+++ b/src/__flowtests__/lints/implicit-inexact-object.js
@@ -1,9 +1,9 @@
 // @flow strict
 
-/* eslint-disable flowtype/require-inexact-type */
+export type ImplicitExact = { x: number };
+export type ExplicitInexact = { x: number, ... };
 
-// This is currently not allowed but it will eventually be the default:
-// flowlint ambiguous-object-type:off
-export type A = { x: number };
-export type B = { x: number, ... };
-export type C = {| x: number |};
+// We no longer allow this syntax (we use implicit exact by default):
+/* eslint-disable flowtype/require-exact-type */
+export type ExplicitExact = {| x: number |};
+/* eslint-enable flowtype/require-exact-type */

--- a/src/babel-preset-adeira/CHANGELOG.md
+++ b/src/babel-preset-adeira/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Breaking changes ahead!
 
+Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
 - Added support for `@babel/eslint-parser` instead of the deprecated `babel-eslint`, see: https://babeljs.io/blog/2020/07/13/the-state-of-babel-eslint
 - Enabled `allowDeclareFields` options for `@babel/plugin-transform-flow-strip-types`. This is the default in Babel 8. You should migrate all type only fields to use `declare` syntax like so:
 

--- a/src/css-colors/CHANGELOG.md
+++ b/src/css-colors/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
 # 2.0.0
 
 Support for Node.js 12 has been removed. This package might continue working on older Node.js versions, however, it's highly recommended upgrading to Node.js version 14 or newer. For more details, see: https://nodejs.org/en/about/releases/, or discuss here: https://github.com/adeira/universe/discussions/1588

--- a/src/eslint-config-adeira/CHANGELOG.md
+++ b/src/eslint-config-adeira/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Unreleased
 
+**Breaking changes ahead!**
+
+Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
+Because of this migration of [`adeira/universe`](https://github.com/adeira/universe) to implicit exact objects (step 4 in this article: https://medium.com/flow-type/on-the-roadmap-exact-objects-by-default-16b72933c5cf) we are changing the following rules:
+
+```text
+flowtype/require-exact-type               OFF -> ERROR with "never"
+flowtype/require-inexact-type             ERROR -> OFF
+flowtype/require-readonly-react-props     ERROR -> ERROR with "useImplicitExactTypes:true"
+```
+
+In case you want to prolong the support for explicit exact objects you can simply reverse these rules and you should be good to go.
+
 # 5.3.0
 
 - Rule [`react/no-unstable-nested-components`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md) enabled (warnings or errors in strict mode)

--- a/src/eslint-config-adeira/__tests__/__fixtures__/valid-eslint-examples/react/jsx-no-bind.js
+++ b/src/eslint-config-adeira/__tests__/__fixtures__/valid-eslint-examples/react/jsx-no-bind.js
@@ -9,10 +9,10 @@ react/no-multi-comp
 
 import { PureComponent, Component, useState, type Element } from 'react';
 
-type LetterProps = {|
+type LetterProps = {
   +letter: string,
   +onClick: () => void,
-|};
+};
 
 const A = 65; // ASCII character code
 
@@ -23,12 +23,12 @@ class Letter extends PureComponent<LetterProps> {
   }
 }
 
-type AplhabetProps = {||};
+type AplhabetProps = {};
 
-type AplhabetState = {|
+type AplhabetState = {
   justClicked: null | string,
   letters: $ReadOnlyArray<string>,
-|};
+};
 
 export class Alphabet1 extends Component<AplhabetProps, AplhabetState> {
   constructor(props: AplhabetProps) {

--- a/src/eslint-config-adeira/__tests__/__fixtures__/valid-eslint-examples/react/no-unused-state.js
+++ b/src/eslint-config-adeira/__tests__/__fixtures__/valid-eslint-examples/react/no-unused-state.js
@@ -3,14 +3,14 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createContext, Component, type Node, type Context, type Element } from 'react';
 
-type Props = {|
+type Props = {
   +accessToken?: string,
   +children: Node,
-|};
+};
 
-type State = {|
+type State = {
   accessToken: ?string,
-|};
+};
 
 const MyContext: Context<State> = createContext({
   accessToken: undefined,

--- a/src/eslint-config-adeira/__tests__/__fixtures__/valid-eslint-examples/react/sort-comp.js
+++ b/src/eslint-config-adeira/__tests__/__fixtures__/valid-eslint-examples/react/sort-comp.js
@@ -6,8 +6,8 @@ const React = {
   Component: class Component<S, P> {},
 };
 
-type Props = {||};
-type State = {||};
+type Props = {};
+type State = {};
 
 export default class MyComponent extends React.Component<void, State> {
   props: Props;

--- a/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
+++ b/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
@@ -159,11 +159,19 @@ Object {
     "flowtype/object-type-curly-spacing": "off",
     "flowtype/object-type-delimiter": "off",
     "flowtype/require-compound-type-alias": 0,
-    "flowtype/require-exact-type": 0,
+    "flowtype/require-exact-type": Array [
+      1,
+      "never",
+    ],
     "flowtype/require-indexer-name": 0,
-    "flowtype/require-inexact-type": 2,
+    "flowtype/require-inexact-type": 0,
     "flowtype/require-parameter-type": 0,
-    "flowtype/require-readonly-react-props": 2,
+    "flowtype/require-readonly-react-props": Array [
+      2,
+      Object {
+        "useImplicitExactTypes": true,
+      },
+    ],
     "flowtype/require-return-type": 0,
     "flowtype/require-types-at-top": 0,
     "flowtype/require-valid-file-annotation": Array [
@@ -1032,6 +1040,11 @@ Snapshot Diff:
 - Value for stable rules
 + Value for STRICT rules
 
+@@ --- --- @@
+      "flowtype/require-exact-type": Array [
+-       1,
++       2,
+        "never",
 @@ --- --- @@
       "flowtype/use-flow-type": 1,
 -     "flowtype/use-read-only-spread": 1,

--- a/src/eslint-config-adeira/ourRules.js
+++ b/src/eslint-config-adeira/ourRules.js
@@ -291,11 +291,16 @@ module.exports = ({
     },
   ],
   'flowtype/require-compound-type-alias': OFF,
-  'flowtype/require-exact-type': OFF,
+  'flowtype/require-exact-type': [NEXT_VERSION_ERROR, 'never'], // we are using `exact_by_default=true`
   'flowtype/require-indexer-name': OFF,
-  'flowtype/require-inexact-type': ERROR,
+  'flowtype/require-inexact-type': OFF,
   'flowtype/require-parameter-type': OFF,
-  'flowtype/require-readonly-react-props': ERROR,
+  'flowtype/require-readonly-react-props': [
+    ERROR,
+    {
+      useImplicitExactTypes: true,
+    },
+  ],
   'flowtype/require-return-type': OFF,
   'flowtype/require-types-at-top': OFF,
   'flowtype/require-valid-file-annotation': [ERROR, 'always'],

--- a/src/eslint-fixtures-tester/src/index.js
+++ b/src/eslint-fixtures-tester/src/index.js
@@ -37,11 +37,11 @@ export default function testFixtures({
   rule,
   validFixturesPath,
   invalidFixturesPath,
-}: {|
+}: {
   rule: EslintRule,
   validFixturesPath: string,
   invalidFixturesPath: string,
-|}): void {
+}): void {
   const validFixtures = [];
   const invalidFixtures = [];
   for (const fixture of fs.readdirSync(validFixturesPath)) {

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/valid/react-clone-element-invalid.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/valid/react-clone-element-invalid.js
@@ -9,9 +9,9 @@
 import * as React from 'react';
 import sx from '@adeira/sx';
 
-type Props = {|
+type Props = {
   +children: React.Element<'strong'>,
-|};
+};
 
 export default function IconButton({ children, ...props }: Props): React.Node {
   return (

--- a/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/valid/react-clone-element.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/fixtures/no-unused-stylesheet/valid/react-clone-element.js
@@ -3,9 +3,9 @@
 import * as React from 'react';
 import sx from '@adeira/sx';
 
-type Props = {|
+type Props = {
   +children: React.Element<'strong'>,
-|};
+};
 
 export default function IconButton({ children, ...props }: Props): React.Node {
   return (

--- a/src/example-relay/src/Homepage/locations/Location.js
+++ b/src/example-relay/src/Homepage/locations/Location.js
@@ -8,10 +8,10 @@ import Image from 'next/image';
 import Text from '../../components/Text';
 import type { Location$key } from './__generated__/Location.graphql';
 
-type Props = {|
+type Props = {
   +location: ?Location$key,
   +dataCount?: string,
-|};
+};
 
 export default function Location(props: Props): Node {
   const location = useFragment(

--- a/src/example-relay/src/Homepage/locations/LocationsList.js
+++ b/src/example-relay/src/Homepage/locations/LocationsList.js
@@ -5,10 +5,10 @@ import sx from '@adeira/sx';
 
 import Location from './Location';
 
-type Props = {|
+type Props = {
   +children: Element<typeof Location> | ChildrenArray<Element<typeof Location>>,
   +start?: number,
-|};
+};
 
 export default function LocationList({ children, start = 1 }: Props): Node {
   return (

--- a/src/example-relay/src/Homepage/locations/LocationsPaginated.js
+++ b/src/example-relay/src/Homepage/locations/LocationsPaginated.js
@@ -12,10 +12,10 @@ import Location from './Location';
 import LocationList from './LocationsList';
 import type { LocationsPaginated_data as LocationsDataType } from './__generated__/LocationsPaginated_data.graphql';
 
-type Props = {|
+type Props = {
   +data: LocationsDataType,
   +relay: PaginationRelayProp,
-|};
+};
 
 function LocationsPaginated(props: Props) {
   function loadMore() {

--- a/src/example-relay/src/Homepage/locations/LocationsPaginatedBidirectional.js
+++ b/src/example-relay/src/Homepage/locations/LocationsPaginatedBidirectional.js
@@ -15,11 +15,11 @@ import Location from './Location';
 import LocationList from './LocationsList';
 import type { LocationsPaginatedBidirectional_data as LocationsDataType } from './__generated__/LocationsPaginatedBidirectional_data.graphql';
 
-type Props = {|
+type Props = {
   +itemsCount: number,
   +data: LocationsDataType,
   +relay: RefetchRelayProp,
-|};
+};
 
 function LocationsPaginatedBidirectional(props: Props) {
   const [start, setStart] = useState(1);
@@ -29,7 +29,7 @@ function LocationsPaginatedBidirectional(props: Props) {
     return null; // or some failure placeholder
   }
 
-  function handlePageChange(args: {| before?: ?string, after?: ?string |}, callback: () => void) {
+  function handlePageChange(args: { before?: ?string, after?: ?string }, callback: () => void) {
     props.relay.refetch(
       {
         first: args.after != null ? props.itemsCount : null,

--- a/src/example-relay/src/Homepage/locations/LocationsPaginatedRefetch.js
+++ b/src/example-relay/src/Homepage/locations/LocationsPaginatedRefetch.js
@@ -12,10 +12,10 @@ import Location from './Location';
 import LocationList from './LocationsList';
 import type { LocationsPaginatedRefetch_data as LocationsDataType } from './__generated__/LocationsPaginatedRefetch_data.graphql';
 
-type Props = {|
+type Props = {
   +data: LocationsDataType,
   +relay: RefetchRelayProp,
-|};
+};
 
 function LocationsPaginatedRefetch(props: Props) {
   function loadMore() {

--- a/src/example-relay/src/LocalForm/index.js
+++ b/src/example-relay/src/LocalForm/index.js
@@ -19,10 +19,10 @@ import TextInput from '../components/TextInput';
 const environment = createLocalEnvironment();
 const consoleStyle = 'color: green; background-color: lightgreen;';
 
-type LocalData = {|
+type LocalData = {
   +subject?: string,
   +message?: string,
-|};
+};
 
 function getLocalStorageData(): LocalData {
   return JSON.parse(window.localStorage.getItem('LocalForm')) ?? {};

--- a/src/example-relay/src/SSRLocations/LocationListItem.js
+++ b/src/example-relay/src/SSRLocations/LocationListItem.js
@@ -5,9 +5,9 @@ import { graphql, useFragment } from '@adeira/relay';
 
 import type { LocationListItem$key } from './__generated__/LocationListItem.graphql';
 
-type Props = {|
+type Props = {
   +location: ?LocationListItem$key,
-|};
+};
 
 export default function LocationListItem(props: Props): Node {
   const location = useFragment(

--- a/src/example-relay/src/SSRLocations/LocationsList.js
+++ b/src/example-relay/src/SSRLocations/LocationsList.js
@@ -6,9 +6,9 @@ import { graphql, useFragment } from '@adeira/relay';
 import LocationListItem from './LocationListItem';
 import type { LocationsList$key } from './__generated__/LocationsList.graphql';
 
-type Props = {|
+type Props = {
   +locations: ?LocationsList$key,
-|};
+};
 
 export default function LocationsList(props: Props): Node {
   const locations = useFragment(

--- a/src/example-relay/src/SSRLocations/LocationsQuery.js
+++ b/src/example-relay/src/SSRLocations/LocationsQuery.js
@@ -21,9 +21,9 @@ export const variables = {
   first: 20,
 };
 
-type Props = {|
+type Props = {
   +ssrData: RecordMap,
-|};
+};
 
 export default function LocationsQuery(props: Props): Node {
   return (

--- a/src/example-relay/src/SSRQueryRenderer.js
+++ b/src/example-relay/src/SSRQueryRenderer.js
@@ -12,12 +12,12 @@ import { isBrowser } from '@adeira/js';
 
 import createRelayEnvironment from './createRelayEnvironment';
 
-type Props<T> = {|
+type Props<T> = {
   +query: GraphQLTaggedNode,
   +variables: Variables,
   +onResponse: (?T) => Node,
   +ssrData: $FlowFixMe,
-|};
+};
 
 export default function SSRQueryRenderer<T>(props: Props<T>): Node {
   // We have to re-create the environment here with initialized store for SSR.

--- a/src/example-relay/src/components/Button.js
+++ b/src/example-relay/src/components/Button.js
@@ -3,7 +3,7 @@
 import type { Node } from 'react';
 import sx from '@adeira/sx';
 
-type Props = {|
+type Props = {
   +onClick?: () => void,
   +children: Node,
   +dataTest?: string,
@@ -11,7 +11,7 @@ type Props = {|
   +iconLeft?: Node,
   +iconRight?: Node,
   +type?: 'submit' | 'button',
-|};
+};
 
 export default function Button({
   children,

--- a/src/example-relay/src/components/Heading.js
+++ b/src/example-relay/src/components/Heading.js
@@ -3,10 +3,10 @@
 import type { Node } from 'react';
 import sx from '@adeira/sx';
 
-type Props = {|
+type Props = {
   +level: 1 | 2 | 3 | 4 | 5 | 6,
   +children: Node,
-|};
+};
 
 export default function Heading({ level, children }: Props): Node {
   const Component = `h${level}`;

--- a/src/example-relay/src/components/Media.js
+++ b/src/example-relay/src/components/Media.js
@@ -7,13 +7,13 @@ import { breakpoints } from './breakpoints';
 
 type MediaValues = 'sm' | 'tablet' | 'desktop';
 
-type AppMediaType = {|
+type AppMediaType = {
   +Media: ComponentType<MediaProps>,
   +createMediaStyle: () => string,
   +MediaContextProvider: ComponentType<AppMediaContextProps>,
-|};
+};
 
-type MediaProps = {|
+type MediaProps = {
   +at?: MediaValues,
   +lessThan?: MediaValues,
   +greaterThan?: MediaValues,
@@ -21,13 +21,13 @@ type MediaProps = {|
   +between?: $ReadOnlyArray<MediaValues>,
   +children: Node,
   // There might be more, check official docs at https://github.com/artsy/fresnel
-|};
+};
 
-type AppMediaContextProps = {|
+type AppMediaContextProps = {
   +children: Node,
   +onlyMatch?: $ReadOnlyArray<MediaValues>,
   +disableDynamicMediaQueries?: boolean,
-|};
+};
 
 // Expand as needed
 const AppMedia: AppMediaType = createMedia({

--- a/src/example-relay/src/components/Navbar.js
+++ b/src/example-relay/src/components/Navbar.js
@@ -13,9 +13,9 @@ import { Media } from './Media';
 /* eslint-disable jsx-a11y/anchor-is-valid */
 // Next.js does this automatically (https://nextjs.org/docs/api-reference/next/link)
 
-type Props = {|
+type Props = {
   +onClick?: () => void,
-|};
+};
 
 function NavLinks({ onClick }: Props): Node {
   return (

--- a/src/example-relay/src/components/Select.js
+++ b/src/example-relay/src/components/Select.js
@@ -6,18 +6,18 @@ import { MdExpandMore } from 'react-icons/md';
 
 import Text from './Text';
 
-type Option = {|
+type Option = {
   +label: string,
   +value: string,
-|};
+};
 
-type Props = {|
+type Props = {
   +options: $ReadOnlyArray<Option>,
   +label: string,
   +onChange: (string) => void,
   +placeholder?: string,
   +name?: string,
-|};
+};
 
 export default function Select({ options, label, placeholder, onChange, ...rest }: Props): Node {
   const [value, setValue] = useState('');

--- a/src/example-relay/src/components/Text.js
+++ b/src/example-relay/src/components/Text.js
@@ -3,11 +3,11 @@
 import type { Node } from 'react';
 import sx from '@adeira/sx';
 
-type Props = {|
+type Props = {
   +size?: 'small' | 'normal',
   +children: Node,
   +dataTest?: string,
-|};
+};
 
 export default function Text({ size = 'normal', children, dataTest }: Props): Node {
   return (

--- a/src/example-relay/src/components/TextInput.js
+++ b/src/example-relay/src/components/TextInput.js
@@ -5,13 +5,13 @@ import sx from '@adeira/sx';
 
 import Text from './Text';
 
-type Props = {|
+type Props = {
   +onChange: (string) => void,
   +value: string,
   +placeholder?: string,
   +label: string,
   +name?: string,
-|};
+};
 
 export default function TextInput({ onChange, label, ...rest }: Props): Node {
   const handleChange = (e) => {

--- a/src/example-relay/src/graphql/currency/types/output/Currency.js
+++ b/src/example-relay/src/graphql/currency/types/output/Currency.js
@@ -3,11 +3,11 @@
 import { GraphQLObjectType, GraphQLString, GraphQLFloat } from 'graphql';
 import globalIdField from '@adeira/graphql-global-id';
 
-export type TSource = {|
+export type TSource = {
   +format: string,
   +id: string,
   +rate: number,
-|};
+};
 
 export default (new GraphQLObjectType({
   name: 'Currency',

--- a/src/example-relay/src/graphql/locations/locations.js
+++ b/src/example-relay/src/graphql/locations/locations.js
@@ -1,20 +1,20 @@
 // @flow strict
 
-export type Location = {|
+export type Location = {
   +id: string,
   +code: string,
   +name: string,
   +slug: string,
   +timezone: string,
   +type: string,
-  +country: {| +id: string, +name: string, +slug: string, +code: string |},
+  +country: { +id: string, +name: string, +slug: string, +code: string },
   +stations: number,
   +airports: number,
   +rank: number,
-|};
+};
 
-export type LocationInput = {|
+export type LocationInput = {
   +locationId: string,
   +name: string,
   +type: string,
-|};
+};

--- a/src/example-relay/src/graphql/locations/types/output/AddLocationOrError.js
+++ b/src/example-relay/src/graphql/locations/types/output/AddLocationOrError.js
@@ -7,7 +7,7 @@ import AddLocationResponse from './AddLocationResponse';
 import type { LocationInput } from '../../locations';
 
 export class ValidLocationResponse {
-  location: $ReadOnly<{| ...LocationInput, +id: string |}>;
+  location: $ReadOnly<{ ...LocationInput, +id: string }>;
   constructor(location: LocationInput) {
     this.location = {
       ...location,

--- a/src/example-relay/src/graphql/locations/types/output/LocationArea.js
+++ b/src/example-relay/src/graphql/locations/types/output/LocationArea.js
@@ -2,12 +2,12 @@
 
 import { GraphQLObjectType, GraphQLString } from 'graphql';
 
-export type LocationArea = {|
+export type LocationArea = {
   +locationId: string,
   +name: string,
   +slug: string,
   +code: string,
-|};
+};
 
 export default (new GraphQLObjectType({
   name: 'LocationArea',

--- a/src/example-relay/src/mutations/FadeIn.js
+++ b/src/example-relay/src/mutations/FadeIn.js
@@ -3,10 +3,10 @@
 import type { Node } from 'react';
 import { CSSTransition } from 'react-transition-group';
 
-type Props = {|
+type Props = {
   +children: Node,
   +timeout: number,
-|};
+};
 
 function FadeIn({ children, ...rest }: Props): Node {
   return (

--- a/src/example-relay/src/mutations/LocationsList.js
+++ b/src/example-relay/src/mutations/LocationsList.js
@@ -11,9 +11,9 @@ import LocationsForm from './RangeAdd/LocationsForm';
 import { tablet } from '../components/breakpoints';
 import type { LocationsListSimple$key } from './__generated__/LocationsListSimple.graphql';
 
-type Props = {|
+type Props = {
   +data: LocationsListSimple$key,
-|};
+};
 
 export default function LocationsList(props: Props): Node {
   const data = useFragment(

--- a/src/example-relay/src/mutations/RangeAdd/LocationsForm.js
+++ b/src/example-relay/src/mutations/RangeAdd/LocationsForm.js
@@ -12,15 +12,15 @@ import Button from '../../components/Button';
 import Select from '../../components/Select';
 import Heading from '../../components/Heading';
 
-type Props = {|
+type Props = {
   +connectionId: string,
-|};
+};
 
-type Location = {|
+type Location = {
   +locationId: string,
   +name: string,
   +type: string,
-|};
+};
 
 const getLocation = (location: Location) => {
   // We have to map the type from string to enum

--- a/src/example-relay/src/mutations/RangeAdd/RangeAdd.js
+++ b/src/example-relay/src/mutations/RangeAdd/RangeAdd.js
@@ -4,7 +4,7 @@ import type { ComponentType } from 'react';
 
 import SimpleLocationsQuery from '../SimpleLocationsQuery';
 
-type Props = {||};
+type Props = {};
 
 export default (function RangeAdd() {
   return <SimpleLocationsQuery />;

--- a/src/example-relay/src/mutations/SimpleLocationsQuery.js
+++ b/src/example-relay/src/mutations/SimpleLocationsQuery.js
@@ -6,7 +6,7 @@ import { QueryRenderer, graphql } from '@adeira/relay';
 import LocationsList from './LocationsList';
 import type { SimpleLocationsQueryResponse } from './__generated__/SimpleLocationsQuery.graphql';
 
-type Props = {||};
+type Props = {};
 
 export default (function LocationsQuery() {
   return (

--- a/src/example-relay/src/pages/_document.js
+++ b/src/example-relay/src/pages/_document.js
@@ -6,11 +6,11 @@ import sx from '@adeira/sx';
 
 import { mediaStyles } from '../components/Media';
 
-type RenderPageResult = {|
+type RenderPageResult = {
   +html: string,
   +head: $ReadOnlyArray<Node>,
   +styles: $ReadOnlyArray<any>,
-|};
+};
 
 export default class MyDocument extends Document {
   static getInitialProps(ctx: DocumentContext): RenderPageResult {

--- a/src/example-relay/src/pages/ssr.js
+++ b/src/example-relay/src/pages/ssr.js
@@ -6,15 +6,15 @@ import { fetchQuery, type RecordMap } from '@adeira/relay';
 import createRelayEnvironment from '../createRelayEnvironment';
 import LocationsQuery, { query, variables } from '../SSRLocations/LocationsQuery';
 
-type Props = {|
+type Props = {
   +ssrData: RecordMap,
-|};
+};
 
 function Ssr(props: Props): Node {
   return <LocationsQuery ssrData={props.ssrData} />;
 }
 
-Ssr.getInitialProps = async function (): Promise<{| +ssrData: any |}> {
+Ssr.getInitialProps = async function (): Promise<{ +ssrData: any }> {
   const environment = createRelayEnvironment(undefined);
   await fetchQuery(environment, query, variables);
   const ssrData = environment.getStore().getSource().toJSON();

--- a/src/fetch/CHANGELOG.md
+++ b/src/fetch/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
 # 2.0.2
 
 Dependency `cross-fetch` update:

--- a/src/fetch/src/fetchWithRetries.js
+++ b/src/fetch/src/fetchWithRetries.js
@@ -6,11 +6,11 @@ import fetch from './fetch';
 import TimeoutError from './TimeoutError';
 import ResponseError from './ResponseError';
 
-type InitWithRetries = $ReadOnly<{|
+type InitWithRetries = $ReadOnly<{
   ...$Exact<RequestOptions>,
   +fetchTimeout?: number,
   +retryDelays?: $ReadOnlyArray<number>,
-|}>;
+}>;
 
 const DEFAULT_TIMEOUT = 15000;
 const DEFAULT_RETRIES = [1000, 3000];

--- a/src/fixtures-tester/CHANGELOG.md
+++ b/src/fixtures-tester/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Unreleased
+
+Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
+# 1.0.0
+
+Initial release.

--- a/src/flow-config-parser/src/ParsedConfig.flow.js
+++ b/src/flow-config-parser/src/ParsedConfig.flow.js
@@ -2,7 +2,7 @@
 
 type List = Array<string>;
 
-export type ParsedConfig = {|
+export type ParsedConfig = {
   declarations: List,
   ignore: List,
   include: List,
@@ -13,4 +13,4 @@ export type ParsedConfig = {|
   strict: List,
   untyped: List,
   version: $FlowFixMe,
-|};
+};

--- a/src/flow-types-eslint/src/index.js
+++ b/src/flow-types-eslint/src/index.js
@@ -18,19 +18,19 @@ import type { VariableDeclarator as _VariableDeclarator } from './types/Variable
 // https://github.com/babel/babel/blob/08c7280167a8dd7696c16ac70e36d5d3120962a9/packages/babel-parser/src/types.js
 export type Node = any; // TODO
 
-type SourceCode = {|
+type SourceCode = {
   +getAllComments: () => $ReadOnlyArray<Node>,
   +text: string,
-|};
+};
 
-type Context = {|
+type Context = {
   +report: ((Node, string) => void) & (({ +node: Node, ... }) => void),
   +getSourceCode: () => SourceCode,
   +getFilename: () => string,
   +settings: { [key: string]: mixed, ... },
-|};
+};
 
-type ASTNodes = {|
+type ASTNodes = {
   +'BlockComment'?: (
     node: any, // TODO
   ) => void,
@@ -54,22 +54,22 @@ type ASTNodes = {|
   +'TaggedTemplateExpression'?: (node: any) => void, // TODO
   +'TypeAlias'?: (node: TypeAlias) => void,
   +'VariableDeclarator'?: (node: _VariableDeclarator) => void,
-|};
+};
 
 export type VariableDeclarator = _VariableDeclarator;
 export type ImportDeclaration = _ImportDeclaration;
 
-export type EslintRule = {|
-  +meta?: {|
+export type EslintRule = {
+  +meta?: {
     +type?: 'problem' | 'suggestion' | 'layout',
-    +docs?: {|
+    +docs?: {
       +description?: string,
       +category?: string,
       +recommended?: boolean,
-    |},
+    },
     +fixable?: boolean,
     +schema?: $ReadOnlyArray<empty>,
-    +messages?: {| +[string]: string |},
-  |},
+    +messages?: { +[string]: string },
+  },
   +create: (Context) => ASTNodes,
-|};
+};

--- a/src/flow-types-eslint/src/types/ArrowFunctionExpression.js
+++ b/src/flow-types-eslint/src/types/ArrowFunctionExpression.js
@@ -2,9 +2,9 @@
 
 import type { INode } from './INode';
 
-export type ArrowFunctionExpression = $ReadOnly<{|
+export type ArrowFunctionExpression = $ReadOnly<{
   ...INode<'ArrowFunctionExpression'>,
   +generator: boolean,
   +async: boolean,
   // ... TODO
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/CallExpression.js
+++ b/src/flow-types-eslint/src/types/CallExpression.js
@@ -9,7 +9,7 @@ import type { TemplateLiteral } from './TemplateLiteral';
 
 // aaa()
 // ^^^^^
-export type CallExpression = $ReadOnly<{|
+export type CallExpression = $ReadOnly<{
   ...INode<'CallExpression'>,
   +callee: any, // TODO
   +arguments: $ReadOnlyArray<
@@ -20,4 +20,4 @@ export type CallExpression = $ReadOnly<{|
     | ObjectExpression
     | TemplateLiteral,
   >,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/ConditionalExpression.js
+++ b/src/flow-types-eslint/src/types/ConditionalExpression.js
@@ -6,10 +6,10 @@ import type { Literal } from './Literal';
 
 // aaa(isAAA ? 'aaa' : null)
 //     ^^^^^^^^^^^^^^^^^^^^
-export type ConditionalExpression = $ReadOnly<{|
+export type ConditionalExpression = $ReadOnly<{
   ...INode<'ConditionalExpression'>,
   +operator: string,
   +test: Identifier | Literal,
   +consequent: Identifier | Literal,
   +alternate: Identifier | Literal,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/ExportDefaultDeclaration.js
+++ b/src/flow-types-eslint/src/types/ExportDefaultDeclaration.js
@@ -3,7 +3,7 @@
 import type { FunctionDeclaration } from './FunctionDeclaration';
 import type { INode } from './INode';
 
-export type ExportDefaultDeclaration = $ReadOnly<{|
+export type ExportDefaultDeclaration = $ReadOnly<{
   ...INode<'ExportDefaultDeclaration'>,
   +declaration: FunctionDeclaration,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/FunctionDeclaration.js
+++ b/src/flow-types-eslint/src/types/FunctionDeclaration.js
@@ -2,6 +2,6 @@
 
 import type { INode } from './INode';
 
-export type FunctionDeclaration = $ReadOnly<{|
+export type FunctionDeclaration = $ReadOnly<{
   ...INode<'FunctionDeclaration'>,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/GenericTypeAnnotation.js
+++ b/src/flow-types-eslint/src/types/GenericTypeAnnotation.js
@@ -3,8 +3,8 @@
 import type { INode } from './INode';
 import type { Identifier } from './Identifier';
 
-export type GenericTypeAnnotation = $ReadOnly<{|
+export type GenericTypeAnnotation = $ReadOnly<{
   ...INode<'GenericTypeAnnotation'>,
   +typeParameters: any, // TODO
   +id: Identifier,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/INode.js
+++ b/src/flow-types-eslint/src/types/INode.js
@@ -2,9 +2,9 @@
 
 import type { SourceLocation } from './SourceLocation';
 
-export type INode<T: string> = {|
+export type INode<T: string> = {
   +type: T,
   +loc: SourceLocation | null,
   +range: [number, number],
   +parent: $FlowFixMe, // TODO
-|};
+};

--- a/src/flow-types-eslint/src/types/Identifier.js
+++ b/src/flow-types-eslint/src/types/Identifier.js
@@ -2,9 +2,9 @@
 
 import type { INode } from './INode';
 
-export type Identifier = $ReadOnly<{|
+export type Identifier = $ReadOnly<{
   ...INode<'Identifier'>,
   +name: string,
   +typeAnnotation: null | string,
   +optional: boolean,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/ImportDeclaration.js
+++ b/src/flow-types-eslint/src/types/ImportDeclaration.js
@@ -6,9 +6,9 @@ import type { ImportNamespaceSpecifier } from './ImportNamespaceSpecifier';
 import type { ImportSpecifier } from './ImportSpecifier';
 import type { ImportDefaultSpecifier } from './ImportDefaultSpecifier';
 
-export type ImportDeclaration = $ReadOnly<{|
+export type ImportDeclaration = $ReadOnly<{
   ...INode<'ImportDeclaration'>,
   +importKind: string,
   +source: Literal,
   +specifiers: $ReadOnlyArray<ImportDefaultSpecifier | ImportNamespaceSpecifier | ImportSpecifier>,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/ImportDefaultSpecifier.js
+++ b/src/flow-types-eslint/src/types/ImportDefaultSpecifier.js
@@ -5,7 +5,7 @@ import type { Identifier } from './Identifier';
 
 // import aaa from 'aaa';
 //        ^^^
-export type ImportDefaultSpecifier = $ReadOnly<{|
+export type ImportDefaultSpecifier = $ReadOnly<{
   ...INode<'ImportDefaultSpecifier'>,
   +local: Identifier,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/ImportNamespaceSpecifier.js
+++ b/src/flow-types-eslint/src/types/ImportNamespaceSpecifier.js
@@ -5,7 +5,7 @@ import type { Identifier } from './Identifier';
 
 // import * as aaa from 'aaa';
 //        ^^^^^^^^
-export type ImportNamespaceSpecifier = $ReadOnly<{|
+export type ImportNamespaceSpecifier = $ReadOnly<{
   ...INode<'ImportNamespaceSpecifier'>,
   +local: Identifier,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/ImportSpecifier.js
+++ b/src/flow-types-eslint/src/types/ImportSpecifier.js
@@ -5,9 +5,9 @@ import type { Identifier } from './Identifier';
 
 // import { aaa, bbb } from 'aaa';
 //          ^^^  ^^^
-export type ImportSpecifier = $ReadOnly<{|
+export type ImportSpecifier = $ReadOnly<{
   ...INode<'ImportSpecifier'>,
   +imported: Identifier,
   +importKind: null | 'type',
   +local: Identifier,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/JSXAttribute.js
+++ b/src/flow-types-eslint/src/types/JSXAttribute.js
@@ -6,8 +6,8 @@ import type { JSXExpressionContainer } from './JSXExpressionContainer';
 
 // <div style={{ color: 'red' }} />
 //      ^^^^^^^^^^^^^^^^^^^^^^^^
-export type JSXAttribute = $ReadOnly<{|
+export type JSXAttribute = $ReadOnly<{
   ...INode<'JSXAttribute'>,
   +name: JSXIdentifier,
   +value: JSXExpressionContainer,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/JSXExpressionContainer.js
+++ b/src/flow-types-eslint/src/types/JSXExpressionContainer.js
@@ -9,7 +9,7 @@ import type { TemplateLiteral } from './TemplateLiteral';
 
 // <div style={{ color: 'red' }} />
 //            ^^^^^^^^^^^^^^^^^^
-export type JSXExpressionContainer = $ReadOnly<{|
+export type JSXExpressionContainer = $ReadOnly<{
   ...INode<'JSXExpressionContainer'>,
   +expression: ObjectExpression | CallExpression | Literal | TemplateLiteral | MemberExpression, // possibly others ...
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/JSXIdentifier.js
+++ b/src/flow-types-eslint/src/types/JSXIdentifier.js
@@ -4,7 +4,7 @@ import type { INode } from './INode';
 
 // <div style={{ color: 'red' }} />
 //      ^^^^^
-export type JSXIdentifier = $ReadOnly<{|
+export type JSXIdentifier = $ReadOnly<{
   ...INode<'JSXIdentifier'>,
   +name: string,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/Literal.js
+++ b/src/flow-types-eslint/src/types/Literal.js
@@ -2,7 +2,7 @@
 
 import type { INode } from './INode';
 
-export type Literal = $ReadOnly<{|
+export type Literal = $ReadOnly<{
   ...INode<'Literal'>,
   +value: string,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/LogicalExpression.js
+++ b/src/flow-types-eslint/src/types/LogicalExpression.js
@@ -6,9 +6,9 @@ import type { Literal } from './Literal';
 
 // aaa(isAAA && 'aaa')
 //     ^^^^^^^^^^^^^^
-export type LogicalExpression = $ReadOnly<{|
+export type LogicalExpression = $ReadOnly<{
   ...INode<'LogicalExpression'>,
   +operator: string,
   +left: Identifier | Literal,
   +right: Identifier | Literal,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/MemberExpression.js
+++ b/src/flow-types-eslint/src/types/MemberExpression.js
@@ -6,8 +6,8 @@ import type { Literal } from './Literal';
 
 // object.property
 // object['property']
-export type MemberExpression = $ReadOnly<{|
+export type MemberExpression = $ReadOnly<{
   ...INode<'MemberExpression'>,
   +object: Identifier, // `object` (in the example above)
   +property: Literal | Identifier, // `property` (in the example above)
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/NewExpression.js
+++ b/src/flow-types-eslint/src/types/NewExpression.js
@@ -4,8 +4,8 @@ import type { INode } from './INode';
 
 // new Date()
 // ^^^^^^^^^^
-export type NewExpression = $ReadOnly<{|
+export type NewExpression = $ReadOnly<{
   ...INode<'NewExpression'>,
   +arguments: any, // TODO
   +callee: any, // TODO
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/NumberLiteralTypeAnnotation.js
+++ b/src/flow-types-eslint/src/types/NumberLiteralTypeAnnotation.js
@@ -2,11 +2,11 @@
 
 import type { INode } from './INode';
 
-export type NumberLiteralTypeAnnotation = $ReadOnly<{|
+export type NumberLiteralTypeAnnotation = $ReadOnly<{
   ...INode<'NumberLiteralTypeAnnotation'>,
-  +extra: {|
+  +extra: {
     +rawValue: number,
     +raw: string,
-  |},
+  },
   +value: number,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/NumericLiteral.js
+++ b/src/flow-types-eslint/src/types/NumericLiteral.js
@@ -2,7 +2,7 @@
 
 import type { INode } from './INode';
 
-export type NumericalLiteral = $ReadOnly<{|
+export type NumericalLiteral = $ReadOnly<{
   ...INode<'NumericalLiteral'>,
   +value: number,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/ObjectExpression.js
+++ b/src/flow-types-eslint/src/types/ObjectExpression.js
@@ -4,7 +4,7 @@ import type { Property } from './Property';
 import type { INode } from './INode';
 import type { SpreadElement } from './SpreadElement';
 
-export type ObjectExpression = $ReadOnly<{|
+export type ObjectExpression = $ReadOnly<{
   ...INode<'ObjectExpression'>,
   +properties: $ReadOnlyArray<Property | SpreadElement>,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/ObjectTypeAnnotation.js
+++ b/src/flow-types-eslint/src/types/ObjectTypeAnnotation.js
@@ -4,11 +4,11 @@ import type { INode } from './INode';
 import type { ObjectTypeProperty } from './ObjectTypeProperty';
 import type { ObjectTypeSpreadProperty } from './ObjectTypeSpreadProperty';
 
-export type ObjectTypeAnnotation = $ReadOnly<{|
+export type ObjectTypeAnnotation = $ReadOnly<{
   ...INode<'ObjectTypeAnnotation'>,
   +properties: $ReadOnlyArray<ObjectTypeProperty | ObjectTypeSpreadProperty>,
   +indexers: $ReadOnlyArray<any>, // TODO
   +internalSlots: $ReadOnlyArray<any>, // TODO
   +exact: boolean,
   +inexact: boolean,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/ObjectTypeProperty.js
+++ b/src/flow-types-eslint/src/types/ObjectTypeProperty.js
@@ -3,7 +3,7 @@
 import type { INode } from './INode';
 import type { Variance } from './Variance';
 
-export type ObjectTypeProperty = $ReadOnly<{|
+export type ObjectTypeProperty = $ReadOnly<{
   ...INode<'ObjectTypeProperty'>,
   +static: boolean,
   +proto: boolean,
@@ -11,4 +11,4 @@ export type ObjectTypeProperty = $ReadOnly<{|
   +method: boolean,
   +variance: Variance | null,
   +optional: boolean,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/ObjectTypeSpreadProperty.js
+++ b/src/flow-types-eslint/src/types/ObjectTypeSpreadProperty.js
@@ -3,7 +3,7 @@
 import type { INode } from './INode';
 import type { GenericTypeAnnotation } from './GenericTypeAnnotation';
 
-export type ObjectTypeSpreadProperty = $ReadOnly<{|
+export type ObjectTypeSpreadProperty = $ReadOnly<{
   ...INode<'ObjectTypeSpreadProperty'>,
   +argument: GenericTypeAnnotation,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/Position.js
+++ b/src/flow-types-eslint/src/types/Position.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-export type Position = {|
+export type Position = {
   +line: number,
   +column: number,
-|};
+};

--- a/src/flow-types-eslint/src/types/Program.js
+++ b/src/flow-types-eslint/src/types/Program.js
@@ -6,9 +6,9 @@ import type { ImportDefaultSpecifier } from './ImportDefaultSpecifier';
 import type { ImportSpecifier } from './ImportSpecifier';
 import type { INode } from './INode';
 
-export type Program = $ReadOnly<{|
+export type Program = $ReadOnly<{
   ...INode<'Program'>,
   +body: $ReadOnlyArray<
     ImportDeclaration | ImportDefaultSpecifier | ImportSpecifier | ExportDefaultDeclaration,
   >,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/Property.js
+++ b/src/flow-types-eslint/src/types/Property.js
@@ -6,8 +6,8 @@ import type { Literal } from './Literal';
 import type { Identifier } from './Identifier';
 import type { TemplateLiteral } from './TemplateLiteral';
 
-export type Property = $ReadOnly<{|
+export type Property = $ReadOnly<{
   ...INode<'Property'>,
   +key: Literal | TemplateLiteral | Identifier,
   +value: Literal | ObjectExpression,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/SourceLocation.js
+++ b/src/flow-types-eslint/src/types/SourceLocation.js
@@ -2,8 +2,8 @@
 
 import type { Position } from './Position';
 
-export type SourceLocation = {|
+export type SourceLocation = {
   +source: string | null,
   +start: Position,
   +end: Position,
-|};
+};

--- a/src/flow-types-eslint/src/types/SpreadElement.js
+++ b/src/flow-types-eslint/src/types/SpreadElement.js
@@ -8,7 +8,7 @@ import type { INode } from './INode';
 //   ...aaa,
 //   ^^^^^^
 // }
-export type SpreadElement = $ReadOnly<{|
+export type SpreadElement = $ReadOnly<{
   ...INode<'SpreadElement'>,
   +argument: CallExpression | Identifier,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/StringLiteral.js
+++ b/src/flow-types-eslint/src/types/StringLiteral.js
@@ -2,7 +2,7 @@
 
 import type { INode } from './INode';
 
-export type StringLiteral = $ReadOnly<{|
+export type StringLiteral = $ReadOnly<{
   ...INode<'StringLiteral'>,
   +value: string,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/StringLiteralTypeAnnotation.js
+++ b/src/flow-types-eslint/src/types/StringLiteralTypeAnnotation.js
@@ -2,11 +2,11 @@
 
 import type { INode } from './INode';
 
-export type StringLiteralTypeAnnotation = $ReadOnly<{|
+export type StringLiteralTypeAnnotation = $ReadOnly<{
   ...INode<'StringLiteralTypeAnnotation'>,
-  +extra: {|
+  +extra: {
     +rawValue: string,
     +raw: string,
-  |},
+  },
   +value: string,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/TemplateElement.js
+++ b/src/flow-types-eslint/src/types/TemplateElement.js
@@ -2,11 +2,11 @@
 
 import type { INode } from './INode';
 
-export type TemplateElement = $ReadOnly<{|
+export type TemplateElement = $ReadOnly<{
   ...INode<'TemplateElement'>,
-  +value: {|
+  +value: {
     +raw: string,
     +cooked: string,
-  |},
+  },
   +tail: boolean,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/TemplateLiteral.js
+++ b/src/flow-types-eslint/src/types/TemplateLiteral.js
@@ -8,10 +8,10 @@ import type { ObjectExpression } from './ObjectExpression';
 import type { StringLiteral } from './StringLiteral';
 import type { TemplateElement } from './TemplateElement';
 
-export type TemplateLiteral = $ReadOnly<{|
+export type TemplateLiteral = $ReadOnly<{
   ...INode<'TemplateLiteral'>,
   +expressions: $ReadOnlyArray<
     StringLiteral | NumericalLiteral | ObjectExpression | ArrowFunctionExpression | CallExpression, // ... possibly others
   >,
   +quasis: $ReadOnlyArray<TemplateElement>,
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/TypeAlias.js
+++ b/src/flow-types-eslint/src/types/TypeAlias.js
@@ -6,7 +6,7 @@ import type { NumberLiteralTypeAnnotation } from './NumberLiteralTypeAnnotation'
 import type { ObjectTypeAnnotation } from './ObjectTypeAnnotation';
 import type { StringLiteralTypeAnnotation } from './StringLiteralTypeAnnotation';
 
-export type TypeAlias = $ReadOnly<{|
+export type TypeAlias = $ReadOnly<{
   ...INode<'TypeAlias'>,
   +right:
     | ObjectTypeAnnotation
@@ -14,4 +14,4 @@ export type TypeAlias = $ReadOnly<{|
     | NumberLiteralTypeAnnotation
     | StringLiteralTypeAnnotation,
   // possibly many others
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/VariableDeclaration.js
+++ b/src/flow-types-eslint/src/types/VariableDeclaration.js
@@ -5,8 +5,8 @@ import type { VariableDeclarator } from './VariableDeclarator';
 
 // let x = …
 // ^^^^^^^^^
-export type VariableDeclaration = $ReadOnly<{|
+export type VariableDeclaration = $ReadOnly<{
   ...INode<'VariableDeclaration'>,
   +declarations: $ReadOnly<VariableDeclarator>,
   +kind: 'const' | 'let' | 'var',
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/VariableDeclarator.js
+++ b/src/flow-types-eslint/src/types/VariableDeclarator.js
@@ -8,7 +8,7 @@ import type { StringLiteral } from './StringLiteral';
 
 // let x = …
 //     ^^^^^
-export type VariableDeclarator = $ReadOnly<{|
+export type VariableDeclarator = $ReadOnly<{
   ...INode<'VariableDeclarator'>,
   +id: Identifier,
   +init:
@@ -16,4 +16,4 @@ export type VariableDeclarator = $ReadOnly<{|
     | CallExpression // let x = y();
     | NumericalLiteral // let x = -1;
     | StringLiteral, // let x = "";
-|}>;
+}>;

--- a/src/flow-types-eslint/src/types/Variance.js
+++ b/src/flow-types-eslint/src/types/Variance.js
@@ -1,5 +1,5 @@
 // @flow strict
 
-export type Variance = {|
+export type Variance = {
   +kind: 'plus' | 'minus',
-|};
+};

--- a/src/graphql-bc-checker/CHANGELOG.md
+++ b/src/graphql-bc-checker/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Support for Node.js 12 has been removed. This package might continue working on older Node.js versions, however, it's highly recommended upgrading to Node.js version 14 or newer. For more details, see: https://nodejs.org/en/about/releases/, or discuss here: https://github.com/adeira/universe/discussions/1588
 
+Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
 # 0.1.4.0
 
 - BC checker now uses signed-source dependency directly

--- a/src/graphql-bc-checker/src/index.js
+++ b/src/graphql-bc-checker/src/index.js
@@ -36,11 +36,11 @@ const createSnapshot = (breakingChangesBlock, newSchema) => {
   );
 };
 
-type Options = {|
+type Options = {
   +allowBreakingChanges: boolean,
   +snapshotLocation: string,
   +schema: GraphQLSchema,
-|};
+};
 
 export default function testBackwardCompatibility({
   allowBreakingChanges,

--- a/src/graphql-global-id/CHANGELOG.md
+++ b/src/graphql-global-id/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Unreleased
 
+Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
 # 2.0.1
 
-Upgrade of peer dependency
+- Upgrade of peer dependencies
 
 # 2.0.0
 

--- a/src/graphql-relay-fauna/src/GlobalID.js
+++ b/src/graphql-relay-fauna/src/GlobalID.js
@@ -5,7 +5,7 @@ import GlobalID, { type OpaqueIDString, encode, decode } from '@adeira/graphql-g
 import { values as FaunaValues, type values$Document as FaunaDocument } from 'faunadb';
 import { type GraphQLFieldConfig } from 'graphql';
 
-type AnyFaunaDocument = FaunaDocument<$Shape<{||}>>;
+type AnyFaunaDocument = FaunaDocument<$Shape<{}>>;
 
 export default function GlobalFaunaID(): GraphQLFieldConfig<any, any> {
   const idFetcher = ({ ref }: AnyFaunaDocument) => {

--- a/src/graphql-relay/src/test-helpers/starWarsData.js
+++ b/src/graphql-relay/src/test-helpers/starWarsData.js
@@ -14,16 +14,16 @@
  * JSON objects in a more complex demo.
  */
 
-type Ship = {|
+type Ship = {
   id: string,
   name: string,
-|};
+};
 
-type Fraction = {|
+type Fraction = {
   id: string,
   name: string,
   ships: $ReadOnlyArray<string>,
-|};
+};
 
 const xwing: Ship = {
   id: '1',

--- a/src/js/CHANGELOG.md
+++ b/src/js/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
 # 2.1.0
 
 - Added a new function `rangeMap` which helps with creating an array of elements with predefined length.

--- a/src/kochka.com.mx/pages/_app.js
+++ b/src/kochka.com.mx/pages/_app.js
@@ -25,10 +25,10 @@ if (
   axe(React, ReactDOM, 1000);
 }
 
-type Props = {|
+type Props = {
   +Component: any,
   +pageProps: any,
-|};
+};
 
 function MyApp({ Component, pageProps }: Props): React.Node {
   const router = useRouter();

--- a/src/kochka.com.mx/pages/_document.js
+++ b/src/kochka.com.mx/pages/_document.js
@@ -6,15 +6,15 @@ import * as React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import sx from '@adeira/sx';
 
-type InitialProps = {|
+type InitialProps = {
   +renderPage: () => $FlowFixMe,
-|};
+};
 
-type RenderPageResult = {|
+type RenderPageResult = {
   +html: string,
   +head: $ReadOnlyArray<React.Node>,
   +styles: $ReadOnlyArray<any>,
-|};
+};
 
 export default class MyDocument extends Document {
   static getInitialProps({ renderPage }: InitialProps): RenderPageResult {

--- a/src/kochka.com.mx/src/LanguageTag.js
+++ b/src/kochka.com.mx/src/LanguageTag.js
@@ -3,10 +3,10 @@
 type Bcp47LanguageTagType = 'en-US' | 'es-MX';
 type UrlLanguageTagType = 'en-us' | 'es-mx';
 
-export type LanguageTagType = {|
+export type LanguageTagType = {
   +bcp47: Bcp47LanguageTagType,
   +url: UrlLanguageTagType,
-|};
+};
 
 const SUPPORTED_PRIMARY_LANGUAGE_SUBTAGS = ['en', 'es'];
 const SUPPORTED_REGION_SUBTAGS = ['US', 'MX'];

--- a/src/kochka.com.mx/src/Layout.js
+++ b/src/kochka.com.mx/src/Layout.js
@@ -8,13 +8,13 @@ import { Heading } from '@adeira/sx-design';
 import LayoutFooter from './LayoutFooter';
 import LayoutNavigation from './LayoutNavigation';
 
-type Props = {|
+type Props = {
   +children: React.Node,
   +title: React.Node,
   +subtitle?: React.Node,
   +withFullWidth?: boolean,
   +withHiddenTitle?: boolean,
-|};
+};
 
 export default function Layout(props: Props): React.Node {
   return (

--- a/src/kochka.com.mx/src/LinkInternal.js
+++ b/src/kochka.com.mx/src/LinkInternal.js
@@ -6,11 +6,11 @@ import { useRouter } from 'next/router';
 import { type AllCSSProperties } from '@adeira/sx';
 import { Link as SXLink } from '@adeira/sx-design';
 
-type Props = {|
+type Props = {
   +href: string,
   +children: React.Node,
   +xstyle?: AllCSSProperties,
-|};
+};
 
 /**
  * Use this link without worrying about the route language to navigate inside the application:

--- a/src/kochka.com.mx/src/Logo.js
+++ b/src/kochka.com.mx/src/Logo.js
@@ -6,11 +6,11 @@ import { Heading } from '@adeira/sx-design';
 
 import KochkaIcon from './design/svg/KochkaIcon';
 
-type Props = {|
+type Props = {
   +color?: string,
   +horizontal?: boolean,
   +size?: 'small' | 'large',
-|};
+};
 
 export default function Logo(props: Props): React.Node {
   const isHorizontal = props.horizontal === true;

--- a/src/kochka.com.mx/src/SocialMediaIcons.js
+++ b/src/kochka.com.mx/src/SocialMediaIcons.js
@@ -8,11 +8,11 @@ import Instagram from './design/svg/__generated__/Instagram';
 import Facebook from './design/svg/__generated__/Facebook';
 import socialLinks from './socialLinks';
 
-type Props = {|
+type Props = {
   +vertical?: boolean,
   +color?: string,
   +size?: number,
-|};
+};
 
 export default function SocialMediaIcons(props: Props): React.Node {
   return (

--- a/src/kochka.com.mx/src/ViewerContextProvider.js
+++ b/src/kochka.com.mx/src/ViewerContextProvider.js
@@ -4,15 +4,15 @@ import * as React from 'react';
 
 import type { LanguageTagType } from './LanguageTag';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   +children: React.Node,
   +languageTag: LanguageTagType,
-|}>;
+}>;
 
 /**
  * @deprecated use `SxDesignProvider` instead (?)
  */
-export type ViewerContextType = {| +languageTag: LanguageTagType |};
+export type ViewerContextType = { +languageTag: LanguageTagType };
 
 /**
  * @deprecated use `SxDesignProvider` instead (?)

--- a/src/kochka.com.mx/src/design/Input.js
+++ b/src/kochka.com.mx/src/design/Input.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import sx, { type AllCSSProperties } from '@adeira/sx';
 
-type Props = {|
+type Props = {
   +name: string,
   +onChange: (event: SyntheticInputEvent<>) => void,
   +type: 'email' | 'text',
@@ -12,7 +12,7 @@ type Props = {|
   +placeholder?: FbtWithoutString,
   +tabIndex?: number,
   +xstyle?: AllCSSProperties,
-|};
+};
 
 export default function Input(props: Props): React.Node {
   // eslint-disable-next-line react/forbid-elements

--- a/src/kochka.com.mx/src/design/InputSubmit.js
+++ b/src/kochka.com.mx/src/design/InputSubmit.js
@@ -3,11 +3,11 @@
 import * as React from 'react';
 import sx from '@adeira/sx';
 
-type Props = {|
+type Props = {
   +name: string,
   +value: Fbt,
   +id?: string,
-|};
+};
 
 export default function InputSubmit(props: Props): React.Node {
   // eslint-disable-next-line react/forbid-elements

--- a/src/kochka.com.mx/src/design/svg/KochkaIcon.js
+++ b/src/kochka.com.mx/src/design/svg/KochkaIcon.js
@@ -4,10 +4,10 @@ import * as React from 'react';
 
 import SVGIcon from './SVGIcon';
 
-type Props = {|
+type Props = {
   +color?: string,
   +size?: number,
-|};
+};
 
 export default function KochkaIcon(props: Props): React.Node {
   const { color = '#fff', size = 175 } = props;

--- a/src/kochka.com.mx/src/design/svg/SVGIcon.js
+++ b/src/kochka.com.mx/src/design/svg/SVGIcon.js
@@ -2,13 +2,13 @@
 
 import * as React from 'react';
 
-type Props = {|
+type Props = {
   +children: React.Node,
   +size: number,
   +viewBox: string,
   +color?: string,
   +strokeColor?: string,
-|};
+};
 
 export default function SVGIcon(props: Props): React.Node {
   return (

--- a/src/kochka.com.mx/src/design/svg/__generated__/Cart.js
+++ b/src/kochka.com.mx/src/design/svg/__generated__/Cart.js
@@ -4,10 +4,10 @@ import * as React from 'react';
 
 import SVGIcon from '../SVGIcon';
 
-type Props = {|
+type Props = {
   +color?: string,
   +size?: number,
-|};
+};
 
 export default function Cart(props: Props): React.Node {
   const { color = '#fff', size = 40 } = props;

--- a/src/kochka.com.mx/src/design/svg/__generated__/Facebook.js
+++ b/src/kochka.com.mx/src/design/svg/__generated__/Facebook.js
@@ -4,10 +4,10 @@ import * as React from 'react';
 
 import SVGIcon from '../SVGIcon';
 
-type Props = {|
+type Props = {
   +color?: string,
   +size?: number,
-|};
+};
 
 export default function Facebook(props: Props): React.Node {
   const { color = '#fff', size = 40 } = props;

--- a/src/kochka.com.mx/src/design/svg/__generated__/Instagram.js
+++ b/src/kochka.com.mx/src/design/svg/__generated__/Instagram.js
@@ -4,10 +4,10 @@ import * as React from 'react';
 
 import SVGIcon from '../SVGIcon';
 
-type Props = {|
+type Props = {
   +color?: string,
   +size?: number,
-|};
+};
 
 export default function Facebook(props: Props): React.Node {
   const { color = '#fff', size = 40 } = props;

--- a/src/kochka.com.mx/src/design/svg/__generated__/flags/mx.js
+++ b/src/kochka.com.mx/src/design/svg/__generated__/flags/mx.js
@@ -4,9 +4,9 @@ import * as React from 'react';
 
 import SVGIcon from '../../SVGIcon';
 
-type Props = {|
+type Props = {
   +size?: number,
-|};
+};
 
 export default function FlagMX(props: Props): React.Node {
   const { size = 50 } = props;

--- a/src/kochka.com.mx/src/design/svg/__generated__/flags/us.js
+++ b/src/kochka.com.mx/src/design/svg/__generated__/flags/us.js
@@ -4,9 +4,9 @@ import * as React from 'react';
 
 import SVGIcon from '../../SVGIcon';
 
-type Props = {|
+type Props = {
   +size?: number,
-|};
+};
 
 export default function FlagUS(props: Props): React.Node {
   const { size = 50 } = props;

--- a/src/kochka.com.mx/src/shop/recoil/filtersAtom.js
+++ b/src/kochka.com.mx/src/shop/recoil/filtersAtom.js
@@ -2,14 +2,14 @@
 
 import { atom, DefaultValue, type RecoilState } from 'recoil';
 
-export type State = {|
-  +categories: {|
+export type State = {
+  +categories: {
     +all: boolean,
-  |},
-  +relevance: {|
+  },
+  +relevance: {
     +price: 'LOW_TO_HIGH' | 'HIGH_TO_LOW',
-  |},
-|};
+  },
+};
 
 export default (atom<State>({
   key: 'filtersAtom',

--- a/src/kochka.com.mx/translations/init.js
+++ b/src/kochka.com.mx/translations/init.js
@@ -6,11 +6,11 @@ import { warning } from '@adeira/js';
 import LanguageTag, { type LanguageTagType } from '../src/LanguageTag';
 
 // {locale: {hash: translation}}
-type TranslationDict = {|
-  [locale: string]: {|
+type TranslationDict = {
+  [locale: string]: {
     [hashKey: string]: string,
-  |},
-|};
+  },
+};
 
 export default function initTranslations(lang: ?string): LanguageTagType {
   const languageTag = LanguageTag.detectLanguageTag(lang);

--- a/src/monorepo-npm-publisher/CHANGELOG.md
+++ b/src/monorepo-npm-publisher/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
 # 2.0.0
 
 - Support for Node.js 12 has been removed. This package might continue working on older Node.js versions, however, it's highly recommended upgrading to Node.js version 14 or newer. For more details, see: https://nodejs.org/en/about/releases/, or discuss here: https://github.com/adeira/universe/discussions/1588

--- a/src/monorepo-npm-publisher/src/NPM.js
+++ b/src/monorepo-npm-publisher/src/NPM.js
@@ -11,15 +11,15 @@ const NPM = new NPMRegistryClient({
   },
 });
 
-type PackageInfoPayload = {|
+type PackageInfoPayload = {
   +latest: string,
-|};
+};
 
 export default {
-  getPackageInfo: (params: {|
+  getPackageInfo: (params: {
     +package: string,
     +npmAuthToken: string,
-  |}): Promise<PackageInfoPayload> => {
+  }): Promise<PackageInfoPayload> => {
     return new Promise<PackageInfoPayload>((resolve, reject) => {
       NPM.distTags.fetch(
         URI,
@@ -42,11 +42,11 @@ export default {
     });
   },
 
-  publishPackage: (params: {|
+  publishPackage: (params: {
     +metadata: { [key: string]: any, ... }, // package.json file
     +body: { [key: string]: any, ... },
     +npmAuthToken: string,
-  |}): Promise<void> => {
+  }): Promise<void> => {
     return new Promise<void>((resolve, reject) => {
       NPM.publish(
         URI,

--- a/src/monorepo-npm-publisher/src/index.js
+++ b/src/monorepo-npm-publisher/src/index.js
@@ -16,13 +16,13 @@ import NPM from './NPM';
 import modifyPackageJSON from './modifyPackageJSON';
 import transformFileVariants from './transformFileVariants';
 
-type Options = {|
+type Options = {
   +dryRun: boolean,
   +buildCache: string,
   +npmAuthToken: string,
   +workspaces: Set<string>,
   +reactRuntime?: 'automatic' | 'classic',
-|};
+};
 
 export default async function publish(options: Options) {
   log('NPM publisher %s', require('../package.json').version);

--- a/src/monorepo-npm-publisher/src/modifyPackageJSON.js
+++ b/src/monorepo-npm-publisher/src/modifyPackageJSON.js
@@ -1,11 +1,11 @@
 // @flow strict
 
-type PackageJSON = {|
+type PackageJSON = {
   +main?: string,
   // Field `module` can be string when you want to use your custom
   // implementation or `false` when you want to disable ESM completely.
   +module?: string | false,
-|};
+};
 
 export default function modifyPackageJSON(packageJSONFile: PackageJSON): PackageJSON {
   const { main, module, ...rest } = packageJSONFile;

--- a/src/monorepo-shipit/ConfigType.flow.js
+++ b/src/monorepo-shipit/ConfigType.flow.js
@@ -1,13 +1,13 @@
 // @flow strict
 
-export type ConfigType = {|
-  +getStaticConfig: () => {|
+export type ConfigType = {
+  +getStaticConfig: () => {
     +repository: string,
-  |},
+  },
   +getPathMappings: () => Map<string, string>,
   +getStrippedFiles?: () => Set<RegExp>,
-  +getBranchConfig?: () => {|
+  +getBranchConfig?: () => {
     +source: string,
     +destination: string,
-  |},
-|};
+  },
+};

--- a/src/monorepo-shipit/bin/shipit.js
+++ b/src/monorepo-shipit/bin/shipit.js
@@ -12,10 +12,10 @@ import createSyncPhase from '../src/phases/createSyncPhase';
 import createVerifyRepoPhase from '../src/phases/createVerifyRepoPhase';
 import createPushPhase from '../src/phases/createPushPhase';
 
-type Phase = {|
+type Phase = {
   (): void,
   +readableName: string,
-|};
+};
 
 iterateConfigs((config) => {
   new Set<Phase>([

--- a/src/monorepo-shipit/src/Changeset.js
+++ b/src/monorepo-shipit/src/Changeset.js
@@ -2,12 +2,12 @@
 
 import { sprintf } from '@adeira/js';
 
-type Diff = {|
+type Diff = {
   +path: string,
   +body: string,
-|};
+};
 
-opaque type ChangesetData = {|
+opaque type ChangesetData = {
   +id: string,
   +timestamp: string,
   +author: string,
@@ -15,7 +15,7 @@ opaque type ChangesetData = {|
   +description: string,
   +diffs: Set<Diff>,
   +debugMessages: Array<string>,
-|};
+};
 
 export default class Changeset {
   declare id: string;

--- a/src/monorepo-shipit/src/RepoGit.js
+++ b/src/monorepo-shipit/src/RepoGit.js
@@ -191,7 +191,7 @@ export default class RepoGit implements AnyRepo, SourceRepo, DestinationRepo {
     return changeset.withDiffs(diffs);
   };
 
-  parseDiffHunk: (hunk: string) => null | {| +body: string, +path: string |} = (hunk) => {
+  parseDiffHunk: (hunk: string) => null | { +body: string, +path: string } = (hunk) => {
     const [head, tail] = splitHead(hunk, '\n');
     const match = head.match(/^diff --git [ab]\/(?:.*?) [ab]\/(?<path>.*?)$/);
     if (!match) {

--- a/src/monorepo-shipit/src/utils/createMockDiff.js
+++ b/src/monorepo-shipit/src/utils/createMockDiff.js
@@ -1,9 +1,9 @@
 // @flow strict
 
-type Diff = {|
+type Diff = {
   +path: string,
   +body: string,
-|};
+};
 
 export default function createMockDiff(filename: string): Diff {
   return {

--- a/src/monorepo-utils/src/Workspaces.flow.js
+++ b/src/monorepo-utils/src/Workspaces.flow.js
@@ -1,10 +1,10 @@
 // @flow strict
 
 export type WorkspaceDependencies = {
-  [string]: {|
+  [string]: {
     +location: string,
     +workspaceDependencies: $ReadOnlyArray<string>,
     +mismatchedWorkspaceDependencies: $ReadOnlyArray<string>,
-  |},
+  },
   ...
 };

--- a/src/monorepo-utils/src/Workspaces.js
+++ b/src/monorepo-utils/src/Workspaces.js
@@ -6,7 +6,7 @@ import { findRootPackageJson } from './findRootPackageJson';
 type MinimalPackageJSON = {
   +workspaces?:
     | $ReadOnlyArray<string>
-    | {| +packages: $ReadOnlyArray<string>, +nohoist: $ReadOnlyArray<string> |},
+    | { +packages: $ReadOnlyArray<string>, +nohoist: $ReadOnlyArray<string> },
   ...
 };
 

--- a/src/monorepo-utils/src/findRootPackageJson.js
+++ b/src/monorepo-utils/src/findRootPackageJson.js
@@ -9,7 +9,7 @@ type AnyNestedObject = { +[string]: AnyNestedObject, ... };
 type PackageJSON = {
   +workspaces?:
     | $ReadOnlyArray<string>
-    | {| +packages: $ReadOnlyArray<string>, +nohoist: $ReadOnlyArray<string> |},
+    | { +packages: $ReadOnlyArray<string>, +nohoist: $ReadOnlyArray<string> },
   +[string]: AnyNestedObject,
   ...
 };

--- a/src/monorepo-utils/src/glob.js
+++ b/src/monorepo-utils/src/glob.js
@@ -6,7 +6,7 @@ import { invariant, isObject } from '@adeira/js';
 
 type GlobPattern = string;
 
-type GlobOptions = $ReadOnly<{|
+type GlobOptions = $ReadOnly<{
   cwd?: string,
   root?: string,
   dot?: boolean,
@@ -16,10 +16,10 @@ type GlobOptions = $ReadOnly<{|
   stat?: boolean,
   silent?: boolean,
   strict?: boolean,
-  cache?: {| [path: string]: boolean | 'DIR' | 'FILE' | $ReadOnlyArray<string> |},
-  statCache?: {| [path: string]: false | {| isDirectory(): boolean |} | void |},
-  symlinks?: {| [path: string]: boolean | void |},
-  realpathCache?: {| [path: string]: string |},
+  cache?: { [path: string]: boolean | 'DIR' | 'FILE' | $ReadOnlyArray<string> },
+  statCache?: { [path: string]: false | { isDirectory(): boolean } | void },
+  symlinks?: { [path: string]: boolean | void },
+  realpathCache?: { [path: string]: string },
   sync?: boolean,
   nounique?: boolean,
   nonull?: boolean,
@@ -36,7 +36,7 @@ type GlobOptions = $ReadOnly<{|
   nonegate?: boolean,
   nocomment?: boolean,
   absolute?: boolean,
-|}>;
+}>;
 
 type GlobCallback = (error: null | Error, filenames: $ReadOnlyArray<string>) => void;
 

--- a/src/murmur-hash/CHANGELOG.md
+++ b/src/murmur-hash/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
 # 2.0.0
 
 Support for Node.js 12 has been removed. This package might continue working on older Node.js versions, however, it's highly recommended upgrading to Node.js version 14 or newer. For more details, see: https://nodejs.org/en/about/releases/, or discuss here: https://github.com/adeira/universe/discussions/1588

--- a/src/relay/CHANGELOG.md
+++ b/src/relay/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
 # 3.2.2
 
 - Added experimental bin `adeira-relay-compiler-experimental` which directly calls official `relay-compiler-experimental` bin. This new Relay compiler written in Rust is unstable (as the name suggests) but eventually will be the default. For now, you can start experimenting with it and report any issues to [`facebook/relay`](https://github.com/facebook/relay) repo.

--- a/src/relay/src/LocalQueryRenderer.js
+++ b/src/relay/src/LocalQueryRenderer.js
@@ -12,22 +12,22 @@ import type { GraphQLTaggedNode } from 'relay-runtime';
 import createLocalEnvironment from './createLocalEnvironment';
 import type { Variables } from './types.flow';
 
-type CommonProps = {|
+type CommonProps = {
   +query: GraphQLTaggedNode,
   +environment?: Environment,
   +variables?: Variables,
-|};
+};
 
 type Props<T> =
-  | $ReadOnly<{|
+  | $ReadOnly<{
       ...CommonProps,
       +onResponse: (T) => Node,
       +onLoading?: () => Node,
-    |}>
-  | $ReadOnly<{|
+    }>
+  | $ReadOnly<{
       ...CommonProps,
       +render: ({ +props: ?T, ... }) => Node,
-    |}>;
+    }>;
 
 // Please note: we are currently only wrapping this component to add it correct Flow types.
 // Eventually, it can be extended with other functions like original QueryRenderer.

--- a/src/relay/src/QueryRenderer.js
+++ b/src/relay/src/QueryRenderer.js
@@ -12,24 +12,24 @@ import type { CacheConfig, GraphQLTaggedNode } from 'relay-runtime';
 
 import type { Variables } from './types.flow';
 
-type ReadyState<T> = {|
+type ReadyState<T> = {
   +error: ?Error,
   +props: T,
   +retry: ?() => void,
-|};
+};
 
 type FetchPolicy = 'store-and-network' | 'network-only';
 
-type CommonProps = {|
+type CommonProps = {
   +query: GraphQLTaggedNode,
   +environment?: Environment,
   +cacheConfig?: CacheConfig,
   +fetchPolicy?: FetchPolicy,
   +variables?: Variables,
-|};
+};
 
 type Props<T> =
-  | $ReadOnly<{|
+  | $ReadOnly<{
       ...CommonProps,
       +onSystemError?: ({
         error: Error,
@@ -38,11 +38,11 @@ type Props<T> =
       }) => Node,
       +onLoading?: () => Node,
       +onResponse: (T) => Node,
-    |}>
-  | $ReadOnly<{|
+    }>
+  | $ReadOnly<{
       ...CommonProps,
       +render: (ReadyState<?T>) => Node,
-    |}>;
+    }>;
 
 export default function QueryRenderer<T>(props: $ReadOnly<Props<T>>): Node {
   function renderQueryRendererResponse({ error, props: rendererProps, retry }: ReadyState<?T>) {

--- a/src/relay/src/__flowtests__/ContainerType.js
+++ b/src/relay/src/__flowtests__/ContainerType.js
@@ -10,10 +10,10 @@ import {
   type RefetchContainerType,
 } from '../index';
 
-type Props = {|
+type Props = {
   +aaa: string,
   +bbb: number,
-|};
+};
 
 function DefaultComponent(props) {
   return <div {...props} />;

--- a/src/relay/src/__flowtests__/CustomQueryRenderer.js
+++ b/src/relay/src/__flowtests__/CustomQueryRenderer.js
@@ -9,10 +9,10 @@ function placeholder() {
   return null;
 }
 
-type Props = {|
+type Props = {
   +query: GraphQLTaggedNode,
   +render: () => Node,
-|};
+};
 
 function CustomQueryRenderer(props: Props) {
   const environment = createLocalEnvironment();

--- a/src/relay/src/__flowtests__/Disposable.js
+++ b/src/relay/src/__flowtests__/Disposable.js
@@ -2,7 +2,7 @@
 
 import { graphql, requestSubscription, type RelayProp, type Disposable } from '../index';
 
-type Props = {| +relay: RelayProp |};
+type Props = { +relay: RelayProp };
 
 type SubscriptionTypeMock = any;
 

--- a/src/relay/src/__flowtests__/Environment.js
+++ b/src/relay/src/__flowtests__/Environment.js
@@ -12,13 +12,13 @@ import {
   type RelayProp,
 } from '../index';
 
-type PropsA = {| +relay: RelayProp |};
-type PropsB = {| +relay: RefetchRelayProp |};
-type PropsC = {| +relay: PaginationRelayProp |};
+type PropsA = { +relay: RelayProp };
+type PropsB = { +relay: RefetchRelayProp };
+type PropsC = { +relay: PaginationRelayProp };
 
-type PropsInvalid = {|
-  +relay: {| environment: number |},
-|};
+type PropsInvalid = {
+  +relay: { environment: number },
+};
 
 // this returns Environment which should never be used directly
 const ManuallyCreatedEnvironment = createEnvironment({

--- a/src/relay/src/__flowtests__/createFragmentContainer-missingProps.js
+++ b/src/relay/src/__flowtests__/createFragmentContainer-missingProps.js
@@ -12,4 +12,4 @@ export default (createFragmentContainer(FunctionalFragmentExport, {
       __typename
     }
   `,
-}): FragmentContainerType<{||}>);
+}): FragmentContainerType<{}>);

--- a/src/relay/src/__flowtests__/createFragmentContainer.js
+++ b/src/relay/src/__flowtests__/createFragmentContainer.js
@@ -38,14 +38,14 @@ function getTestCases(Container) {
   };
 }
 
-type Props = {|
+type Props = {
   +relay: RelayProp,
-  +data: {|
+  +data: {
     +required: string,
     +$refType: any,
-  |},
+  },
   +fun?: (string) => void,
-|};
+};
 
 const FunctionalComponent = (props: Props) => <div {...props} />;
 

--- a/src/relay/src/__flowtests__/createPaginationContainer-missingProps.js
+++ b/src/relay/src/__flowtests__/createPaginationContainer-missingProps.js
@@ -24,4 +24,4 @@ export default (createPaginationContainer(
       }
     `,
   },
-): PaginationContainerType<{||}>);
+): PaginationContainerType<{}>);

--- a/src/relay/src/__flowtests__/createPaginationContainer.js
+++ b/src/relay/src/__flowtests__/createPaginationContainer.js
@@ -5,9 +5,9 @@ import { useEffect } from 'react';
 
 import { createPaginationContainer, graphql, type PaginationRelayProp } from '../index';
 
-type Props = {|
+type Props = {
   +relay: PaginationRelayProp,
-|};
+};
 
 module.exports = ({
   validUsage() {

--- a/src/relay/src/__flowtests__/createRefetchContainer-missingProps.js
+++ b/src/relay/src/__flowtests__/createRefetchContainer-missingProps.js
@@ -21,4 +21,4 @@ export default (createRefetchContainer(
       ...createRefetchContainerMissingProps_data
     }
   `,
-): RefetchContainerType<{||}>);
+): RefetchContainerType<{}>);

--- a/src/relay/src/__flowtests__/createRefetchContainer.js
+++ b/src/relay/src/__flowtests__/createRefetchContainer.js
@@ -3,9 +3,9 @@
 
 import { createRefetchContainer, graphql, type RefetchRelayProp } from '../index';
 
-type Props = {|
+type Props = {
   +relay: RefetchRelayProp,
-|};
+};
 
 module.exports = ({
   validUsage() {

--- a/src/relay/src/__flowtests__/mutations.js
+++ b/src/relay/src/__flowtests__/mutations.js
@@ -28,21 +28,21 @@ const variables = {
   someEnum: 'up',
 };
 
-type NamedMutationVariables = {|
+type NamedMutationVariables = {
   +someNumber: number,
   +someEnum: 'down' | 'up',
-|};
+};
 
-type NamedMutationResponse = {|
-  +commitMutation: ?{|
+type NamedMutationResponse = {
+  +commitMutation: ?{
     +__typename: 'CommitMutationResponse',
-  |},
-|};
+  },
+};
 
-type NamedMutation = {|
+type NamedMutation = {
   +variables: NamedMutationVariables,
   +response: NamedMutationResponse,
-|};
+};
 
 module.exports = {
   validMutation(): Disposable {
@@ -86,13 +86,13 @@ module.exports = {
       mutation,
       variables,
       // $FlowExpectedError[prop-missing]: response type differs from onCompleted declaration
-      onCompleted: (response: {||}) => {}, // eslint-disable-line no-unused-vars
+      onCompleted: (response: {}) => {}, // eslint-disable-line no-unused-vars
     });
   },
-  invalidAsyncMutation(): Promise<{|
+  invalidAsyncMutation(): Promise<{
     +errors: ?$ReadOnlyArray<Error>,
     +response: $ElementType<NamedMutation, 'response'>,
-  |}> {
+  }> {
     // $FlowExpectedError[prop-missing]: onCompleted is disabled in config for commitMutationAsync
     return commitMutationAsync<NamedMutation>(environment, {
       mutation,

--- a/src/relay/src/__flowtests__/useLazyLoadQuery.js
+++ b/src/relay/src/__flowtests__/useLazyLoadQuery.js
@@ -8,10 +8,10 @@ const query = graphql`
   }
 `;
 
-type QueryTypeMock = {|
-  +variables: {||},
-  +response: {||},
-|};
+type QueryTypeMock = {
+  +variables: {},
+  +response: {},
+};
 
 module.exports = {
   validUsage: (): (() => void) => {

--- a/src/relay/src/__flowtests__/useMutation.js
+++ b/src/relay/src/__flowtests__/useMutation.js
@@ -12,9 +12,9 @@ module.exports = {
   validUsage: (): (() => void) => {
     return function TestComponent() {
       const [executeMutation, isMutationPending] = useMutation(mutation);
-      (executeMutation: ({|
+      (executeMutation: ({
         onCompleted: () => void,
-      |}) => Disposable);
+      }) => Disposable);
       (isMutationPending: boolean);
 
       executeMutation({

--- a/src/relay/src/__tests__/createFragmentContainer.test.js
+++ b/src/relay/src/__tests__/createFragmentContainer.test.js
@@ -4,7 +4,7 @@ import { Component } from 'react';
 
 import createFragmentContainer from '../createFragmentContainer';
 
-class MockComponent extends Component<{||}> {}
+class MockComponent extends Component<{}> {}
 
 it('throws when used with empty fragment spec', () => {
   let error = new Error();

--- a/src/relay/src/__tests__/createPaginationContainer.test.js
+++ b/src/relay/src/__tests__/createPaginationContainer.test.js
@@ -4,7 +4,7 @@ import { Component } from 'react';
 
 import createPaginationContainer from '../createPaginationContainer';
 
-class MockComponent extends Component<{||}> {}
+class MockComponent extends Component<{}> {}
 
 it('throws when used with empty fragment spec', () => {
   let error = new Error();

--- a/src/relay/src/__tests__/createRefetchContainer.test.js
+++ b/src/relay/src/__tests__/createRefetchContainer.test.js
@@ -4,7 +4,7 @@ import { Component } from 'react';
 
 import createRefetchContainer from '../createRefetchContainer';
 
-class MockComponent extends Component<{||}> {}
+class MockComponent extends Component<{}> {}
 
 it('throws when used with empty fragment spec', () => {
   let error = new Error();

--- a/src/relay/src/compiler/buildLanguagePlugin.js
+++ b/src/relay/src/compiler/buildLanguagePlugin.js
@@ -5,13 +5,13 @@ import { find } from 'relay-compiler/lib/language/javascript/FindGraphQLTags'; /
 
 import formatGeneratedModule from './formatGeneratedModule';
 
-type LanguagePlugin = {|
+type LanguagePlugin = {
   +inputExtensions: $ReadOnlyArray<string>,
   +outputExtension: string,
   +typeGenerator: $FlowFixMe,
   +formatModule: $FlowFixMe,
   +findGraphQLTags: $FlowFixMe,
-|};
+};
 
 export default function buildLanguagePlugin(): LanguagePlugin {
   return {

--- a/src/relay/src/compiler/buildWatchExpression.js
+++ b/src/relay/src/compiler/buildWatchExpression.js
@@ -2,11 +2,11 @@
 
 type WatchmanConfig = $ReadOnlyArray<string | WatchmanConfig>;
 
-export default function buildWatchExpression(config: {|
+export default function buildWatchExpression(config: {
   extensions: $ReadOnlyArray<string>,
   include: $ReadOnlyArray<string>,
   exclude: $ReadOnlyArray<string>,
-|}): WatchmanConfig {
+}): WatchmanConfig {
   // https://facebook.github.io/watchman/docs/install.html
   return [
     'allof',

--- a/src/relay/src/compiler/formatGeneratedModule.js
+++ b/src/relay/src/compiler/formatGeneratedModule.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-type FormatModuleInput = $ReadOnly<{|
+type FormatModuleInput = $ReadOnly<{
   documentType: $FlowFixMe,
   concreteText: string,
   typeText: string,
@@ -8,7 +8,7 @@ type FormatModuleInput = $ReadOnly<{|
   devOnlyAssignments?: string,
   docText?: string,
   hash?: string,
-|}>;
+}>;
 
 export default function formatGeneratedModule({
   documentType,

--- a/src/relay/src/compiler/index.js
+++ b/src/relay/src/compiler/index.js
@@ -16,13 +16,13 @@ import buildWatchExpression from './buildWatchExpression';
 import createPrintRequireDefaultModuleDependency from './createPrintRequireDefaultModuleDependency';
 import getSchemaSource from './getSchemaSource';
 
-type ExternalOptions = {|
+type ExternalOptions = {
   +src: string,
   +schema: string,
   +validate: boolean,
   +watch: boolean,
   +persistMode?: 'fs', // TODO consider more generic: +persistFunction?: ?(query: string) => Promise<string>,
-|};
+};
 
 const {
   commonTransforms,

--- a/src/relay/src/createEnvironment.js
+++ b/src/relay/src/createEnvironment.js
@@ -14,7 +14,7 @@ import createRelayStore from './createRelayStore';
 import createRequestHandler from './createRequestHandler';
 import RelayLazyLogger from './loggers/RelayLazyLogger';
 
-type Options = {|
+type Options = {
   +fetchFn: (...args: $ReadOnlyArray<any>) => any,
   +subscribeFn?: (...args: $ReadOnlyArray<any>) => any,
   +handlerProvider?: (string) => void,
@@ -22,7 +22,7 @@ type Options = {|
   +records?: ?RecordObjectMap,
   +gcReleaseBufferSize?: ?number,
   +log?: LogFunction,
-|};
+};
 
 function createNetwork(
   fetchFn: (...args: $ReadOnlyArray<any>) => any,

--- a/src/relay/src/createFragmentContainer.js
+++ b/src/relay/src/createFragmentContainer.js
@@ -6,9 +6,9 @@ import { invariant, isObjectEmpty } from '@adeira/js';
 
 import type { FragmentSpec, $RelayProps } from './types.flow';
 
-export type RelayProp = {|
+export type RelayProp = {
   +environment: Environment,
-|};
+};
 
 /**
  * @deprecated use `useFragment` instead

--- a/src/relay/src/createNetworkFetcher.js
+++ b/src/relay/src/createNetworkFetcher.js
@@ -6,15 +6,15 @@ import type { UploadableMap } from 'relay-runtime';
 import { handleData, getRequestBody, getHeaders } from './helpers';
 import type { RequestNode, Variables } from './types.flow';
 
-type Headers = {|
+type Headers = {
   +[key: string]: string,
-|};
+};
 
 type AdditionalHeaders = Headers | Promise<Headers>;
-type RefetchConfig = {|
+type RefetchConfig = {
   +fetchTimeout?: number,
   +retryDelays?: $ReadOnlyArray<number>,
-|};
+};
 
 export default function createNetworkFetcher(
   graphQLServerURL: string,

--- a/src/relay/src/createRefetchContainer.js
+++ b/src/relay/src/createRefetchContainer.js
@@ -13,7 +13,7 @@ type RefetchOptions = {
   ...
 };
 
-export type RefetchRelayProp = {|
+export type RefetchRelayProp = {
   +environment: Environment,
   +refetch: (
     refetchVariables:
@@ -26,7 +26,7 @@ export type RefetchRelayProp = {|
     callback: ?(error: ?Error) => void,
     options?: RefetchOptions,
   ) => Disposable,
-|};
+};
 
 /**
  * @deprecated use `useRefetchableFragment` instead

--- a/src/relay/src/createRelayStore.js
+++ b/src/relay/src/createRelayStore.js
@@ -6,7 +6,7 @@ import type { GetDataID } from 'relay-runtime/store/RelayResponseNormalizer';
 // eslint-disable-next-line import/no-unresolved
 import type { RecordObjectMap, Scheduler } from 'relay-runtime/store/RelayStoreTypes';
 
-type Options = {|
+type Options = {
   gcScheduler?: ?Scheduler,
   log?: ?LogFunction,
   operationLoader?: ?OperationLoader,
@@ -14,7 +14,7 @@ type Options = {|
   gcReleaseBufferSize?: ?number,
   queryCacheExpirationTime?: ?number,
   shouldProcessClientComponents?: ?boolean,
-|};
+};
 
 export default function createRelayStore(records: ?RecordObjectMap, options?: Options): Store {
   const source = records == null ? new RecordSource() : new RecordSource(records);

--- a/src/relay/src/createRequestHandler.js
+++ b/src/relay/src/createRequestHandler.js
@@ -14,12 +14,12 @@ import type { RequestNode, Variables } from './types.flow';
  * The methods are to be called to trigger each event. It also contains a closed
  * field to see if the resulting subscription has closed.
  */
-type Sink = {|
+type Sink = {
   +next: (GraphQLResponse) => void,
   +error: (Error, isUncaughtThrownError?: boolean) => void,
   +complete: () => void,
   +closed: boolean,
-|};
+};
 
 export default function createRequestHandler(
   customFetcher: (...args: $ReadOnlyArray<any>) => any,

--- a/src/relay/src/getDataFromRequest.js
+++ b/src/relay/src/getDataFromRequest.js
@@ -9,10 +9,10 @@ import {
 } from 'relay-runtime';
 import type { Environment } from 'react-relay';
 
-type Operation = {|
+type Operation = {
   +query: GraphQLTaggedNode,
   +variables: Variables,
-|};
+};
 
 export default function getDataFromRequest(
   { query, variables }: Operation,

--- a/src/relay/src/helpers.js
+++ b/src/relay/src/helpers.js
@@ -12,7 +12,7 @@ export const isQuery = (request: RequestNode): boolean %checks => {
   return request.operationKind === 'query';
 };
 
-export const forceFetch = (cacheConfig: {| +force?: ?boolean |}): boolean %checks => {
+export const forceFetch = (cacheConfig: { +force?: ?boolean }): boolean %checks => {
   return !!(cacheConfig && cacheConfig.force);
 };
 
@@ -67,7 +67,7 @@ export function getRequestBody(
   return getRequestBodyWithoutUplodables(request, variables);
 }
 
-export const getHeaders = (uploadables: ?UploadableMap): {| +[string]: string |} => {
+export const getHeaders = (uploadables: ?UploadableMap): { +[string]: string } => {
   if (uploadables) {
     return {
       Accept: '*/*',

--- a/src/relay/src/mutations.js
+++ b/src/relay/src/mutations.js
@@ -13,26 +13,26 @@ import type { Variables } from './types.flow';
 
 opaque type SelectorData = $FlowFixMe;
 
-export type MutationParameters = {|
+export type MutationParameters = {
   +response: { +[key: string]: any, ... },
   +variables: Variables,
   +rawResponse?: { ... },
-|};
+};
 
 // See https://github.com/facebook/relay/blob/9ee5a52ad8e385bae6e48bb97922006cc6f83bc0/packages/relay-runtime/mutations/commitMutation.js
-type MutationConfig<T: MutationParameters> = {|
+type MutationConfig<T: MutationParameters> = {
   +mutation: GraphQLTaggedNode,
   +variables: $ElementType<T, 'variables'>,
   // TODO: 2 kinds of errors? What about changing the interface a little bit to make it more obvious?
   +onCompleted?: ?(response: $ElementType<T, 'response'>, errors: ?$ReadOnlyArray<Error>) => void,
   +onError?: ?(error: Error) => void,
   +onUnsubscribe?: ?() => void,
-  +optimisticResponse?: $ElementType<{| +rawResponse?: { ... }, ...T |}, 'rawResponse'>,
+  +optimisticResponse?: $ElementType<{ +rawResponse?: { ... }, ...T }, 'rawResponse'>,
   +optimisticUpdater?: ?(store: RecordSourceSelectorProxy) => void,
   +updater?: ?(store: RecordSourceSelectorProxy, data: SelectorData) => void,
   +uploadables?: UploadableMap,
   +configs?: $ReadOnlyArray<DeclarativeMutationConfig>,
-|};
+};
 
 /**
  * The first parameter `environment` should be from `props.relay.environment`
@@ -58,10 +58,10 @@ export function commitMutation<T: MutationParameters>(
   return _commitMutation(environment, config);
 }
 
-type DisabledConfigProps<T> = {|
+type DisabledConfigProps<T> = {
   +onCompleted: ?(response: $ElementType<T, 'response'>, errors: ?$ReadOnlyArray<Error>) => void,
   +onError: ?(error: Error) => void,
-|};
+};
 
 type PromisifiedMutationConfig<T> = $Rest<MutationConfig<T>, DisabledConfigProps<T>>;
 
@@ -78,7 +78,7 @@ type PromisifiedMutationConfig<T> = $Rest<MutationConfig<T>, DisabledConfigProps
 export function commitMutationAsync<T: MutationParameters>(
   environment: Environment,
   config: PromisifiedMutationConfig<T>,
-): Promise<{| +response: $ElementType<T, 'response'>, +errors: ?$ReadOnlyArray<Error> |}> {
+): Promise<{ +response: $ElementType<T, 'response'>, +errors: ?$ReadOnlyArray<Error> }> {
   return new Promise((resolve, reject) => {
     const enhancedConfig = {
       ...config,

--- a/src/relay/src/types.flow.js
+++ b/src/relay/src/types.flow.js
@@ -8,7 +8,7 @@ import type { RefetchRelayProp } from './createRefetchContainer';
 import type { PaginationRelayProp } from './createPaginationContainer';
 
 // See: https://github.com/facebook/flow/issues/8627
-export type Variables = {| +[string]: $FlowFixMe |};
+export type Variables = { +[string]: $FlowFixMe };
 
 export type RequestNode = $FlowFixMe;
 

--- a/src/relay/src/useLazyLoadQuery.js
+++ b/src/relay/src/useLazyLoadQuery.js
@@ -14,12 +14,12 @@ import type {
 export default function useLazyLoadQuery<TQuery: OperationType>(
   gqlQuery: GraphQLTaggedNode,
   variables?: VariablesOf<TQuery>,
-  options?: {|
+  options?: {
     fetchKey?: string | number,
     fetchPolicy?: FetchPolicy,
     networkCacheConfig?: CacheConfig,
     UNSTABLE_renderPolicy?: RenderPolicy,
-  |},
+  },
 ): $ElementType<TQuery, 'response'> {
   return _useLazyLoadQuery(gqlQuery, variables ?? {}, options);
 }

--- a/src/relay/src/useMutation.js
+++ b/src/relay/src/useMutation.js
@@ -12,7 +12,7 @@ import type {
 
 import type { MutationParameters } from './mutations';
 
-type HookMutationConfig<T: MutationParameters> = {|
+type HookMutationConfig<T: MutationParameters> = {
   // This config is essentially `MutationConfig` type except there are some small differences
   // to make the hook interface more friendly. Feel free to expand it as needed.
   +onCompleted: (
@@ -27,7 +27,7 @@ type HookMutationConfig<T: MutationParameters> = {|
   +updater?: ?(store: RecordSourceSelectorProxy, data: $ElementType<T, 'response'>) => void,
   +configs?: Array<DeclarativeMutationConfig>,
   +uploadables?: UploadableMap,
-|};
+};
 
 /**
  * Usage:

--- a/src/signed-source/CHANGELOG.md
+++ b/src/signed-source/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
 # 2.0.0
 
 Support for Node.js 12 has been removed. This package might continue working on older Node.js versions, however, it's highly recommended upgrading to Node.js version 14 or newer. For more details, see: https://nodejs.org/en/about/releases/, or discuss here: https://github.com/adeira/universe/discussions/1588

--- a/src/sx-design/src/Emoji/Emoji.js
+++ b/src/sx-design/src/Emoji/Emoji.js
@@ -2,10 +2,10 @@
 
 import * as React from 'react';
 
-type Props = {|
+type Props = {
   +label: FbtWithoutString,
   +symbol: string,
-|};
+};
 
 export default function Emoji(props: Props): React.Node {
   return (

--- a/src/sx-design/src/ErrorBoundary/ErrorBoundary.js
+++ b/src/sx-design/src/ErrorBoundary/ErrorBoundary.js
@@ -8,18 +8,18 @@ import Heading from '../Heading/Heading';
 import Section from '../Section/Section';
 import windowLocationReload from './windowLocationReload';
 
-type Props = {|
+type Props = {
   +children: Node,
   +title?: FbtWithoutString,
   +code?: string,
   +onComponentDidCatch?: (Error, { componentStack: string, ... }) => void,
   +onRetry?: () => void,
-|};
+};
 
-type State = {|
+type State = {
   +hasError: boolean,
   +error: Error | null,
-|};
+};
 
 export default class ErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {

--- a/src/sx-design/src/Heading/Heading.js
+++ b/src/sx-design/src/Heading/Heading.js
@@ -5,10 +5,10 @@ import sx, { type AllCSSProperties } from '@adeira/sx';
 
 import HeadingLevel from '../HeadingLevel';
 
-type Props = {|
+type Props = {
   +children: React.Node,
   +xstyle?: AllCSSProperties,
-|};
+};
 
 /**
  * Heading component automatically renders the right `h[1-6]` HTML element based on the location in

--- a/src/sx-design/src/Kbd/Kbd.js
+++ b/src/sx-design/src/Kbd/Kbd.js
@@ -10,9 +10,9 @@ const keyMap = {
   SHIFT: 'Shift',
 };
 
-type Props = {|
+type Props = {
   +code: $Keys<typeof keyMap>,
-|};
+};
 
 /**
  * This component provides KBD element rendering single keyboard key. It tries to render the correct

--- a/src/sx-design/src/Link/Link.js
+++ b/src/sx-design/src/Link/Link.js
@@ -3,13 +3,13 @@
 import * as React from 'react';
 import sx, { type AllCSSProperties } from '@adeira/sx';
 
-type Props = {|
+type Props = {
   +href: string,
   +children: React.Node,
   +target?: string,
   +isActive?: boolean,
   +xstyle?: AllCSSProperties,
-|};
+};
 
 /**
  * This component tries to create a normal `<a />` link with some reasonable default styles for

--- a/src/sx-design/src/LinkButton/LinkButton.js
+++ b/src/sx-design/src/LinkButton/LinkButton.js
@@ -3,12 +3,12 @@
 import * as React from 'react';
 import sx, { type AllCSSProperties } from '@adeira/sx';
 
-type Props = {|
+type Props = {
   +onClick: () => void,
   +children: React.Node,
   +isActive?: boolean,
   +xstyle?: AllCSSProperties,
-|};
+};
 
 /**
  * Stylistically similar to <Link /> except it renders a button and expects `onClick` instead of

--- a/src/sx-design/src/Money/Money.js
+++ b/src/sx-design/src/Money/Money.js
@@ -6,10 +6,10 @@ import sx from '@adeira/sx';
 import type { SupportedCurrencies, SupportedLocales } from '../constants';
 import useSxDesignContext from '../useSxDesignContext';
 
-type MoneyProps = {|
+type MoneyProps = {
   +priceUnitAmount: number,
   +priceUnitAmountCurrency: SupportedCurrencies,
-|};
+};
 
 export default function Money(props: MoneyProps): React.Node {
   const sxDesign = useSxDesignContext();
@@ -30,11 +30,11 @@ const styles = sx.create({
   },
 });
 
-type MoneyFnProps = {|
+type MoneyFnProps = {
   +priceUnitAmount: number,
   +priceUnitAmountCurrency: SupportedCurrencies,
   +locale: SupportedLocales,
-|};
+};
 
 // This function does essentially the same like the React <Money /> component except it can be
 // called from non-React environment.

--- a/src/sx-design/src/ProductCard/ProductCard.js
+++ b/src/sx-design/src/ProductCard/ProductCard.js
@@ -11,14 +11,14 @@ import Heading from '../Heading/Heading';
 import Money from '../Money/Money';
 import type { SupportedCurrencies } from '../constants';
 
-type Props = {|
+type Props = {
   +title: Fbt,
   +priceUnitAmount: number,
   +priceUnitAmountCurrency: SupportedCurrencies,
   +imgBlurhash?: string,
   +imgSrc?: string,
   +imgAlt?: Fbt,
-|};
+};
 
 /**
  * This component display product card with product title and product price. The recommended usage

--- a/src/sx-design/src/Section/Section.js
+++ b/src/sx-design/src/Section/Section.js
@@ -5,10 +5,10 @@ import sx, { type AllCSSProperties } from '@adeira/sx';
 
 import HeadingLevel from '../HeadingLevel';
 
-type Props = {|
+type Props = {
   +children: React.Node,
   +xstyle?: AllCSSProperties,
-|};
+};
 
 /**
  * Section component is used to automatically advance Heading component level.

--- a/src/sx-design/src/SkipLink/SkipLink.js
+++ b/src/sx-design/src/SkipLink/SkipLink.js
@@ -3,9 +3,9 @@
 import * as React from 'react';
 import sx from '@adeira/sx';
 
-type Props = {|
+type Props = {
   +text: FbtWithoutString,
-|};
+};
 
 // https://web.dev/headings-and-landmarks/#bypass-repetitive-content-with-skip-links
 export default function SkipLink(props: Props): React.Node {

--- a/src/sx-design/src/SxDesignContext.js
+++ b/src/sx-design/src/SxDesignContext.js
@@ -4,10 +4,10 @@ import React, { type Context } from 'react';
 
 import type { SupportedLocales } from './constants';
 
-export type SxDesignContextValue = {|
+export type SxDesignContextValue = {
   +locale: SupportedLocales,
   +theme?: 'light' | 'dark' | 'system',
-|};
+};
 
 export default (React.createContext(
   // We could make it optional by providing some reasonable default values. However, since

--- a/src/sx-design/src/SxDesignProvider.js
+++ b/src/sx-design/src/SxDesignProvider.js
@@ -8,11 +8,11 @@ import SxDesignContext from './SxDesignContext';
 import SxDesignProviderCSSVariables from './SxDesignProviderCSSVariables';
 import type { SupportedLocales } from './constants';
 
-type Props = {|
+type Props = {
   +children: Node,
   +locale?: SupportedLocales,
   +theme?: 'light' | 'dark' | 'system',
-|};
+};
 
 export default function SxDesignProvider(props: Props): Node {
   const locale = props.locale ?? 'en-US';

--- a/src/sx-tailwind-website/src/components/Code.js
+++ b/src/sx-tailwind-website/src/components/Code.js
@@ -2,9 +2,9 @@
 
 import type { Node } from 'react';
 
-type Props = {|
+type Props = {
   +children: Node,
-|};
+};
 
 export default function Code({ children }: Props): Node {
   return (

--- a/src/sx-tailwind-website/src/components/CodeBlock.js
+++ b/src/sx-tailwind-website/src/components/CodeBlock.js
@@ -9,11 +9,11 @@ import bash from 'refractor/lang/bash';
 refractor.register(jsx);
 refractor.register(bash);
 
-type Props = {|
+type Props = {
   +children: Node,
   +language?: 'jsx' | 'bash',
   +attached?: boolean,
-|};
+};
 
 export default function SyntaxHighlighter({
   children,

--- a/src/sx-tailwind-website/src/components/H2.js
+++ b/src/sx-tailwind-website/src/components/H2.js
@@ -2,9 +2,9 @@
 
 import type { Node } from 'react';
 
-type Props = {|
+type Props = {
   +children: Node,
-|};
+};
 
 export default function H2({ children }: Props): Node {
   return (

--- a/src/sx-tailwind-website/src/components/Layout.js
+++ b/src/sx-tailwind-website/src/components/Layout.js
@@ -7,10 +7,10 @@ import MainContent from './MainContent';
 import Overlay from './sidebar/Overlay';
 import { SidebarContext } from './sidebar/Context';
 
-type Props = {|
+type Props = {
   +title: string,
   +children: Node,
-|};
+};
 
 export default function Layout({ title, children }: Props): Node {
   const { isOpen } = useContext(SidebarContext);

--- a/src/sx-tailwind-website/src/components/Link.js
+++ b/src/sx-tailwind-website/src/components/Link.js
@@ -2,10 +2,10 @@
 
 import type { Node } from 'react';
 
-type Props = {|
+type Props = {
   +href: string,
   +children: Node,
-|};
+};
 
 export default function Link({ href, children }: Props): Node {
   return (

--- a/src/sx-tailwind-website/src/components/MainContent.js
+++ b/src/sx-tailwind-website/src/components/MainContent.js
@@ -4,10 +4,10 @@ import type { Node } from 'react';
 
 import Hamburger from './sidebar/Hamburger';
 
-type Props = {|
+type Props = {
   +title: string,
   +children: Node,
-|};
+};
 
 export default function MainContent({ title, children }: Props): Node {
   return (

--- a/src/sx-tailwind-website/src/components/P.js
+++ b/src/sx-tailwind-website/src/components/P.js
@@ -2,9 +2,9 @@
 
 import type { Node } from 'react';
 
-type Props = {|
+type Props = {
   +children: Node,
-|};
+};
 
 export default function P({ children }: Props): Node {
   return <p sxt="text-gray-700 mb-4">{children}</p>;

--- a/src/sx-tailwind-website/src/components/Showcase.js
+++ b/src/sx-tailwind-website/src/components/Showcase.js
@@ -4,10 +4,10 @@ import type { Node } from 'react';
 
 import CodeBlock from './CodeBlock';
 
-type Props = {|
+type Props = {
   +children: Node,
   +code: string,
-|};
+};
 
 export default function Showcase({ children, code }: Props): Node {
   return (

--- a/src/sx-tailwind-website/src/components/Sidebar.js
+++ b/src/sx-tailwind-website/src/components/Sidebar.js
@@ -4,15 +4,15 @@ import type { Node } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 
-type Props = {|
+type Props = {
   +screenSize?: 'small' | 'large',
-|};
+};
 
-type MenuItemProps = {|
+type MenuItemProps = {
   +label: string,
   +href: string,
   +screenSize: 'small' | 'large',
-|};
+};
 
 function MenuItem({ label, href, screenSize }: MenuItemProps): Node {
   const router = useRouter();

--- a/src/sx-tailwind-website/src/components/sidebar/Context.js
+++ b/src/sx-tailwind-website/src/components/sidebar/Context.js
@@ -2,15 +2,15 @@
 
 import { createContext, useState, useMemo, type Context, type Node } from 'react';
 
-type Props = {|
+type Props = {
   +children: Node,
-|};
+};
 
-type State = {|
+type State = {
   isOpen: boolean,
   open: () => void,
   close: () => void,
-|};
+};
 
 export const SidebarContext: Context<State> = createContext({
   isOpen: false,

--- a/src/sx-tailwind-website/src/components/sidebar/Overlay.js
+++ b/src/sx-tailwind-website/src/components/sidebar/Overlay.js
@@ -4,9 +4,9 @@ import { useContext, type Node } from 'react';
 
 import { SidebarContext } from './Context';
 
-type Props = {|
+type Props = {
   +children: Node,
-|};
+};
 
 export default function Overlay({ children }: Props): Node {
   return (

--- a/src/sx-tailwind-website/src/pages/_document.js
+++ b/src/sx-tailwind-website/src/pages/_document.js
@@ -4,11 +4,11 @@ import type { Node, Element } from 'react';
 import Document, { Head, Main, NextScript, type DocumentContext } from 'next/document';
 import sx from '@adeira/sx';
 
-type RenderPageResult = {|
+type RenderPageResult = {
   +html: string,
   +head: $ReadOnlyArray<Node>,
   +styles: $ReadOnlyArray<any>,
-|};
+};
 
 export default class MyDocument extends Document {
   static getInitialProps(ctx: DocumentContext): RenderPageResult {

--- a/src/sx-tailwind/src/sxTailwind.js
+++ b/src/sx-tailwind/src/sxTailwind.js
@@ -2,7 +2,7 @@
 
 import levenshtein from 'fast-levenshtein';
 
-export function suggestUtility(className: string, styles: {| +[string]: any |}): string {
+export function suggestUtility(className: string, styles: { +[string]: any }): string {
   return Object.keys(styles).sort((first, second) => {
     const firstScore = levenshtein.get(className, first);
     const secondScore = levenshtein.get(className, second);

--- a/src/sx-tailwind/src/tailwindToSx.js
+++ b/src/sx-tailwind/src/tailwindToSx.js
@@ -14,12 +14,12 @@ import purgeUnusedStyles from 'tailwindcss/lib/lib/purgeUnusedStyles';
 import processPlugins from 'tailwindcss/lib/util/processPlugins';
 import corePlugins from 'tailwindcss/lib/corePlugins';
 
-type SxTailwindDefinitions = {|
-  +keyframes: {| +[string]: any |},
-  +styles: {| +[string]: any |},
-|};
+type SxTailwindDefinitions = {
+  +keyframes: { +[string]: any },
+  +styles: { +[string]: any },
+};
 
-export function generateTailwind(config: {| +[string]: any |}): Promise<SxTailwindDefinitions> {
+export function generateTailwind(config: { +[string]: any }): Promise<SxTailwindDefinitions> {
   return convert(
     ` @tailwind base;
       @tailwind components;
@@ -31,7 +31,7 @@ export function generateTailwind(config: {| +[string]: any |}): Promise<SxTailwi
 
 export default async function convert(
   css: string,
-  tailwindConfig: {| +[string]: any |},
+  tailwindConfig: { +[string]: any },
 ): Promise<SxTailwindDefinitions> {
   const processor = getTailwindProcessor(tailwindConfig);
   const postCss = await processor.process(css, { from: '' });

--- a/src/sx/__flowtests__/sx-composability.js
+++ b/src/sx/__flowtests__/sx-composability.js
@@ -6,10 +6,10 @@ import sx, { type AllCSSProperties } from '../index';
 
 // fileA.js
 
-type Props = {|
+type Props = {
   +xstyle: AllCSSProperties,
   +ystyle: AllCSSProperties,
-|};
+};
 
 const internalStyles = sx.create({ default: { fontSize: 16 } });
 export function MyBaseComponent(props: Props): Node {

--- a/src/sx/src/StyleCollector.js
+++ b/src/sx/src/StyleCollector.js
@@ -41,9 +41,9 @@ class StyleCollector {
   #styleBuffer: StyleBufferType = new Map();
   #keyframes: Map<string, string> = new Map();
 
-  collect(baseStyleSheet: {|
+  collect(baseStyleSheet: {
     +[sheetName: string]: $FlowFixMe,
-  |}): {| +hashRegistry: HashRegistryType, +styleBuffer: StyleBufferType |} {
+  }): { +hashRegistry: HashRegistryType, +styleBuffer: StyleBufferType } {
     const hashRegistry: HashRegistryType = new Map();
 
     const traverse = (styleSheetName, styleSheetObject, styleBuffer, hashSeed = '') => {

--- a/src/sx/src/StyleCollectorNodeInterface.js
+++ b/src/sx/src/StyleCollectorNodeInterface.js
@@ -1,10 +1,10 @@
 // @flow strict
 
-export type PrintConfig = {|
+export type PrintConfig = {
   +pseudo?: string,
   +bumpSpecificity?: boolean,
   +trailingSemicolon?: boolean, // https://github.com/thysultan/stylis.js/issues/250
-|};
+};
 
 export interface StyleCollectorNodeInterface {
   addNodes(nodes: Map<string, StyleCollectorNodeInterface>): void;

--- a/src/sx/src/create.js
+++ b/src/sx/src/create.js
@@ -11,22 +11,22 @@ import type { AllCSSPseudoTypes } from './css-properties/__generated__/AllCSSPse
 type CSSVariableValue = string;
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries
-type MediaQueries = {|
+type MediaQueries = {
   ...AllCSSPropertyTypes,
   ...AllCSSPseudoTypes,
   +[string]: MediaQueries | CSSVariableValue, // media queries can be recursively nested or have extra CSS variables
-|};
+};
 
-export type AllCSSProperties = {|
+export type AllCSSProperties = {
   ...AllCSSPropertyTypes,
   ...AllCSSPseudoTypes,
   // we are unable to statically typecheck the key because it can be almost anything (@media, CSS variable, …)
   +[string]: MediaQueries | CSSVariableValue,
-|};
+};
 
-export type SheetDefinitions = {|
+export type SheetDefinitions = {
   +[sheetName: string]: AllCSSProperties,
-|};
+};
 
 function suggest(sheetDefinitionName: string, alternativeNames: Array<string>): string {
   return alternativeNames.sort((firstEl, secondEl) => {
@@ -36,11 +36,11 @@ function suggest(sheetDefinitionName: string, alternativeNames: Array<string>): 
   })[0];
 }
 
-type CreateReturnType<T> = {|
+type CreateReturnType<T> = {
   (...$ReadOnlyArray<?$Keys<T> | false>): string, // conditional strings `styles(isRed && 'red')`
-  ({| +[$Keys<T>]: boolean |}): string, // conditional object `styles({ red: isRed })`
+  ({ +[$Keys<T>]: boolean }): string, // conditional object `styles({ red: isRed })`
   +[$Keys<T>]: AllCSSProperties, // for external styles merging
-|};
+};
 
 export default function create<T: SheetDefinitions>(sheetDefinitions: T): CreateReturnType<T> {
   invariant(

--- a/src/sx/src/css-properties/__generated__/AllCSSPropertyTypes.js
+++ b/src/sx/src/css-properties/__generated__/AllCSSPropertyTypes.js
@@ -1,12 +1,12 @@
 /**
- * @generated SignedSource<<e1cef639311b427a222ff7769e0b7998>>
+ * @generated SignedSource<<3a9757ef3b43899c54fb79eef9f21de1>>
  * @flow strict
  *
  * @see https://www.w3.org/Style/CSS/all-properties.en.html
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Values_and_Units
  */
 
-export type AllCSSPropertyTypes = {|
+export type AllCSSPropertyTypes = {
   +webkitLineClamp?: 'none' | number | 'inherit' | 'initial' | 'unset', // https://developer.mozilla.org/docs/Web/CSS/-webkit-line-clamp
   +alignContent?: number | string, // https://developer.mozilla.org/docs/Web/CSS/align-content
   +alignItems?: number | string, // https://developer.mozilla.org/docs/Web/CSS/align-items
@@ -751,4 +751,4 @@ export type AllCSSPropertyTypes = {|
     | 'initial'
     | 'unset',
   +zIndex?: 'auto' | number | 'inherit' | 'initial' | 'unset', // https://developer.mozilla.org/docs/Web/CSS/z-index
-|};
+};

--- a/src/sx/src/css-properties/__generated__/AllCSSPseudoTypes.js
+++ b/src/sx/src/css-properties/__generated__/AllCSSPseudoTypes.js
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a69d430535b3997b17c340b1e6a1090a>>
+ * @generated SignedSource<<e61f9f1a121ea8385f0d9327c817f662>>
  * @flow strict
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
@@ -8,7 +8,7 @@
 
 import type { AllCSSPropertyTypes } from './AllCSSPropertyTypes';
 
-export type AllCSSPseudoTypes = {|
+export type AllCSSPseudoTypes = {
   +':active'?: AllCSSPropertyTypes, // https://developer.mozilla.org/docs/Web/CSS/:active
   +':any-link'?: AllCSSPropertyTypes, // https://developer.mozilla.org/docs/Web/CSS/:any-link
   +':checked'?: AllCSSPropertyTypes, // https://developer.mozilla.org/docs/Web/CSS/:checked
@@ -80,4 +80,4 @@ export type AllCSSPseudoTypes = {|
   +'::selection'?: AllCSSPropertyTypes, // https://developer.mozilla.org/docs/Web/CSS/::selection
   +'::slotted'?: AllCSSPropertyTypes, // https://developer.mozilla.org/docs/Web/CSS/::slotted
   +'::spelling-error'?: AllCSSPropertyTypes, // https://developer.mozilla.org/docs/Web/CSS/::spelling-error
-|};
+};

--- a/src/sx/src/css-properties/generatePropertyTypes.js
+++ b/src/sx/src/css-properties/generatePropertyTypes.js
@@ -64,9 +64,9 @@ export default function generatePropertyTypes(cb: (string) => void): void {
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Values_and_Units
  */
 
-export type AllCSSPropertyTypes = {|
+export type AllCSSPropertyTypes = {
   ${flowPrint}
-|};
+};
 `);
 
   return prettify(template, cb);

--- a/src/sx/src/css-properties/generatePseudoTypes.js
+++ b/src/sx/src/css-properties/generatePseudoTypes.js
@@ -34,9 +34,9 @@ export default function generatePseudoTypes(cb: (string) => void): void {
 
 import type { AllCSSPropertyTypes } from './AllCSSPropertyTypes';
 
-export type AllCSSPseudoTypes = {|
+export type AllCSSPseudoTypes = {
   ${flowPseudoPrint}
-|};
+};
 `);
 
   return prettify(template, cb);

--- a/src/sx/src/keyframes.js
+++ b/src/sx/src/keyframes.js
@@ -10,11 +10,11 @@ import transformStyleName from './transformStyleName';
 import transformStyleValue from './transformValue';
 import { injectRuntimeKeyframes } from './injectRuntimeStyles';
 
-type KeyFrames = {|
+type KeyFrames = {
   +from?: AllCSSPropertyTypes,
   +to?: AllCSSPropertyTypes,
   +[string]: AllCSSPropertyTypes,
-|};
+};
 
 const extractStyles = (styles: AllCSSPropertyTypes) => {
   let cssDefinition = '';

--- a/src/sx/src/renderPageWithSX.js
+++ b/src/sx/src/renderPageWithSX.js
@@ -5,11 +5,11 @@ import { compile, serialize, stringify, prefixer, middleware } from 'stylis';
 
 import StyleCollector from './StyleCollector';
 
-type RenderPageResult = {|
+type RenderPageResult = {
   +html: string,
   +head: $ReadOnlyArray<Node>,
   +styles: $ReadOnlyArray<any>,
-|};
+};
 
 // Note: this is currently a bit Next.js centric, we can make it more abstract later
 export default function renderPageWithSX(renderPage: () => any): RenderPageResult {

--- a/src/ya-comiste-backoffice/src/Layout.js
+++ b/src/ya-comiste-backoffice/src/Layout.js
@@ -7,9 +7,9 @@ import { fbt } from 'fbt';
 
 import Navigation from './Navigation';
 
-type Props = {|
+type Props = {
   +children: Node,
-|};
+};
 
 export default function Layout(props: Props): Node {
   return (

--- a/src/ya-comiste-backoffice/src/LayoutHeading.js
+++ b/src/ya-comiste-backoffice/src/LayoutHeading.js
@@ -7,12 +7,12 @@ import LayoutHeadingButton from './LayoutHeadingButton';
 import LayoutHeadingLink from './LayoutHeadingLink';
 import StatusBar from './StatusBar';
 
-type Props = {|
+type Props = {
   +heading?: Node,
   +children?: ChildrenArray<
     RestrictedElement<typeof LayoutHeadingLink> | Element<typeof LayoutHeadingButton>,
   >,
-|};
+};
 
 export default function LayoutHeading(props: Props): Node {
   return (

--- a/src/ya-comiste-backoffice/src/LayoutHeadingButton.js
+++ b/src/ya-comiste-backoffice/src/LayoutHeadingButton.js
@@ -5,12 +5,12 @@ import sx, { type AllCSSProperties } from '@adeira/sx';
 
 import LinkButton from './LinkButton';
 
-type Props = {|
+type Props = {
   +onClick: () => void,
   +confirmMessage: FbtWithoutString,
   +children: FbtWithoutString,
   +xstyle?: AllCSSProperties,
-|};
+};
 
 // creates <button onClick="…" />
 export default function LayoutHeadingButton(props: Props): Node {

--- a/src/ya-comiste-backoffice/src/LayoutHeadingLink.js
+++ b/src/ya-comiste-backoffice/src/LayoutHeadingLink.js
@@ -5,10 +5,10 @@ import sx from '@adeira/sx';
 
 import Link from './Link';
 
-type Props = {|
+type Props = {
   +href: string,
   +children: FbtWithoutString,
-|};
+};
 
 // creates <a href="…" />
 export default function LayoutHeadingLink(props: Props): Node {

--- a/src/ya-comiste-backoffice/src/Link.js
+++ b/src/ya-comiste-backoffice/src/Link.js
@@ -5,14 +5,14 @@ import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import sx, { type AllCSSProperties } from '@adeira/sx';
 
-type Props = {|
+type Props = {
   +href: string,
   +children: React.Node,
   +xstyle?: AllCSSProperties,
   +xstyleActive?: AllCSSProperties,
   +target?: '_blank',
   +disabled?: boolean,
-|};
+};
 
 export default function Link(props: Props): React.Node {
   const router = useRouter();

--- a/src/ya-comiste-backoffice/src/LinkButton.js
+++ b/src/ya-comiste-backoffice/src/LinkButton.js
@@ -3,11 +3,11 @@
 import * as React from 'react';
 import sx, { type AllCSSProperties } from '@adeira/sx';
 
-type Props = {|
+type Props = {
   +onClick: () => void,
   +children: React.Node,
   +xstyle?: AllCSSProperties,
-|};
+};
 
 export default function LinkButton(props: Props): React.Node {
   return (

--- a/src/ya-comiste-backoffice/src/pos/POSCheckoutSummary.js
+++ b/src/ya-comiste-backoffice/src/pos/POSCheckoutSummary.js
@@ -6,9 +6,9 @@ import React, { type Node } from 'react';
 
 import useSelectedItemsApi from './recoil/selectedItemsState';
 
-type Props = {|
+type Props = {
   +tint: string,
-|};
+};
 
 export default function POSCheckoutSummary(props: Props): Node {
   const { stats, selectedItems } = useSelectedItemsApi();

--- a/src/ya-comiste-backoffice/src/pos/recoil/selectedItemsState.js
+++ b/src/ya-comiste-backoffice/src/pos/recoil/selectedItemsState.js
@@ -6,12 +6,12 @@ import { atom, selector, useRecoilState, DefaultValue, useRecoilValue } from 're
 
 /* global window */
 
-export type AtomItemType = {|
+export type AtomItemType = {
   +itemID: string,
   +itemTitle: string,
   +itemUnitAmount: number,
   +units: number,
-|};
+};
 
 type AtomValue = Immutable.List<AtomItemType>;
 
@@ -44,10 +44,10 @@ const selectedItemsAtom = atom<AtomValue>({
   effects_UNSTABLE: [localStorageEffect('ycbo:selectedItems')],
 });
 
-type SelectorItem = {|
+type SelectorItem = {
   +totalSelectedItems: number,
   +totalPrice: number,
-|};
+};
 
 const selectedItemsStatsSelector = selector<SelectorItem>({
   key: 'selectedItemsStats',
@@ -68,14 +68,14 @@ const selectedItemsStatsSelector = selector<SelectorItem>({
   },
 });
 
-export default function useSelectedItemsApi(): {|
+export default function useSelectedItemsApi(): {
   +selectedItems: AtomValue,
   +select: (AtomItemType) => void,
   +increaseUnits: (string) => void,
   +decreaseUnits: (string) => void,
   +reset: () => void,
   +stats: SelectorItem,
-|} {
+} {
   const [selectedItems, setSelectedItems] = useRecoilState(selectedItemsAtom);
   const selectedItemsStats = useRecoilValue(selectedItemsStatsSelector);
 

--- a/src/ya-comiste-backoffice/src/products/EditProductForm.js
+++ b/src/ya-comiste-backoffice/src/products/EditProductForm.js
@@ -11,9 +11,9 @@ import { uiStatusBarAtom } from '../recoil/uiStatusBarAtom';
 import type { EditProductFormFragment$key } from './__generated__/EditProductFormFragment.graphql';
 import type { EditProductFormMutation } from './__generated__/EditProductFormMutation.graphql';
 
-type Props = {|
+type Props = {
   +product: ?EditProductFormFragment$key,
-|};
+};
 
 export default function EditProductForm(props: Props): Node {
   const [, setFiles] = useState(undefined);

--- a/src/ya-comiste-backoffice/src/products/EditProductHeading.js
+++ b/src/ya-comiste-backoffice/src/products/EditProductHeading.js
@@ -16,9 +16,9 @@ import { uiStatusBarAtom } from '../recoil/uiStatusBarAtom';
 import type { EditProductHeadingDeleteMutation } from './__generated__/EditProductHeadingDeleteMutation.graphql';
 import type { EditProductHeading$key } from './__generated__/EditProductHeading.graphql';
 
-type Props = {|
+type Props = {
   +product: EditProductHeading$key,
-|};
+};
 
 export default function EditProductHeading(props: Props): React.Node {
   const setStatusBar = useSetRecoilState(uiStatusBarAtom);

--- a/src/ya-comiste-backoffice/src/products/EditProductHeadingPublishUnpublish.js
+++ b/src/ya-comiste-backoffice/src/products/EditProductHeadingPublishUnpublish.js
@@ -11,10 +11,10 @@ import { uiStatusBarAtom } from '../recoil/uiStatusBarAtom';
 import type { EditProductHeadingPublishUnpublishPublishMutation } from './__generated__/EditProductHeadingPublishUnpublishPublishMutation.graphql';
 import type { EditProductHeadingPublishUnpublishUnpublishMutation } from './__generated__/EditProductHeadingPublishUnpublishUnpublishMutation.graphql';
 
-type Props = {|
+type Props = {
   +isPublished: boolean,
   +productKey: string,
-|};
+};
 
 export default function EditProductHeadingPublishUnpublish(
   props: Props,

--- a/src/ya-comiste-backoffice/src/products/ProductsEditLayout.js
+++ b/src/ya-comiste-backoffice/src/products/ProductsEditLayout.js
@@ -7,9 +7,9 @@ import EditProductForm from './EditProductForm';
 import EditProductHeading from './EditProductHeading';
 import type { ProductsEditLayoutQuery } from './__generated__/ProductsEditLayoutQuery.graphql';
 
-type Props = {|
+type Props = {
   +productKey: string,
-|};
+};
 
 export default function ProductsEditLayout(props: Props): Node {
   const data = useLazyLoadQuery<ProductsEditLayoutQuery>(

--- a/src/ya-comiste-backoffice/src/products/form/CustomErrorMessage.js
+++ b/src/ya-comiste-backoffice/src/products/form/CustomErrorMessage.js
@@ -3,9 +3,9 @@
 import React, { type Node } from 'react';
 import sx from '@adeira/sx';
 
-type Props = {|
+type Props = {
   +children: Node,
-|};
+};
 
 export default function CustomErrorMessage({ children }: Props): Node {
   return <div className={styles('error')}>{children}</div>;

--- a/src/ya-comiste-backoffice/src/products/form/ProductForm.js
+++ b/src/ya-comiste-backoffice/src/products/form/ProductForm.js
@@ -9,27 +9,27 @@ import { Kbd } from '@adeira/sx-design';
 import createProductFormSchema from '../createProductFormSchema';
 import CustomErrorMessage from './CustomErrorMessage';
 
-export type FormValues = {|
+export type FormValues = {
   +name_en: string,
   +name_es: string,
   +description_en: string,
   +description_es: string,
   +price: string | number,
   +visibility: $ReadOnlyArray<'POS' | 'ESHOP'>,
-|};
+};
 
 // https://formik.org/docs/api/withFormik#the-formikbag
-type FormikBag = {|
-  +resetForm: ({| +values: FormValues |} | void) => void,
+type FormikBag = {
+  +resetForm: ({ +values: FormValues } | void) => void,
   +setSubmitting: (boolean) => void,
-|};
+};
 
-type Props = {|
+type Props = {
   +submitButtonTitle: FbtWithoutString,
   +initialValues: FormValues,
   +onUploadablesChange: (FileList) => void,
   +onSubmit: (FormValues, FormikBag) => void,
-|};
+};
 
 // TODO: https://formik.org/docs/tutorial#reducing-boilerplate
 export default function ProductForm(props: Props): Node {

--- a/src/ya-comiste-backoffice/src/recoil/uiStatusBarAtom.js
+++ b/src/ya-comiste-backoffice/src/recoil/uiStatusBarAtom.js
@@ -3,10 +3,10 @@
 import type { Node } from 'react';
 import { atom, type RecoilState } from 'recoil';
 
-type State = {|
+type State = {
   +message: null | FbtWithoutString | Node,
   +type?: 'SUCCESS' | 'ERROR',
-|};
+};
 
 export const uiStatusBarAtom = (atom({
   key: 'uiStatusBarAtom',

--- a/src/ya-comiste-backoffice/src/useSessionTokenAPI.js
+++ b/src/ya-comiste-backoffice/src/useSessionTokenAPI.js
@@ -4,11 +4,11 @@ import { useSessionStorage } from './useSessionStorage';
 
 /* global window */
 
-type UseSessionTokenAPI = {|
+type UseSessionTokenAPI = {
   +login: (string | null) => void,
   +logout: () => void,
   +sessionToken: string | null,
-|};
+};
 
 export function useSessionTokenAPI(): UseSessionTokenAPI {
   // https://stackoverflow.com/a/40376819/3135248


### PR DESCRIPTION
Flow standard is now to use `{ }` for strict objects and `{ key: value, ... }` for open objects, see: https://github.com/facebook/relay/commit/6fa0b0d83b45af67d086e5b850b4b49915eccb4a and https://github.com/facebook/react-native/commit/00cfb0f919207fcdc8fe8b6c3b7d76591447b91d

This change should be without any problems as longs as users of our NPM libraries are using Flow with `exact_by_default=true` (which is now pretty standard I'd say).

Here is how object types behave before this change:

```
type A = { x: number }; // already "exact" type but disallowed because it would be confusing to mix different syntaxes
type B = { x: number, ... }; // this is inexact
type C = {| x: number |}; // this is explicitly exact and the only allowed way how to describe type "exactness"
```

Here is how object types behave _after_ this change:

```
type A = { x: number }; // this is the only allowed syntax for "exact" type
type B = { x: number, ... }; // this is still inexact
type C = {| x: number |}; // this is also exact but no longer allowed (so it's not confusing)
```

Some related (non-blocking) issues:

- https://github.com/gajus/eslint-plugin-flowtype/issues/467
- https://github.com/facebook/flow/issues/8612

TODO:

- [x] [backward compatibility: what about exported NPM libs with these new types](https://github.com/mrtnzlml/test-flow-exact-by-default-compatibility)
- [x] coordinate with next major Eslint Config release: https://github.com/adeira/universe/pull/2159