### PR TITLE
Package.json: add `engines.node`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "src/*"
   ],
   "engines": {
+    "node": ">=14.13.1",
     "yarn": ">=1.0.0"
   },
   "dependencies": {},


### PR DESCRIPTION
In preparation for native ES modules. We support only Node.js 14+ but specifically because of native ES modules we have to restrict it to Node.js version >=14.13.1.

See: https://nodejs.org/en/blog/release/v14.13.0/