### PR TITLE
Kochka: Flow bin version unification

### DIFF
--- a/src/kochka.com.mx/package.json
+++ b/src/kochka.com.mx/package.json
@@ -40,7 +40,7 @@
     "@axe-core/react": "^4.1.1",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.22.0",
-    "flow-bin": "^0.146.0",
+    "flow-bin": "^0.147.0",
     "jest": "^26.6.3",
     "prettier": "^2.2.1"
   }


### PR DESCRIPTION
For some reason there was not used the same version of `flow-bin` as it is in the rest of Universe repo.