### PR TITLE
Abacus: install `kube-state-metrics` (k8s)

### DIFF
--- a/src/abacus/kubernetes/README.md
+++ b/src/abacus/kubernetes/README.md
@@ -13,6 +13,7 @@ First, make sure you are in the correct DigitalOcean/local context (`kubectl con
 
 ```bash
 (cd src/abacus/kubernetes && kubectl apply -f third_party/arangodb/)
+(cd src/abacus/kubernetes && kubectl apply -f third_party/kube-state-metrics/)
 
 (cd src/abacus/kubernetes && kubectl diff -f abacus.yaml)
 (cd src/abacus/kubernetes && kubectl apply -f abacus.yaml)

--- a/src/abacus/kubernetes/third_party/kube-state-metrics/README.md
+++ b/src/abacus/kubernetes/third_party/kube-state-metrics/README.md
@@ -1,0 +1,2 @@
+- https://docs.digitalocean.com/products/kubernetes/how-to/monitor-advanced/
+- https://github.com/kubernetes/kube-state-metrics

--- a/src/abacus/kubernetes/third_party/kube-state-metrics/cluster-role-binding.yaml
+++ b/src/abacus/kubernetes/third_party/kube-state-metrics/cluster-role-binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.0.0
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+  - kind: ServiceAccount
+    name: kube-state-metrics
+    namespace: kube-system

--- a/src/abacus/kubernetes/third_party/kube-state-metrics/cluster-role.yaml
+++ b/src/abacus/kubernetes/third_party/kube-state-metrics/cluster-role.yaml
@@ -1,0 +1,108 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.0.0
+  name: kube-state-metrics
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - secrets
+      - nodes
+      - pods
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+      - ingresses
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - list
+      - watch

--- a/src/abacus/kubernetes/third_party/kube-state-metrics/deployment.yaml
+++ b/src/abacus/kubernetes/third_party/kube-state-metrics/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.0.0
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/version: 2.0.0
+    spec:
+      containers:
+        - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          name: kube-state-metrics
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+            - containerPort: 8081
+              name: telemetry
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8081
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          securityContext:
+            runAsUser: 65534
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: kube-state-metrics

--- a/src/abacus/kubernetes/third_party/kube-state-metrics/service-account.yaml
+++ b/src/abacus/kubernetes/third_party/kube-state-metrics/service-account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.0.0
+  name: kube-state-metrics
+  namespace: kube-system

--- a/src/abacus/kubernetes/third_party/kube-state-metrics/service.yaml
+++ b/src/abacus/kubernetes/third_party/kube-state-metrics/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.0.0
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 8080
+      targetPort: http-metrics
+    - name: telemetry
+      port: 8081
+      targetPort: telemetry
+  selector:
+    app.kubernetes.io/name: kube-state-metrics


### PR DESCRIPTION
This enables advanced metrics in DigitalOcean.