### PR TITLE
SX Design: implement dark mode for ProductCard component

### DIFF
--- a/src/sx-design/README.md
+++ b/src/sx-design/README.md
@@ -40,36 +40,34 @@ The error boundary is optional but highly recommended.
 
 ## Styles customization
 
-SX Design leverages full power of [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) as a main way of style customization ([CSS Variables: Why Should You Care?](https://developers.google.com/web/updates/2016/02/css-variables-why-should-you-care)). You can optionally adjust the values if you want from your application. Here are some default values:
+SX Design leverages full power of [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) as a main way of style customization. You can optionally adjust the values if you want from your application. Here are some component specific default values (not dependent on dark mode):
 
-```css
-.common {
-  /* component specific vars: */
-  --sx-kbd-border: '1px solid #b4b4b4';
-  --sx-skipLink-background-color: '28, 30, 33';
-  --sx-skipLink-text-color: '255, 255, 255';
-}
+<!-- TODO: generate automatically from the source code? -->
+
+```text
+--sx-kbd-border: '1px solid #b4b4b4'
+--sx-money-text-color: var(--sx-text-color) ¹
+--sx-skipLink-background-color: '28, 30, 33' ²
+--sx-skipLink-text-color: '255, 255, 255'
 ```
 
-Default values for light mode:
+Generic default values for light mode:
 
-```css
-.light-theme {
-  --sx-background-color: '255, 255, 255';
-  --sx-text-color: '28, 30, 33';
-}
+```text
+--sx-background-color: '255, 255, 255' ²
+--sx-text-color: '28, 30, 33'
 ```
 
-And finally default values for dark mode:
+And finally generic default values for dark mode:
 
-```css
-.dark-theme {
-  --sx-background-color: '51, 51, 51';
-  --sx-text-color: '255, 255, 255';
-}
+```text
+--sx-background-color: '51, 51, 51' ²
+--sx-text-color: '255, 255, 255'
 ```
 
-[https://caniuse.com/css-variables](https://caniuse.com/css-variables)
+¹ Some CSS variables fallback to default value of some other CSS variable. This allows you to overwrite very specific value if you want or just leave it to the common default.
+
+² All colors are written as triplets of values from 0 to 255 and passed to RGBA function likes so: `rgba(--var)`. This allows us to optionally specify an alpha channel when needed: `rgba(--var, 0.5)`.
 
 ## Available components
 
@@ -88,7 +86,7 @@ Legend:
 | `<Heading />`       |     ✅     |     🧐     |     🧐      |      🧐      |   ✅    |
 | `<Kbd />`           |     ✅     |     ✅     |     🧐      |      ✅      |   ✅    |
 | `<Money />`         |     ✅     |     ✅     |     🧐      |      🧐      |   ✅    |
-| `<ProductCard />`   |     🧐     |     🧐     |     🧐      |      ✅      |   🧐    |
+| `<ProductCard />`   |     ✅     |     ✅     |     🧐      |      ✅      |   🧐    |
 | `<Section />`       |     ✅     |     🧐     |     🧐      |      🧐      |   🧐    |
 | `<Skeleton />`      |     ✅     |     🧐     |     🧐      |      ✅      |   🧐    |
 | `<SkipLink />`      |     ✅     |     🧐     |     🧐      |      🧐      |   🧐    |

--- a/src/sx-design/src/Kbd/Kbd.js
+++ b/src/sx-design/src/Kbd/Kbd.js
@@ -28,7 +28,7 @@ export default function Kbd(props: Props): Node {
 const styles = sx.create({
   kbd: {
     borderRadius: '3px',
-    border: 'var(--sx-kbd-border)',
+    border: 'var(--sx-kbd-border, 1px solid #b4b4b4)',
     color: 'rgba(var(--sx-text-color))',
     display: 'inline-block',
     fontSize: '0.85em',

--- a/src/sx-design/src/Money/Money.js
+++ b/src/sx-design/src/Money/Money.js
@@ -6,10 +6,12 @@ import sx from '@adeira/sx';
 import type { SupportedCurrencies, SupportedLocales } from '../constants';
 import useSxDesignContext from '../useSxDesignContext';
 
-export default function Money(props: {|
+type MoneyProps = {|
   +priceUnitAmount: number,
   +priceUnitAmountCurrency: SupportedCurrencies,
-|}): React.Node {
+|};
+
+export default function Money(props: MoneyProps): React.Node {
   const sxDesign = useSxDesignContext();
   return (
     <span className={styles('text')}>
@@ -21,22 +23,25 @@ export default function Money(props: {|
   );
 }
 
-// This function does essentially the same like the React <Money /> component except it can be
-// called from non-React environment.
-export function MoneyFn(props: {|
+const styles = sx.create({
+  text: {
+    color: 'rgba(var(--sx-money-text-color, var(--sx-text-color)))',
+    transition: 'inherit',
+  },
+});
+
+type MoneyFnProps = {|
   +priceUnitAmount: number,
   +priceUnitAmountCurrency: SupportedCurrencies,
   +locale: SupportedLocales,
-|}): string {
+|};
+
+// This function does essentially the same like the React <Money /> component except it can be
+// called from non-React environment.
+export function MoneyFn(props: MoneyFnProps): string {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat
   return new Intl.NumberFormat(props.locale, {
     style: 'currency',
     currency: props.priceUnitAmountCurrency,
   }).format(props.priceUnitAmount);
 }
-
-const styles = sx.create({
-  text: {
-    color: 'rgba(var(--sx-text-color))',
-  },
-});

--- a/src/sx-design/src/ProductCard/ProductCard.js
+++ b/src/sx-design/src/ProductCard/ProductCard.js
@@ -133,12 +133,16 @@ const styles = sx.create({
     padding: '1rem',
   },
   highlight: {
-    color: 'rgba(var(--sx-text-color))',
-    backgroundColor: 'rgba(var(--sx-background-color))',
+    'color': 'rgba(var(--sx-text-color))',
+    'backgroundColor': 'rgba(var(--sx-background-color))',
+    // $FlowFixMe[incompatible-call] CSS variables are tricky to typecheck in SX
+    '--sx-money-text-color': 'var(--sx-text-color)',
   },
   highlightHover: {
-    color: 'rgba(var(--sx-background-color))',
-    backgroundColor: 'rgba(var(--sx-text-color))',
+    'color': 'rgba(var(--sx-background-color))',
+    'backgroundColor': 'rgba(var(--sx-text-color))',
+    // $FlowFixMe[incompatible-call] CSS variables are tricky to typecheck in SX
+    '--sx-money-text-color': 'var(--sx-background-color)',
   },
   heading: {
     margin: 0,

--- a/src/sx-design/src/SxDesignProvider.js
+++ b/src/sx-design/src/SxDesignProvider.js
@@ -5,6 +5,7 @@ import { init as fbtInit, IntlVariations } from 'fbt';
 import sx from '@adeira/sx';
 
 import SxDesignContext from './SxDesignContext';
+import SxDesignProviderCSSVariables from './SxDesignProviderCSSVariables';
 import type { SupportedLocales } from './constants';
 
 type Props = {|
@@ -54,46 +55,13 @@ export default function SxDesignProvider(props: Props): Node {
   );
 }
 
-/**
- * Check and update README.md as well (TODO: make it automatic or remove from readme)
- *
- * Note: all colors are written using RGB triplet. Why? It's because it allows us to optionally
- * apply alpha channel when needed (https://stackoverflow.com/a/41265350). Usage:
- *
- * ```js
- * { color: 'rgb(var(--sx-text-color))' }
- * ```
- *
- * With optional alpha channel:
- *
- * ```js
- * { color: 'rgb(var(--sx-text-color), 0.5)' }
- * ```
- *
- * TODO: fix $FlowFixMe[incompatible-call] - CSS variables are tricky to typecheck in SX
- */
+/* eslint-disable sx/valid-usage */
 const styles = sx.create({
-  common: {
-    // component specific vars:
-    // $FlowFixMe[incompatible-call]
-    '--sx-kbd-border': '1px solid #b4b4b4',
-    // $FlowFixMe[incompatible-call]
-    '--sx-skipLink-background-color': '28, 30, 33', // #1c1e21
-    // $FlowFixMe[incompatible-call]
-    '--sx-skipLink-text-color': '255, 255, 255', // #ffffff
-  },
-  lightTheme: {
-    // global vars:
-    // $FlowFixMe[incompatible-call]
-    '--sx-background-color': '255, 255, 255', // #ffffff
-    // $FlowFixMe[incompatible-call]
-    '--sx-text-color': '28, 30, 33', // #1c1e21
-  },
-  darkTheme: {
-    // global vars:
-    // $FlowFixMe[incompatible-call]
-    '--sx-background-color': '51, 51, 51', // #333333
-    // $FlowFixMe[incompatible-call]
-    '--sx-text-color': '255, 255, 255', // #ffffff
-  },
+  // $FlowFixMe[incompatible-call] CSS variables are tricky to typecheck in SX
+  common: SxDesignProviderCSSVariables.common,
+  // $FlowFixMe[incompatible-call] CSS variables are tricky to typecheck in SX
+  lightTheme: SxDesignProviderCSSVariables.lightTheme,
+  // $FlowFixMe[incompatible-call] CSS variables are tricky to typecheck in SX
+  darkTheme: SxDesignProviderCSSVariables.darkTheme,
 });
+/* eslint-enable sx/valid-usage */

--- a/src/sx-design/src/SxDesignProviderCSSVariables.js
+++ b/src/sx-design/src/SxDesignProviderCSSVariables.js
@@ -1,0 +1,33 @@
+/**
+ * Check and update README.md as well!
+ *
+ * Note: all colors are written using RGB triplet. Why? It's because it allows us to optionally
+ * apply alpha channel when needed (https://stackoverflow.com/a/41265350). Usage:
+ *
+ * ```js
+ * { color: 'rgb(var(--sx-text-color))' }
+ * ```
+ *
+ * With optional alpha channel:
+ *
+ * ```js
+ * { color: 'rgb(var(--sx-text-color), 0.5)' }
+ * ```
+ *
+ * @flow
+ */
+
+export default {
+  common: {
+    '--sx-skipLink-background-color': '28, 30, 33', // #1c1e21
+    '--sx-skipLink-text-color': '255, 255, 255', // #ffffff
+  },
+  lightTheme: {
+    '--sx-background-color': '255, 255, 255', // #ffffff
+    '--sx-text-color': '28, 30, 33', // #1c1e21
+  },
+  darkTheme: {
+    '--sx-background-color': '51, 51, 51', // #333333
+    '--sx-text-color': '255, 255, 255', // #ffffff
+  },
+};


### PR DESCRIPTION
Basically, the only missing piece was to overwrite the Money component styles via CSS variable.