### PR TITLE
SX Design: install `@storybook/addon-a11y`

### DIFF
--- a/src/sx-design/.storybook/main.js
+++ b/src/sx-design/.storybook/main.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
-  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-links', '@storybook/addon-a11y'],
 };

--- a/src/sx-design/README.md
+++ b/src/sx-design/README.md
@@ -2,12 +2,12 @@
 
 [![Crowdin](https://badges.crowdin.net/sx-design/localized.svg)](https://crowdin.com/project/sx-design)
 
-Basic design system written using [`@adeira/sx`](https://github.com/adeira/sx). Core value of this project are (in this order):
+Inclusive design system written using [`@adeira/sx`](https://github.com/adeira/sx). Core value of this project are (in this order):
 
 - ⚛️ exclusively using atomic CSS via [`@adeira/sx`](https://github.com/adeira/sx)
 - 🏳️‍🌈 fully supported localization ([🇺🇸🇲🇽🇨🇿🇳🇴🇺🇦🇷🇺](https://crowdin.com/project/sx-design))
-- ☯️ dark mode out of the box
-- 🆘 accessible components
+- ☯️ light and dark theme out of the box
+- 🆘 accessible components for people with visual impairment
 - حلال support for RTL layouts
 
 # Installation and Usage
@@ -28,6 +28,7 @@ export default function MyRootApp() {
     <SxDesignProvider
       locale="en-US" // affects translations as well as dates, monetary values and similar
       theme="light" // or "dark" or "system"
+      direction="ltr" // or "rtl"
     >
       <ErrorBoundary>{/* … */}</ErrorBoundary>
     </SxDesignProvider>

--- a/src/sx-design/package.json
+++ b/src/sx-design/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adeira/sx-design",
-  "description": "Basic design system written using @adeira/sx",
+  "description": "Inclusive design system written using @adeira/sx",
   "homepage": "https://github.com/adeira/universe/tree/master/src/sx-design",
   "license": "MIT",
   "private": false,
@@ -26,6 +26,7 @@
     "@adeira/sx-jest-snapshot-serializer": "^0.1.0",
     "@babel/core": "^7.13.16",
     "@fbtjs/default-collection-transform": "^0.0.3",
+    "@storybook/addon-a11y": "^6.2.9",
     "@storybook/addon-actions": "^6.2.9",
     "@storybook/addon-essentials": "^6.2.9",
     "@storybook/addon-links": "^6.2.9",

--- a/src/sx-design/src/SxDesignProvider.js
+++ b/src/sx-design/src/SxDesignProvider.js
@@ -31,6 +31,7 @@ export default function SxDesignProvider(props: Props): Node {
   };
 
   // TODO: invariant when selected `locale` and `direction` are not compatible
+  // TODO: alternatively setup the `direction` automatically based on the `locale` (?)
 
   fbtInit({
     translations: supportedLocales[locale],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2577,6 +2577,28 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@storybook/addon-a11y@^6.2.9":
+  version "6.2.9"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-6.2.9.tgz#8386d73343db03c15d07f6bf927a4030d441d1ff"
+  integrity sha512-wo7nFpEqEeiHDsRKnhqe2gIHZ9Z7/Aefw570kBgReU5tKlmrb5rFAfTVBWGBZlLHWeJMsFsRsWrWrmkf1B52OQ==
+  dependencies:
+    "@storybook/addons" "6.2.9"
+    "@storybook/api" "6.2.9"
+    "@storybook/channels" "6.2.9"
+    "@storybook/client-api" "6.2.9"
+    "@storybook/client-logger" "6.2.9"
+    "@storybook/components" "6.2.9"
+    "@storybook/core-events" "6.2.9"
+    "@storybook/theming" "6.2.9"
+    axe-core "^4.1.1"
+    core-js "^3.8.2"
+    global "^4.4.0"
+    lodash "^4.17.20"
+    react-sizeme "^3.0.1"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-actions@6.2.9", "@storybook/addon-actions@^6.2.9":
   version "6.2.9"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.2.9.tgz#688413ac77410690755a5da3c277bfa0ff1a10b0"


### PR DESCRIPTION
I also changed the wording of README.md a little bit to be more explicit about the inclusivity of this project.

See: https://github.com/storybookjs/storybook/tree/next/addons/a11y