### PR TITLE
Shipit: fix `adeira-source-id` position when using `Co-authored-by` lines

### DIFF
--- a/src/monorepo-shipit/bin/create-patch.js
+++ b/src/monorepo-shipit/bin/create-patch.js
@@ -4,7 +4,7 @@ import { findMonorepoRoot } from '@adeira/monorepo-utils';
 
 import RepoGit from '../src/RepoGit';
 
-// yarn monorepo-babel-node src/core/monorepo-shipit/bin/create-patch.js <REVISION>
+// yarn monorepo-babel-node src/monorepo-shipit/bin/create-patch.js <REVISION>
 const argv = process.argv.slice(2);
 const revision = argv[0];
 

--- a/src/monorepo-shipit/src/Changeset.js
+++ b/src/monorepo-shipit/src/Changeset.js
@@ -14,7 +14,8 @@ opaque type ChangesetData = {
   +subject: string,
   +description: string,
   +diffs: Set<Diff>,
-  +debugMessages: Array<string>,
+  +coAuthorLines: $ReadOnlyArray<string>,
+  +debugMessages: $ReadOnlyArray<string>,
 };
 
 export default class Changeset {
@@ -24,7 +25,8 @@ export default class Changeset {
   declare subject: string;
   declare description: string;
   declare diffs: Set<Diff>;
-  debugMessages: Array<string> = [];
+  coAuthorLines: $ReadOnlyArray<string> = [];
+  debugMessages: $ReadOnlyArray<string> = [];
 
   isValid(): boolean {
     return this.diffs.size > 0;
@@ -52,6 +54,14 @@ export default class Changeset {
 
   withAuthor(author: string): Changeset {
     return this.__clone({ author });
+  }
+
+  getCoAuthorLines(): $ReadOnlyArray<string> {
+    return this.coAuthorLines;
+  }
+
+  withCoAuthorLines(coAuthorLines: $ReadOnlyArray<string>): Changeset {
+    return this.__clone({ coAuthorLines });
   }
 
   getSubject(): string {

--- a/src/monorepo-shipit/src/__tests__/Changeset.test.js
+++ b/src/monorepo-shipit/src/__tests__/Changeset.test.js
@@ -21,6 +21,7 @@ test('immutability of the changesets', () => {
   // everything in the original changeset should be empty
   expect(originalChangeset).toMatchInlineSnapshot(`
     Changeset {
+      "coAuthorLines": Array [],
       "debugMessages": Array [],
     }
   `);
@@ -29,6 +30,7 @@ test('immutability of the changesets', () => {
   expect(modifiedChangeset1).toMatchInlineSnapshot(`
     Changeset {
       "author": "John Doe",
+      "coAuthorLines": Array [],
       "debugMessages": Array [
         "DEBUG yadada",
       ],
@@ -58,6 +60,7 @@ test('immutability of the changesets', () => {
   expect(modifiedChangeset2).toMatchInlineSnapshot(`
     Changeset {
       "author": "John Doe",
+      "coAuthorLines": Array [],
       "debugMessages": Array [
         "DEBUG yadada",
         "DEBUG should be appended",

--- a/src/monorepo-shipit/src/__tests__/RepoGit.findLastSourceCommit.test.js
+++ b/src/monorepo-shipit/src/__tests__/RepoGit.findLastSourceCommit.test.js
@@ -29,6 +29,17 @@ it('can find last source commit', () => {
   expect(repo.findLastSourceCommit(new Set())).toBe(fakeCommitID);
 });
 
+it('can find last source commit with Co-authored-by', () => {
+  const fakeCommitID = generateCommitID();
+  const description = addTrackingData(
+    new Changeset()
+      .withID(fakeCommitID)
+      .withCoAuthorLines(['Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>']),
+  ).getDescription();
+  const repo = createGITRepoWithCommit(description);
+  expect(repo.findLastSourceCommit(new Set())).toBe(fakeCommitID);
+});
+
 it('can find last source commit with multiple markers', () => {
   const fakeCommitID1 = generateCommitID();
   const fakeCommitID2 = generateCommitID();

--- a/src/monorepo-shipit/src/__tests__/ShipitConfig.test.js
+++ b/src/monorepo-shipit/src/__tests__/ShipitConfig.test.js
@@ -39,3 +39,18 @@ it('creates and runs the default filters', () => {
 
   expect(defaultFilter(createMockChangeset(2, '/known_path/'))).toMatchSnapshot();
 });
+
+it('creates and runs the default filters with Co-authored-by', () => {
+  const defaultFilter = new Config(
+    'fake monorepo path',
+    'fake exported repo URL',
+    new Map([['/known_path', '/destination_path']]),
+    new Set([/mocked/]),
+  ).getDefaultShipitFilter();
+
+  const changeset = createMockChangeset(2, '/known_path/').withCoAuthorLines([
+    'Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>',
+    'Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>',
+  ]);
+  expect(defaultFilter(changeset)).toMatchSnapshot();
+});

--- a/src/monorepo-shipit/src/__tests__/__snapshots__/ShipitConfig.test.js.snap
+++ b/src/monorepo-shipit/src/__tests__/__snapshots__/ShipitConfig.test.js.snap
@@ -3,12 +3,55 @@
 exports[`creates and runs the default filters 1`] = `
 Changeset {
   "author": "John Doe <john@doe.com>",
+  "coAuthorLines": Array [],
   "debugMessages": Array [
     "ADD TRACKING DATA: \\"adeira-source-id: 1234567890\\"",
   ],
   "description": "Test description
 
 adeira-source-id: 1234567890",
+  "diffs": Set {
+    Object {
+      "body": "new file mode 100644
+index 0000000000000000000000000000000000000000..1111111111111111111111111111111111111111
+--- /dev/null
++++ b//destination_path/fakeFile_1.txt
+@@ -0,0 +1 @@
++fake content",
+      "path": "/destination_path/fakeFile_1.txt",
+    },
+    Object {
+      "body": "new file mode 100644
+index 0000000000000000000000000000000000000000..1111111111111111111111111111111111111111
+--- /dev/null
++++ b//destination_path/fakeFile_2.txt
+@@ -0,0 +1 @@
++fake content",
+      "path": "/destination_path/fakeFile_2.txt",
+    },
+  },
+  "id": "1234567890",
+  "subject": "Test subject",
+  "timestamp": "Mon, 16 July 2019 10:55:04 -0100",
+}
+`;
+
+exports[`creates and runs the default filters with Co-authored-by 1`] = `
+Changeset {
+  "author": "John Doe <john@doe.com>",
+  "coAuthorLines": Array [
+    "Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>",
+    "Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>",
+  ],
+  "debugMessages": Array [
+    "ADD TRACKING DATA: \\"adeira-source-id: 1234567890\\"",
+  ],
+  "description": "Test description
+
+adeira-source-id: 1234567890
+
+Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>
+Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>",
   "diffs": Set {
     Object {
       "body": "new file mode 100644

--- a/src/monorepo-shipit/src/__tests__/__snapshots__/parsePatchHeader.test.js.snap
+++ b/src/monorepo-shipit/src/__tests__/__snapshots__/parsePatchHeader.test.js.snap
@@ -1,5 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`matches expected output: co-authored-by.header 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+From 160feaf6d2637b22216987d1f95b96d585a838a6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Zl=C3=A1mal?= <mrtnzlml@gmail.com>
+Date: Thu, 15 Apr 2021 13:18:49 -0500
+Subject: [PATCH] SX Design: add Norwegian language
+
+Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>
+
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "coAuthorLines": [
+    "Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>"
+  ],
+  "debugMessages": [],
+  "description": "",
+  "author": "=?UTF-8?q?Martin=20Zl=C3=A1mal?= <mrtnzlml@gmail.com>",
+  "timestamp": "Thu, 15 Apr 2021 13:18:49 -0500",
+  "subject": "SX Design: add Norwegian language"
+}
+`;
+
+exports[`matches expected output: co-authored-by-multiple.header 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+From 160feaf6d2637b22216987d1f95b96d585a838a6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Zl=C3=A1mal?= <mrtnzlml@gmail.com>
+Date: Thu, 15 Apr 2021 13:18:49 -0500
+Subject: [PATCH] SX Design: add Norwegian language
+
+Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>
+Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>
+
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "coAuthorLines": [
+    "Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>",
+    "Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>"
+  ],
+  "debugMessages": [],
+  "description": "",
+  "author": "=?UTF-8?q?Martin=20Zl=C3=A1mal?= <mrtnzlml@gmail.com>",
+  "timestamp": "Thu, 15 Apr 2021 13:18:49 -0500",
+  "subject": "SX Design: add Norwegian language"
+}
+`;
+
 exports[`matches expected output: multiline-subject.header 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 From 93ee65de02e77c52eb9d677b859554b40253bafa Mon Sep 17 00:00:00 2001
@@ -11,6 +59,7 @@ Subject: [PATCH] Docs: add Relay and GraphQL related videos from our internal
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 {
+  "coAuthorLines": [],
   "debugMessages": [],
   "description": "",
   "author": "=?UTF-8?q?Martin=20Zl=C3=A1mal?= <adeira@example.com>",
@@ -31,6 +80,7 @@ Formerly known as '@mrtnzlml/relay'
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 {
+  "coAuthorLines": [],
   "debugMessages": [],
   "description": "Formerly known as '@mrtnzlml/relay'",
   "author": "Automator <adeira@example.com>",
@@ -49,6 +99,7 @@ Subject: [PATCH] Let's party 🍺 🍻 🍷 🍸😀 😬 😁 😂 😃 😄 �
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 {
+  "coAuthorLines": [],
   "debugMessages": [],
   "description": "",
   "author": "=?UTF-8?q?Martin=20Zl=C3=A1mal?= <adeira@example.com>",

--- a/src/monorepo-shipit/src/__tests__/fixtures/headers/co-authored-by-multiple.header
+++ b/src/monorepo-shipit/src/__tests__/fixtures/headers/co-authored-by-multiple.header
@@ -1,0 +1,8 @@
+From 160feaf6d2637b22216987d1f95b96d585a838a6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Zl=C3=A1mal?= <mrtnzlml@gmail.com>
+Date: Thu, 15 Apr 2021 13:18:49 -0500
+Subject: [PATCH] SX Design: add Norwegian language
+
+Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>
+Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>
+

--- a/src/monorepo-shipit/src/__tests__/fixtures/headers/co-authored-by.header
+++ b/src/monorepo-shipit/src/__tests__/fixtures/headers/co-authored-by.header
@@ -1,0 +1,7 @@
+From 160feaf6d2637b22216987d1f95b96d585a838a6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Zl=C3=A1mal?= <mrtnzlml@gmail.com>
+Date: Thu, 15 Apr 2021 13:18:49 -0500
+Subject: [PATCH] SX Design: add Norwegian language
+
+Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>
+

--- a/src/monorepo-shipit/src/filters/__tests__/__snapshots__/moveDirectories.test.js.snap
+++ b/src/monorepo-shipit/src/filters/__tests__/__snapshots__/moveDirectories.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`handles complex filenames requiring regexp escaping correctly 1`] = `
 Changeset {
+  "coAuthorLines": Array [],
   "debugMessages": Array [],
   "description": "MOCKED_HEADER",
   "diffs": Set {

--- a/src/monorepo-shipit/src/filters/__tests__/addTrackingData.test.js
+++ b/src/monorepo-shipit/src/filters/__tests__/addTrackingData.test.js
@@ -13,6 +13,7 @@ it('adds tracking data', () => {
   expect(changeset).toMatchInlineSnapshot(`
     Changeset {
       "author": "John Doe",
+      "coAuthorLines": Array [],
       "debugMessages": Array [],
       "description": "Commit description",
       "id": "MOCK_COMMIT_ID",
@@ -23,12 +24,60 @@ it('adds tracking data', () => {
   expect(addTrackingData(changeset)).toMatchInlineSnapshot(`
     Changeset {
       "author": "John Doe",
+      "coAuthorLines": Array [],
       "debugMessages": Array [
         "ADD TRACKING DATA: \\"adeira-source-id: MOCK_COMMIT_ID\\"",
       ],
       "description": "Commit description
 
     adeira-source-id: MOCK_COMMIT_ID",
+      "id": "MOCK_COMMIT_ID",
+      "subject": "Commit subject",
+    }
+  `);
+});
+
+it('adds tracking data with Co-authored-by line', () => {
+  const changeset = new Changeset()
+    .withID('MOCK_COMMIT_ID')
+    .withAuthor('John Doe')
+    .withSubject('Commit subject')
+    .withDescription('Commit description')
+    .withCoAuthorLines([
+      'Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>',
+      'Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>',
+    ]);
+
+  expect(changeset).toMatchInlineSnapshot(`
+    Changeset {
+      "author": "John Doe",
+      "coAuthorLines": Array [
+        "Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>",
+        "Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>",
+      ],
+      "debugMessages": Array [],
+      "description": "Commit description",
+      "id": "MOCK_COMMIT_ID",
+      "subject": "Commit subject",
+    }
+  `);
+
+  expect(addTrackingData(changeset)).toMatchInlineSnapshot(`
+    Changeset {
+      "author": "John Doe",
+      "coAuthorLines": Array [
+        "Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>",
+        "Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>",
+      ],
+      "debugMessages": Array [
+        "ADD TRACKING DATA: \\"adeira-source-id: MOCK_COMMIT_ID\\"",
+      ],
+      "description": "Commit description
+
+    adeira-source-id: MOCK_COMMIT_ID
+
+    Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>
+    Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>",
       "id": "MOCK_COMMIT_ID",
       "subject": "Commit subject",
     }

--- a/src/monorepo-shipit/src/filters/__tests__/stripDescriptions.test.js
+++ b/src/monorepo-shipit/src/filters/__tests__/stripDescriptions.test.js
@@ -12,6 +12,7 @@ it('strips commit descriptions correctly', () => {
   expect(changeset).toMatchInlineSnapshot(`
     Changeset {
       "author": "John Doe",
+      "coAuthorLines": Array [],
       "debugMessages": Array [],
       "description": "This description should be stripped.",
       "subject": "Commit subject",
@@ -21,6 +22,7 @@ it('strips commit descriptions correctly', () => {
   expect(stripDescriptions(changeset)).toMatchInlineSnapshot(`
     Changeset {
       "author": "John Doe",
+      "coAuthorLines": Array [],
       "debugMessages": Array [],
       "description": "",
       "subject": "Commit subject",

--- a/src/monorepo-shipit/src/filters/addTrackingData.js
+++ b/src/monorepo-shipit/src/filters/addTrackingData.js
@@ -5,7 +5,15 @@ import Changeset from '../Changeset';
 export default function addTrackingData(changeset: Changeset): Changeset {
   const revision = changeset.getID();
   const tracking = `adeira-source-id: ${revision}`;
-  const newDescription = `${changeset.getDescription()}\n\n${tracking}`;
+
+  let newDescription = `${changeset.getDescription()}\n\n${tracking}`;
+
+  // Co-authored-by must be the absolute last thing in the message
+  const coAuthorLines = changeset.getCoAuthorLines();
+  if (coAuthorLines.length > 0) {
+    newDescription += `\n\n${coAuthorLines.join('\n')}`;
+  }
+
   return changeset
     .withDebugMessage('ADD TRACKING DATA: "%s"', tracking)
     .withDescription(newDescription.trim());

--- a/src/monorepo-shipit/src/parsePatchHeader.js
+++ b/src/monorepo-shipit/src/parsePatchHeader.js
@@ -5,8 +5,24 @@ import splitHead from './splitHead';
 
 export default function parsePatchHeader(header: string): Changeset {
   const [rawEnvelope, rawBody] = splitHead(header, '\n\n');
-  const description = rawBody.trim();
-  let changeset = new Changeset().withDescription(description);
+
+  const description = [];
+  const coAuthorLines = [];
+
+  // Co-authored-by must be the absolute last thing in the message so we separate it here from the
+  // description and compose it later correctly (to add the `adeira-source-id` label correctly).
+  for (const line of rawBody.trim().split('\n')) {
+    if (line.startsWith('Co-authored-by:')) {
+      coAuthorLines.push(line);
+    } else {
+      description.push(line);
+    }
+  }
+
+  let changeset = new Changeset()
+    .withDescription(description.join('\n'))
+    .withCoAuthorLines(coAuthorLines);
+
   const envelope = rawEnvelope.replace(/(?:\n\t|\n )/, ' ');
   for (const line of envelope.split('\n')) {
     if (!line.includes(':')) {


### PR DESCRIPTION
Basically, we were always printing `adeira-source-id` line as a last one in the commit description. But turned out that `Co-authored-by` lines must be always the last ones for it to work correctly.

This change attempts to do exactly that: it separates the actual description and `Co-authored-by` lines when parsing the commit header (`parsePatchHeader`) and it constructs the commit description correctly in `addTrackingData` function.

Closes: https://github.com/adeira/universe/issues/2261