### PR TITLE
CI: use latest Bazelisk version 1.7.5

### DIFF
--- a/.github/workflows/continuous-integration-bazel.yml
+++ b/.github/workflows/continuous-integration-bazel.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Install bazelisk
         run: |
-          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.6.1/bazelisk-linux-amd64"
+          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.7.5/bazelisk-linux-amd64"
           mkdir -p "${GITHUB_WORKSPACE}/bin/"
           mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
           chmod +x "${GITHUB_WORKSPACE}/bin/bazel"


### PR DESCRIPTION
See:

- https://github.com/bazelbuild/bazelisk/releases/tag/v1.7.0
- https://github.com/bazelbuild/bazelisk/releases/tag/v1.7.5