### PR TITLE
CI: setup Dockerfile builder

### DIFF
--- a/.github/workflows/dockerfile-builder.yml
+++ b/.github/workflows/dockerfile-builder.yml
@@ -1,0 +1,64 @@
+name: Dockerfile Builder
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  # https://docs.docker.com/ci-cd/github-actions/
+  build-and-publish:
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - 'abacus'
+        include:
+          - project: abacus
+            projectPath: './src/abacus'
+            projectGlob: './src/abacus/**'
+            projectDockerfile: './src/abacus/Dockerfile'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v2.10.1
+        id: changes
+        with:
+          filters: |
+            src:
+              - ${{ matrix.projectGlob }}
+
+      # https://github.com/docker/login-action
+      - name: Login to Docker Hub
+        if: steps.changes.outputs.src == 'true'
+        uses: docker/login-action@v1.9.0
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.src == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v1.3.0
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push
+        if: steps.changes.outputs.src == 'true'
+        id: docker_build
+        uses: docker/build-push-action@v2.4.0
+        with:
+          context: ${{ matrix.projectPath }}
+          file: ${{ matrix.projectDockerfile }}
+          push: true
+          tags: adeira/abacus:latest # TODO: include in the build matrix
+
+      - name: Image digest
+        if: steps.changes.outputs.src == 'true'
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Continuous Integration (JavaScript)](<https://github.com/adeira/universe/workflows/Continuous%20Integration%20(JavaScript)/badge.svg>) ![Continuous Integration (Rust)](<https://github.com/adeira/universe/workflows/Continuous%20Integration%20(Rust)/badge.svg>) ![Continuous Integration (Bazel)](<https://github.com/adeira/universe/workflows/Continuous%20Integration%20(Bazel)/badge.svg>)
 
-![Shipit](https://github.com/adeira/universe/workflows/Shipit/badge.svg) ![NPM Publisher](https://github.com/adeira/universe/workflows/NPM%20Publisher/badge.svg)
+![Shipit](https://github.com/adeira/universe/workflows/Shipit/badge.svg) ![NPM Publisher](https://github.com/adeira/universe/workflows/NPM%20Publisher/badge.svg) ![Dockerfile Builder](https://github.com/adeira/universe/workflows/Dockerfile%20Builder/badge.svg)
 
 See: https://adeira.dev/ for more info.
 

--- a/src/abacus/Dockerfile
+++ b/src/abacus/Dockerfile
@@ -1,8 +1,3 @@
-##
-## docker build --tag abacus --file Dockerfile .
-##
-
-
 FROM rust:1.51.0 AS builder
 # Let's switch our working directory to `app` (equivalent to `cd app`)
 # The `app` folder will be created for us by Docker in case it does not

--- a/src/abacus/kubernetes/README.md
+++ b/src/abacus/kubernetes/README.md
@@ -39,36 +39,6 @@ Dashboard: [http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/service
 
 Creating a user: [https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/creating-sample-user.md](https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/creating-sample-user.md)
 
-# Abacus Docker image
-
-Executed from `src/abacus` context:
-
-```bash
-# docker build --tag mrtnzlml/abacus --file Dockerfile .
-# docker push
-
-(cd src/abacus && docker build --tag mrtnzlml/abacus --file Dockerfile .)
-```
-
-Running the image directly:
-
-```bash
-docker run \
-  --memory=64m \
-  --cpus=0.1 \
-  -p 5000:5000 \
-  -d \
-  --name=abacus \
-  abacus
-```
-
-Publishing the image:
-
-```bash
-docker image ls
-docker image push mrtnzlml/abacus:latest
-```
-
 # Troubleshooting
 
 Problem: `kubectl get pods` returns many `Evicted` pods and `kubectl describe pod <name>` returns message `The node had condition: [DiskPressure]`.

--- a/src/abacus/kubernetes/abacus.yaml
+++ b/src/abacus/kubernetes/abacus.yaml
@@ -122,7 +122,7 @@ spec:
     spec:
       containers:
         - name: abacus
-          image: mrtnzlml/abacus
+          image: adeira/abacus
           ports:
             - containerPort: 5000
           env:


### PR DESCRIPTION
The idea is that `adeira/universe` is responsible for the `Dockerfile` building and pushing so developers do not have to take care of it at all. It uses GitHub Actions build matrix together with `dorny/paths-filter` action to build the Dockerfiles only when needed.