### PR TITLE
Lint: fix `react/jsx-no-target-blank` error

### DIFF
--- a/src/sx-design/src/Link/Link.js
+++ b/src/sx-design/src/Link/Link.js
@@ -18,7 +18,6 @@ type Props = {
 export default function Link(props: Props): React.Node {
   const href = props.href;
   const isExternalLink = /^https?:\/\//.test(href);
-  /* eslint-disable react/jsx-no-target-blank */
   return (
     <a
       href={href}
@@ -29,7 +28,6 @@ export default function Link(props: Props): React.Node {
       {props.children}
     </a>
   );
-  /* eslint-enable react/jsx-no-target-blank */
 }
 
 const styles = sx.create({


### PR DESCRIPTION
The behavior of this rule changed in https://github.com/yannickcr/eslint-plugin-react/pull/2953 and we upgraded the plugin in https://github.com/adeira/universe/pull/2172