### PR TITLE
Relay: relax compiler schema signature requirements

### DIFF
--- a/src/relay/CHANGELOG.md
+++ b/src/relay/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - removed required `X-Client` HTTP header from `createNetworkFetcher` (you can still use it but it's no longer mandatory)
+- relax signature verification when using `adeira-relay-compiler` - it no longer requires the signature but still verifies it if it exists
 
 # 3.1.1
 

--- a/src/relay/src/compiler/__tests__/__snapshots__/getSchemaSource.test.js.snap
+++ b/src/relay/src/compiler/__tests__/__snapshots__/getSchemaSource.test.js.snap
@@ -2,12 +2,6 @@
 
 exports[`loads the fixture as expected 1`] = `
 "
-Schema 'invalidSignatureSchema.schema.txt' has invalid signature! Did you do some manual changes? Download a fresh schema using 'adeira-fetch-schema' script.
-"
-`;
-
-exports[`loads the fixture as expected 2`] = `
-"
-Schema 'missingSignatureSchema.graphql.txt' cannot be verified because it's missing a valid signature! Download a fresh schema using 'adeira-fetch-schema' script.
+Schema 'invalidSignatureSchema.schema.txt' has invalid signature! Did you do some manual changes? You can download a fresh schema using 'adeira-fetch-schema' script.
 "
 `;

--- a/src/relay/src/compiler/getSchemaSource.js
+++ b/src/relay/src/compiler/getSchemaSource.js
@@ -4,19 +4,19 @@ import fs from 'fs';
 import SignedSource from '@adeira/signed-source';
 import { Source } from 'graphql';
 
+/**
+ * Returns extended GraphQL schema from the path. It optionally checks whether the schema is signed
+ * via `@adeira/signed-source` and validates the signature if yes.
+ */
 export default function getSchemaSource(schemaPath: string): Source {
   let source = fs.readFileSync(schemaPath, 'utf8');
 
-  if (!SignedSource.isSigned(source)) {
-    throw new Error(
-      `Schema '${schemaPath}' cannot be verified because it's missing a valid signature! Download a fresh schema using 'adeira-fetch-schema' script.`,
-    );
-  }
-
-  if (!SignedSource.verifySignature(source)) {
-    throw new Error(
-      `Schema '${schemaPath}' has invalid signature! Did you do some manual changes? Download a fresh schema using 'adeira-fetch-schema' script.`,
-    );
+  if (SignedSource.isSigned(source)) {
+    if (!SignedSource.verifySignature(source)) {
+      throw new Error(
+        `Schema '${schemaPath}' has invalid signature! Did you do some manual changes? You can download a fresh schema using 'adeira-fetch-schema' script.`,
+      );
+    }
   }
 
   source = `


### PR DESCRIPTION
Before:

- always required signed schema
- always validated the signature

After:

- does not require the schema signature
- verifies the signature only if it exists