### PR TITLE
Abacus: make `k8s` ready for DigitalOcean

### DIFF
--- a/src/abacus-backoffice/src/constants.js
+++ b/src/abacus-backoffice/src/constants.js
@@ -1,6 +1,8 @@
 // @flow strict
 
 export default {
-  graphqlServerURL: ((__DEV__ ? 'http://0.0.0.0:5000/graphql' : 'http://0.0.0.0/graphql'): string),
+  graphqlServerURL: ((__DEV__
+    ? 'http://0.0.0.0:5000/graphql'
+    : 'http://abacus.kochka.com.mx/graphql'): string), // TODO: HTTPS, better "abacus" domain
   googleClientID: '245356693889-63qeuc6183hab6be342blikbknsvqrhk.apps.googleusercontent.com',
 };

--- a/src/abacus/README.md
+++ b/src/abacus/README.md
@@ -134,5 +134,6 @@ analyzers.remove('bigram');
 ✅ 007 - DB migrations
 🚧 008 - queries whitelisting (persistent queries)
 🚧 009 - explore WASM on server instead of Docker (https://github.com/deislabs/krustlet)
-🚧 010 - ArangoDB database backups (k8s)
+🚧 010 - ArangoDB database backups and restores (k8s)
+🚧 011 - development k8s cluster + Telepresence (https://www.getambassador.io/docs/telepresence/latest/howtos/intercepts/)
 ```

--- a/src/abacus/kubernetes/README.md
+++ b/src/abacus/kubernetes/README.md
@@ -5,7 +5,11 @@
 - https://www.arangodb.com/docs/stable/deployment-kubernetes.html
 - https://www.arangodb.com/docs/stable/tutorials-kubernetes.html
 
+The main Kubernetes cluster runs on DigitalOcean, see: https://cloud.digitalocean.com/kubernetes/clusters
+
 # Deploying
+
+First, make sure you are in the correct DigitalOcean/local context (`kubectl config get-contexts`).
 
 ```bash
 (cd src/abacus/kubernetes && kubectl apply -f third_party/arangodb/)
@@ -20,7 +24,7 @@
 - https://github.com/zegl/kube-score
 
 ```bash
-docker run -v $(pwd):/project zegl/kube-score:v1.10.0 score src/abacus/kubernetes/abacus.yaml
+docker run -v $(pwd):/project zegl/kube-score:v1.11.0 score src/abacus/kubernetes/abacus.yaml
 ```
 
 # Kubernetes dashboard (development only)
@@ -91,4 +95,29 @@ Delete evicted/failed pods:
 ```bash
 kubectl get pods --field-selector=status.phase=Failed
 kubectl delete pods --field-selector=status.phase=Failed
+```
+
+# Creating necessary secrets
+
+- https://kubernetes.io/docs/concepts/configuration/secret/
+- https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/
+
+```bash
+kubectl create secret generic abacus-aws-secret
+```
+
+```bash
+echo -n 'supersecret' | base64
+```
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: abacus-aws-secret
+data:
+  AWS_ACCESS_KEY_ID: supersecretbase64
+  AWS_SECRET_ACCESS_KEY: supersecretbase64
+EOF
 ```

--- a/src/abacus/kubernetes/abacus.yaml
+++ b/src/abacus/kubernetes/abacus.yaml
@@ -1,3 +1,4 @@
+# https://www.arangodb.com/docs/stable/deployment-kubernetes-deployment-resource.html
 apiVersion: 'database.arangodb.com/v1alpha'
 kind: 'ArangoDeployment'
 metadata:
@@ -9,28 +10,19 @@ spec:
     caSecretName: None # TODO
   auth:
     jwtSecretName: None # TODO
+  externalAccess:
+    type: None
   single:
-    storageClassName: my-local-ssd
-    overrideDetectedTotalMemory: True
+    storageClassName: do-block-storage # DigitalOcean Block Storage
     resources:
       requests:
         cpu: 1
         memory: 512M
+        storage: 1Gi
       limits:
         cpu: 2
         memory: 1024M
-
----
-apiVersion: 'storage.arangodb.com/v1alpha'
-kind: 'ArangoLocalStorage'
-metadata:
-  name: 'arangodb-single-server-storage'
-spec:
-  storageClass:
-    name: my-local-ssd
-    isDefault: true
-  localPath:
-    - /Users/martinzlamal/Desktop/arango-storage # TODO
+        storage: 1Gi
 
 ---
 apiVersion: 'batch/v1beta1'
@@ -47,7 +39,7 @@ spec:
   #          │ │ │ │ │
   #          │ │ │ │ │
   schedule: '*/5 * * * *' # every 5 minutes
-  #schedule: '0 * * * *' # equivalent to `@hourly`
+  #schedule: '0 * * * *' # equivalent to `@hourly` # TODO
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -59,10 +51,10 @@ spec:
               image: 'arangodb/arangodb:3.7.9'
               args:
                 - 'arangodump'
-                # https://<deployment-name>.<namespace>.svc:8529
+                # https://<deployment-name>.<namespace>.svc.cluster.local:8529
                 - '--server.endpoint=tcp://arangodb-single-server.default.svc.cluster.local:8529' # TODO: ssl://…
-                #- '--server.username=$(username)'
-                #- '--server.password=$(password)'
+                #- '--server.username=$(username)' # TODO
+                #- '--server.password=$(password)' # TODO
                 - '--server.authentication=false'
                 - '--server.database=abacus'
                 - '--output-directory=/tmp/dump'
@@ -74,8 +66,21 @@ spec:
             - name: db-dump-upload
               image: amazon/aws-cli:2.1.29
               command: ['/bin/sh', '-c']
-              args: ['aws --help']
-              #args: ['aws s3 sync /tmp/dump s3://bucket/$(date -I)']
+              args:
+                [
+                  'aws s3 sync /tmp/dump s3://abacus-arangodb-backup-38c739d1-9e39-4052-8746-b2f21523f6c0/$(date "+%Y-%m-%dT%H:%M:%S")',
+                ]
+              env:
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: abacus-aws-secret
+                      key: AWS_ACCESS_KEY_ID
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: abacus-aws-secret
+                      key: AWS_SECRET_ACCESS_KEY
               volumeMounts:
                 - name: dump
                   mountPath: /tmp/dump
@@ -120,5 +125,16 @@ spec:
           image: mrtnzlml/abacus
           ports:
             - containerPort: 5000
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: abacus-aws-secret
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: abacus-aws-secret
+                  key: AWS_SECRET_ACCESS_KEY
           args:
             - '--arangodb-url=http://arangodb-single-server.default.svc.cluster.local:8529' # TODO: https://…


### PR DESCRIPTION
This change kinda makes it broken for localhost BUT it makes it work on DigitalOcean (including database backups to S3) which is more important. I will improve the localhost experience later (either via Kustomize or Telepresence or both).