### PR TITLE
SX Design: prevent "The above error..." addendum

### DIFF
--- a/src/abacus-backoffice/package.json
+++ b/src/abacus-backoffice/package.json
@@ -17,7 +17,7 @@
     "@adeira/js": "^2.1.0",
     "@adeira/relay": "^3.2.4",
     "@adeira/sx": "^0.25.0",
-    "@adeira/sx-design": "^0.10.0",
+    "@adeira/sx-design": "^0.11.0",
     "fbt": "^0.16.6",
     "immutable": "^4.0.0-rc.12",
     "next": "^10.2.3",

--- a/src/kochka.com.mx/package.json
+++ b/src/kochka.com.mx/package.json
@@ -19,7 +19,7 @@
     "@adeira/js": "^2.1.0",
     "@adeira/relay": "^3.2.4",
     "@adeira/sx": "^0.25.0",
-    "@adeira/sx-design": "^0.10.0",
+    "@adeira/sx-design": "^0.11.0",
     "babel-plugin-fbt": "^0.20.0",
     "babel-plugin-fbt-runtime": "^0.9.17",
     "blurhash": "^1.1.3",

--- a/src/sx-design/package.json
+++ b/src/sx-design/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/sx-design",
   "license": "MIT",
   "private": false,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "main": "./index.js",
   "type": "commonjs",
   "sideEffects": false,

--- a/src/sx-design/src/ErrorBoundary/ErrorBoundary.js
+++ b/src/sx-design/src/ErrorBoundary/ErrorBoundary.js
@@ -39,10 +39,19 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     };
   }
 
+  componentDidMount() {
+    // prevents "The above error..." addendum from React (https://github.com/facebook/react/commit/3938ccc88aa3dcc5a4460474bda40af97dd6e234)
+    window.addEventListener('error', (event) => event.preventDefault());
+  }
+
   componentDidCatch(error: Error, errorInfo: { componentStack: string, ... }): void {
     if (this.props.onComponentDidCatch != null) {
-      // log the error to an error reporting service
+      // allows to log the error to an error reporting service
       this.props.onComponentDidCatch(error, errorInfo);
+    } else {
+      // or simply print the error to console
+      // eslint-disable-next-line no-console
+      console.error(error);
     }
   }
 

--- a/src/sx-design/src/ErrorBoundary/__tests__/ErrorBoundary.test.js
+++ b/src/sx-design/src/ErrorBoundary/__tests__/ErrorBoundary.test.js
@@ -74,8 +74,14 @@ it('does not render the error message in production', () => {
   expect(queryByTestId('errorDev')).toBeNull(); // <<<
   expect(getByText('Retry')).toBeDefined();
 
-  expect(spy.mock.calls[0][0]).toMatch(/^Error: Uncaught \[Error: yadada]/);
-  expect(spy.mock.calls[1][0]).toMatch(/^The above error occurred in the <Throws> component:/);
+  expect(spy.mock.calls[0][0]).toMatchInlineSnapshot(
+    /^Error: Uncaught \[Error: yadada]/,
+    `
+    Object {
+      "_suppressLogging": true,
+    }
+  `,
+  );
   __DEV__ = __PREV_DEV__; // eslint-disable-line no-global-assign
 });
 

--- a/src/sx-design/translations/source_strings.json
+++ b/src/sx-design/translations/source_strings.json
@@ -5,9 +5,9 @@
     "6FVmvS0nS9q0ld8LQ5VSyw==": "An unexpected error has occurred."
    },
    "filepath": "src/ErrorBoundary/ErrorBoundary.js",
-   "line_beg": 60,
+   "line_beg": 69,
    "col_beg": 18,
-   "line_end": 60,
+   "line_end": 69,
    "col_end": 83,
    "desc": "generic error message",
    "project": "",
@@ -19,9 +19,9 @@
     "CR7beIPZB69plBEoMZd6Kg==": "Retry"
    },
    "filepath": "src/ErrorBoundary/ErrorBoundary.js",
-   "line_beg": 71,
+   "line_beg": 80,
    "col_beg": 14,
-   "line_end": 71,
+   "line_end": 80,
    "col_end": 71,
    "desc": "error boundary retry button title",
    "project": "",


### PR DESCRIPTION
This commit prevents the "The above error..." addendum flowing from React when uncaught error is detected (error boundary catches it). Instead, we simply print the error to console (or call user provided callback `onComponentDidCatch` when available).

See: https://github.com/facebook/react/commit/3938ccc88aa3dcc5a4460474bda40af97dd6e234