### PR TITLE
Dependabot: ignore 'relay-compiler-experimental'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
       - 'dependencies'
       - 'automerge' # see Kodiak `merge.automerge_label`
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: 'relay-compiler-experimental'
 
   - package-ecosystem: 'github-actions'
     directory: '/.github/workflows/'


### PR DESCRIPTION
This dependency is by nature unstable, and I'd like to always require a specific "master" version instead of the "latest" version (example of incorrect PR: https://github.com/adeira/universe/pull/2117/files).

See: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#ignore