### PR TITLE
Kodiak: Improved automerge setup

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,7 +1,7 @@
 version = 1
 
 [merge]
-automerge_label = "automerge"
+automerge_label = ["automerge", "automerge priority"]
 priority_merge_label = "automerge priority"
 require_automerge_label = true
 method = "rebase"


### PR DESCRIPTION
This could make "automerge priority" label to work alone.

Currently you have to add "automerge" together with "automerge priority".

See https://kodiakhq.com/docs/config-reference#mergeautomerge_label