### PR TITLE
SX Design: fix '@storybook/addon-actions' dependency version

### DIFF
--- a/src/sx-design/package.json
+++ b/src/sx-design/package.json
@@ -25,7 +25,7 @@
     "@adeira/sx": "^0.25.0",
     "@babel/core": "^7.13.14",
     "@fbtjs/default-collection-transform": "^0.0.2",
-    "@storybook/addon-actions": "^6.1.21",
+    "@storybook/addon-actions": "^6.2.1",
     "@storybook/addon-essentials": "^6.2.1",
     "@storybook/addon-links": "^6.2.1",
     "@storybook/react": "^6.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,7 +2563,7 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@storybook/addon-actions@6.2.1", "@storybook/addon-actions@^6.1.21":
+"@storybook/addon-actions@6.2.1", "@storybook/addon-actions@^6.2.1":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.2.1.tgz#af5924969c691a4fe6ec9266ffefe02b95245063"
   integrity sha512-pRzyJIcso+7FJ4Xv4lJZ/mppFgkdnJ3B/R6QPYl1Enwlxjk2CH2iDD+Hq85WFHGfg5cjtFm3fd9EbPXC09ReeA==


### PR DESCRIPTION
Dependabot sometimes closes the PR prematurely without updating the `package.json` (like in this case: https://github.com/adeira/universe/pull/2107). This PR fixes it.