### PR TITLE
Upgrade `eslint-plugin-flowtype` to the latest version 5.7.1

### DIFF
--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -12,7 +12,7 @@
     "eslint-config-prettier": "^8.2.0",
     "eslint-plugin-adeira": "^0.13.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
-    "eslint-plugin-flowtype": "^5.7.0",
+    "eslint-plugin-flowtype": "^5.7.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.3.5",
     "eslint-plugin-jsx-a11y": "^6.4.1",

--- a/src/kochka.com.mx/src/Layout.js
+++ b/src/kochka.com.mx/src/Layout.js
@@ -36,9 +36,6 @@ export default function Layout(props: Props): React.Node {
 
   return (
     <>
-      {/* https://github.com/gajus/eslint-plugin-flowtype/pull/477 */}
-      {/* https://github.com/gajus/eslint-plugin-flowtype/pull/478 */}
-      {/* eslint-disable-next-line flowtype/require-readonly-react-props */}
       <Head>
         <title>KOCHKA café · {props.title}</title>
       </Head>

--- a/src/sx-design/src/Link/Link.js
+++ b/src/sx-design/src/Link/Link.js
@@ -22,6 +22,7 @@ export default (React.forwardRef(function Link(props, ref) {
   const href = props.href;
   const isExternalLink = /^https?:\/\//.test(href);
   return (
+    // eslint-disable-next-line react/forbid-elements
     <a
       ref={ref}
       href={href}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7779,10 +7779,10 @@ eslint-plugin-eslint-comments@^3.2.0:
     escape-string-regexp "^1.0.5"
     ignore "^5.0.5"
 
-eslint-plugin-flowtype@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.7.0.tgz#1fe68f9cd16e35bf30e09d4ebacf9cfbfe7a41a4"
-  integrity sha512-6Oa0D6kq3PGwJvivrLNSgeiPN/ftPkRvhbeHWoXUEGQ+ZugerSJvoMDSCc9dZa4R691b/eLXpx8dyMSZM1Tc4w==
+eslint-plugin-flowtype@^5.7.1:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.7.1.tgz#16b15d7a981bc0894284a87e71021f523b4fa580"
+  integrity sha512-RsurlNszyKLIHJvw6J4C98ubTTsLlgzL5xYqQ6ZTV5d2E2iHIR744SxoU3o7yQf0HjIe0GwnAIxpD+g0IV+emg==
   dependencies:
     lodash "^4.17.15"
     string-natural-compare "^3.0.1"


### PR DESCRIPTION
This release includes some fixes for our codebase, see:

- https://github.com/gajus/eslint-plugin-flowtype/pull/477
- https://github.com/gajus/eslint-plugin-flowtype/pull/478