### PR TITLE
Cleanup global `.eslintrc.js`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,7 @@
 
 node_modules/
 
+src/babel-preset-adeira/src/__tests__/__fixtures__
 src/example-relay/__github__/flow-typed
 src/sx-tailwind-website/__github__/flow-typed
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,14 @@
 // @flow strict
 
-/* eslint-disable no-unused-vars */
-const OFF = 0;
-const WARN = 1;
-const ERROR = 2;
-/* eslint-enable no-unused-vars */
-
 module.exports = {
+  root: true, // stop ESLint from looking for a configuration file in parent folders
+  extends: ['@adeira/eslint-config/strict'],
+  env: {
+    // TODO: consider moving this into `eslint-config-adeira`
+    es6: true,
+    jest: true,
+    node: true,
+  },
   parser: '@babel/eslint-parser', // TODO: consider moving this into `eslint-config-adeira`
   parserOptions: {
     sourceType: 'module',
@@ -14,58 +16,5 @@ module.exports = {
     ecmaFeatures: {
       jsx: false,
     },
-  },
-  root: true, // stop ESLint from looking for a configuration file in parent folders
-  env: {
-    // TODO: consider moving this into `eslint-config-adeira`
-    es6: true,
-    jest: true,
-    node: true,
-  },
-
-  extends: ['@adeira/eslint-config/strict'],
-
-  overrides: [
-    {
-      files: ['**/babel-preset-adeira/**/__fixtures__/**/*.js', 'src/__flowtests__/**'],
-      rules: {
-        'eslint-comments/no-unlimited-disable': OFF,
-      },
-    },
-  ],
-
-  rules: {
-    'no-restricted-imports': [
-      ERROR,
-      {
-        paths: [
-          {
-            name: 'child_process',
-            message: 'Use `ShellCommand` from @adeira/monorepo instead.',
-          },
-          {
-            name: 'glob',
-            message: 'Use `glob` from @adeira/monorepo instead.',
-          },
-          {
-            name: 'react-relay',
-            message: 'Use @adeira/relay instead.',
-          },
-        ],
-      },
-    ],
-    'import/no-extraneous-dependencies': [
-      ERROR,
-      {
-        devDependencies: [
-          '**/.babelrc.js',
-          '**/next.config.js',
-          '**/scripts/**',
-          '**/__flowtests__/**',
-          '**/__tests__/**',
-          '**/.storybook/**',
-        ],
-      },
-    ],
   },
 };

--- a/src/__flowtests__/lints/__untypedFile.js
+++ b/src/__flowtests__/lints/__untypedFile.js
@@ -1,1 +1,1 @@
-/* eslint-disable */
+/* eslint-disable flowtype/require-valid-file-annotation */

--- a/src/__flowtests__/lints/unsafe-getters-setters.js
+++ b/src/__flowtests__/lints/unsafe-getters-setters.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-/* eslint-disable */
+/* eslint-disable accessor-pairs */
 
 export const o = {
   // $FlowExpectedError[unsafe-getters-setters]

--- a/src/__flowtests__/lints/untyped-import.js
+++ b/src/__flowtests__/lints/untyped-import.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-/* eslint-disable */
+/* eslint-disable no-unused-vars */
 
 // $FlowExpectedError[untyped-import]
 import { XYZ } from './__untypedFile';

--- a/src/__flowtests__/lints/untyped-type-import.js
+++ b/src/__flowtests__/lints/untyped-type-import.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-/* eslint-disable */
+/* eslint-disable no-unused-vars */
 
 // $FlowExpectedError[untyped-type-import]
 import type { XYZ } from './__untypedFile';

--- a/src/eslint-config-adeira/CHANGELOG.md
+++ b/src/eslint-config-adeira/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Rule `import/no-extraneous-dependencies` now ignores `**/__flowtests__/**`, `**/__tests__/**` and `**/.storybook/**` by default.
+
 # 6.0.0
 
 Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues with Flow types as long as you are using `exact_by_default=true` Flow option.

--- a/src/eslint-config-adeira/README.md
+++ b/src/eslint-config-adeira/README.md
@@ -36,16 +36,21 @@ const ERROR = 2;
 module.exports = {
   root: true,
 
-  extends: ['@adeira/eslint-config'],
+  extends: ['@adeira/eslint-config/strict'],
 
-  // adjust the rules as needed
   parser: '@babel/eslint-parser',
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2021,
+    ecmaFeatures: {
+      jsx: false,
+    },
+  },
+
   env: {
+    es6: true,
     jest: true,
     node: true,
-  },
-  rules: {
-    eqeqeq: [ERROR, 'smart'],
   },
 };
 ```

--- a/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
+++ b/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
@@ -254,11 +254,14 @@ Object {
       2,
       Object {
         "devDependencies": Array [
-          "**/*.test.js",
           "**/*.spec.js",
           "**/*.stories.js",
-          "**/webpack.config.js",
+          "**/*.test.js",
+          "**/.storybook/**",
+          "**/__flowtests__/**",
+          "**/__tests__/**",
           "**/metro.config.js",
+          "**/webpack.config.js",
         ],
       },
     ],

--- a/src/eslint-config-adeira/ourRules.js
+++ b/src/eslint-config-adeira/ourRules.js
@@ -608,11 +608,14 @@ module.exports = ({
     ERROR,
     {
       devDependencies: [
-        '**/*.test.js',
         '**/*.spec.js',
         '**/*.stories.js',
-        '**/webpack.config.js',
+        '**/*.test.js',
+        '**/.storybook/**',
+        '**/__flowtests__/**',
+        '**/__tests__/**',
         '**/metro.config.js',
+        '**/webpack.config.js',
       ],
     },
   ],

--- a/src/example-relay/.eslintrc.js
+++ b/src/example-relay/.eslintrc.js
@@ -1,7 +1,31 @@
 // @flow strict
 
+/* eslint-disable no-unused-vars */
+const OFF = 0;
+const WARN = 1;
+const ERROR = 2;
+/* eslint-enable no-unused-vars */
+
 module.exports = {
   env: {
     browser: true,
+  },
+  rules: {
+    'import/no-extraneous-dependencies': [
+      ERROR,
+      {
+        devDependencies: [
+          '**/*.spec.js',
+          '**/*.stories.js',
+          '**/*.test.js',
+          '**/.storybook/**',
+          '**/__flowtests__/**',
+          '**/__tests__/**',
+          '**/metro.config.js',
+          '**/scripts/**',
+          '**/webpack.config.js',
+        ],
+      },
+    ],
   },
 };

--- a/src/fixtures-tester/src/generateTestsFromFixtures.js
+++ b/src/fixtures-tester/src/generateTestsFromFixtures.js
@@ -59,6 +59,7 @@ export default function generateTestsFromFixtures( // eslint-disable-line jest/n
     fixtures = onlyFixtures;
   }
 
+  // eslint-disable-next-line jest/no-identical-title
   test.each(fixtures.filter(isFile))('matches expected output: %s', async (file) => {
     const input = fs.readFileSync(path.join(fixturesPath, file), 'utf8');
     const output = await getOutputForFixture(input, operation, file);

--- a/src/monorepo-utils/src/ShellCommand.js
+++ b/src/monorepo-utils/src/ShellCommand.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import nodeChildProcess from 'child_process'; // eslint-disable-line no-restricted-imports
+import nodeChildProcess from 'child_process';
 
 import ShellCommandResult from './ShellCommandResult';
 

--- a/src/monorepo-utils/src/__tests__/ShellCommand.test.js
+++ b/src/monorepo-utils/src/__tests__/ShellCommand.test.js
@@ -1,7 +1,7 @@
 // @flow strict
 
 import path from 'path';
-import nodeChildProcess from 'child_process'; // eslint-disable-line no-restricted-imports
+import nodeChildProcess from 'child_process';
 
 import ShellCommand from '../ShellCommand';
 

--- a/src/monorepo-utils/src/glob.js
+++ b/src/monorepo-utils/src/glob.js
@@ -1,7 +1,7 @@
 // @flow
 
 import util from 'util';
-import _glob from 'glob'; // eslint-disable-line no-restricted-imports
+import _glob from 'glob';
 import { invariant, isObject } from '@adeira/js';
 
 type GlobPattern = string;

--- a/src/sx-tailwind-website/next.config.js
+++ b/src/sx-tailwind-website/next.config.js
@@ -1,7 +1,9 @@
 // @flow
 
 const path = require('path');
+// eslint-disable-next-line import/no-extraneous-dependencies
 const withTranspileModules = require('next-transpile-modules');
+// eslint-disable-next-line import/no-extraneous-dependencies
 const withCustomBabelConfigFile = require('next-plugin-custom-babel-config');
 
 module.exports = (withCustomBabelConfigFile(

--- a/src/sx/scripts/setupTests.js
+++ b/src/sx/scripts/setupTests.js
@@ -1,3 +1,4 @@
 // @flow strict
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 import '@testing-library/jest-dom/extend-expect';


### PR DESCRIPTION
The purpose of this change is to remove as many things from the global config as possible and move them closer to the actual projects. This plays better with a monorepo approach where every project can have relative freedom to do what it needs/wants to do.