### PR TITLE
Graphql Global ID: Release 2.0.1

### DIFF
--- a/src/graphql-global-id/CHANGELOG.md
+++ b/src/graphql-global-id/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 2.0.1
+
+Upgrade of peer dependency
+
 # 2.0.0
 
 Support for Node.js 12 has been removed. This package might continue working on older Node.js versions, however, it's highly recommended upgrading to Node.js version 14 or newer. For more details, see: https://nodejs.org/en/about/releases/, or discuss here: https://github.com/adeira/universe/discussions/1588

--- a/src/graphql-global-id/package.json
+++ b/src/graphql-global-id/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/graphql-global-id",
   "license": "MIT",
   "private": false,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "src/index",
   "sideEffects": false,
   "dependencies": {


### PR DESCRIPTION
Just a peer dependency upgrade