### PR TITLE
Explicitly mark all packages with `commonjs` type

### DIFF
--- a/src/babel-plugin-transform-sx-tailwind/package.json
+++ b/src/babel-plugin-transform-sx-tailwind/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "0.18.0",
   "main": "./src/index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@adeira/murmur-hash": "^2.0.0",

--- a/src/babel-preset-adeira/package.json
+++ b/src/babel-preset-adeira/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "version": "3.0.0",
   "main": "./src/index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.12.13",

--- a/src/css-colors/package.json
+++ b/src/css-colors/package.json
@@ -6,6 +6,7 @@
   "sideEffects": false,
   "private": false,
   "main": "./src/index.js",
+  "type": "commonjs",
   "license": "MIT",
   "dependencies": {
     "@adeira/js": "^2.1.0",

--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "6.0.0",
   "main": "./index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@babel/runtime": "^7.14.0",

--- a/src/eslint-fixtures-tester/package.json
+++ b/src/eslint-fixtures-tester/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/eslint-fixtures-tester",
   "version": "0.1.0",
   "main": "./src/index.js",
+  "type": "commonjs",
   "license": "MIT",
   "private": false,
   "dependencies": {

--- a/src/eslint-plugin-adeira/package.json
+++ b/src/eslint-plugin-adeira/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "0.13.0",
   "main": "./src/index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@babel/runtime": "^7.14.0",

--- a/src/eslint-plugin-sx/package.json
+++ b/src/eslint-plugin-sx/package.json
@@ -11,6 +11,7 @@
     "eslint-plugin"
   ],
   "main": "./src/index.js",
+  "type": "commonjs",
   "dependencies": {
     "@babel/runtime": "^7.14.0"
   },

--- a/src/fetch/package.json
+++ b/src/fetch/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "version": "2.1.0",
   "main": "./src/fetchWithRetries.js",
+  "type": "commonjs",
   "sideEffects": false,
   "homepage": "https://github.com/adeira/universe/tree/master/src/fetch",
   "description": "Production ready fetch function with advanced capabilities like retries with delay and request cancellation after timeout.",

--- a/src/fixtures-tester/package.json
+++ b/src/fixtures-tester/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "1.0.1",
   "main": "./src/index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@adeira/js": "^2.1.0",

--- a/src/flow-config-parser/package.json
+++ b/src/flow-config-parser/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "license": "MIT",
   "main": "./src/index.js",
+  "type": "commonjs",
   "dependencies": {
     "@adeira/fixtures-tester": "^1.0.1",
     "@adeira/js": "^2.1.0",

--- a/src/flow-types-eslint/package.json
+++ b/src/flow-types-eslint/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "private": true,
   "main": "./src/index.js",
+  "type": "commonjs",
   "license": "MIT",
   "dependencies": {}
 }

--- a/src/graphql-bc-checker/package.json
+++ b/src/graphql-bc-checker/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "0.3.0",
   "main": "./src/index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@adeira/signed-source": "^2.0.0",

--- a/src/graphql-global-id/package.json
+++ b/src/graphql-global-id/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "2.0.1",
   "main": "./src/index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@adeira/js": "^2.1.0",

--- a/src/graphql-relay-fauna/package.json
+++ b/src/graphql-relay-fauna/package.json
@@ -3,6 +3,7 @@
   "private": false,
   "version": "0.3.0",
   "main": "./src/index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "homepage": "https://github.com/adeira/universe/tree/master/src/graphql-relay-fauna",
   "description": "Helpers for Relay compliant GraphQL server with FaunaDB backend",

--- a/src/graphql-relay/package.json
+++ b/src/graphql-relay/package.json
@@ -14,6 +14,7 @@
     "url": "http://github.com/adeira/universe.git"
   },
   "main": "./src/index.js",
+  "type": "commonjs",
   "peerDependencies": {
     "graphql": "^15.0.0"
   },

--- a/src/graphql-resolve-wrapper/package.json
+++ b/src/graphql-resolve-wrapper/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "0.3.0",
   "main": "./src/index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@babel/runtime": "^7.14.0"

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "2.1.0",
   "main": "./src/index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@babel/runtime": "^7.14.0"

--- a/src/monorepo-npm-publisher/package.json
+++ b/src/monorepo-npm-publisher/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "2.0.0",
   "main": "./src/index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@adeira/babel-preset-adeira": "^3.0.0",

--- a/src/monorepo-scanner/src/scans/PackageJson.scan.js
+++ b/src/monorepo-scanner/src/scans/PackageJson.scan.js
@@ -9,11 +9,23 @@ Workspaces.iterateWorkspaces((packageJSONLocation) => {
   test(`${packageJson.name}`, () => {
     const dirname = path.dirname(packageJSONLocation);
     const main = packageJson.main;
+    const type = packageJson.type;
+
     if (main != null) {
       const mainEntrypoint = path.join(dirname, main);
       // $FlowIssue[incompatible-call]: https://github.com/facebook/flow/issues/3018
       expect(fs.existsSync(mainEntrypoint)).toGiveHelp(
         `The file specified in main field does not exist (${mainEntrypoint}). If this is intentional, you can remove this field from package.json`,
+      );
+
+      // $FlowIssue[incompatible-call]: https://github.com/facebook/flow/issues/3018
+      expect(type != null).toGiveHelp(
+        `Each package must specify "type" to be either "commonjs" or "module".`,
+      );
+
+      // $FlowIssue[incompatible-call]: https://github.com/facebook/flow/issues/3018
+      expect(['commonjs', 'module'].includes(type)).toGiveHelp(
+        `Package type must be either "commonjs" or "module" (given "${type}").`,
       );
     }
   });

--- a/src/monorepo-utils/package.json
+++ b/src/monorepo-utils/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "0.11.0",
   "main": "./src/index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "bin": {
     "monorepo-babel-node": "bin/monorepo-babel-node.js",

--- a/src/murmur-hash/package.json
+++ b/src/murmur-hash/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "2.0.0",
   "main": "./src/murmurHash.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@babel/runtime": "^7.14.0"

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -3,6 +3,7 @@
   "private": false,
   "version": "3.2.4",
   "main": "./src/index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "homepage": "https://github.com/adeira/universe/tree/master/src/relay",
   "description": "Opinionated wrapper around Relay - a JavaScript framework for building data-driven React applications",

--- a/src/signed-source/package.json
+++ b/src/signed-source/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "2.0.0",
   "main": "./src/SignedSource.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@babel/runtime": "^7.14.0"

--- a/src/sx-design/package.json
+++ b/src/sx-design/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "0.10.0",
   "main": "./index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@adeira/js": "^2.1.0",

--- a/src/sx-jest-snapshot-serializer/package.json
+++ b/src/sx-jest-snapshot-serializer/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "0.1.0",
   "main": "./index.js",
+  "type": "commonjs",
   "sideEffects": true,
   "dependencies": {
     "@adeira/sx": "^0.25.0",

--- a/src/sx-tailwind/package.json
+++ b/src/sx-tailwind/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "0.12.0",
   "main": "./index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@adeira/js": "^2.1.0",

--- a/src/sx/package.json
+++ b/src/sx/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "version": "0.25.0",
   "main": "./index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
     "@adeira/css-colors": "^2.0.0",


### PR DESCRIPTION
See: https://nodejs.org/api/packages.html#packages_determining_module_system

> Package authors should include the "type" field, even in packages where all sources are CommonJS. Being explicit about the type of the package will future-proof the package in case the default type of Node.js ever changes, and it will also make things easier for build tools and loaders to determine how the files in the package should be interpreted.

Related issue: https://github.com/adeira/universe/issues/2341