### PR TITLE
CI: enable Node.js 16 tests

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 15.x]
+        node-version: [14.x, 15.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/src/example-relay/__github__/.github/workflows/continuous-integration.yml
+++ b/src/example-relay/__github__/.github/workflows/continuous-integration.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 15.x]
+        node-version: [14.x, 15.x, 16.x]
 
     # TODO: lint
     steps:

--- a/src/sx-tailwind-website/__github__/.github/workflows/continuous-integration.yml
+++ b/src/sx-tailwind-website/__github__/.github/workflows/continuous-integration.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 15.x]
+        node-version: [14.x, 15.x, 16.x]
 
     # TODO: lint
     steps:


### PR DESCRIPTION
Note: Node.js version 16 is not required check in our CI yet.

See: https://nodejs.org/en/blog/release/v16.0.0/