### PR TITLE
KOCHKA: revert `LanguageTag` test

### DIFF
--- a/src/kochka.com.mx/src/__tests__/LanguageTag.test.js
+++ b/src/kochka.com.mx/src/__tests__/LanguageTag.test.js
@@ -1,0 +1,35 @@
+// @flow
+
+import LanguageTag from '../LanguageTag';
+
+it('returns default language as expected', () => {
+  expect(LanguageTag.getDefaultLanguageTag()).toMatchInlineSnapshot(`
+    Object {
+      "bcp47": "es-MX",
+      "url": "es-mx",
+    }
+  `);
+});
+
+test.each`
+  languageTag | expectedBCP47
+  ${'en-US'}  | ${'en-US'}
+  ${'en-us'}  | ${'en-US'}
+  ${'en_us'}  | ${'en-US'}
+  ${'EN_us'}  | ${'en-US'}
+  ${'xx-us'}  | ${'es-US'}
+  ${'en-xx'}  | ${'en-MX'}
+  ${'abc'}    | ${'es-MX'}
+`('detects language correctly for: $languageTag', ({ languageTag, expectedBCP47 }) => {
+  expect(LanguageTag.detectLanguageTag(languageTag).bcp47).toBe(expectedBCP47);
+});
+
+test.each`
+  languageTag | expected
+  ${'en-US'}  | ${false}
+  ${'abc'}    | ${true}
+  ${'es-mx'}  | ${true}
+  ${'es_mx'}  | ${true}
+`('detects default language tag correctly for: $languageTag', ({ languageTag, expected }) => {
+  expect(LanguageTag.isDefaultLanguageTag(languageTag)).toBe(expected);
+});


### PR DESCRIPTION
This is an attempt to partially revert `LanguageTag` test which was removed in this PR: https://github.com/adeira/universe/pull/2080. I had to disable it because it was miraculously failing on our CI and I was not able to figure out WTF. Let's see if it's better now after some dependency upgrades.