### PR TITLE
SX: update conditional object invariants

### DIFF
--- a/src/abacus-backoffice/package.json
+++ b/src/abacus-backoffice/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@adeira/js": "^2.1.0",
     "@adeira/relay": "^3.2.4",
-    "@adeira/sx": "^0.25.0",
+    "@adeira/sx": "^0.26.0",
     "@adeira/sx-design": "^0.12.0",
     "fbt": "^0.16.6",
     "graphql": "^15.5.0",

--- a/src/eslint-plugin-sx/package.json
+++ b/src/eslint-plugin-sx/package.json
@@ -24,7 +24,7 @@
     "react": "^17.0.2"
   },
   "peerDependencies": {
-    "@adeira/sx": "^0.25.0",
+    "@adeira/sx": "^0.26.0",
     "eslint": "^7.28.0"
   }
 }

--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -12,7 +12,7 @@
     "@adeira/js": "^2.1.0",
     "@adeira/monorepo-utils": "^0.11.0",
     "@adeira/relay": "^3.2.4",
-    "@adeira/sx": "^0.25.0",
+    "@adeira/sx": "^0.26.0",
     "@artsy/fresnel": "^1.6.0",
     "apollo-server-micro": "^2.25.0",
     "cors": "^2.8.5",

--- a/src/kochka.com.mx/package.json
+++ b/src/kochka.com.mx/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@adeira/js": "^2.1.0",
     "@adeira/relay": "^3.2.4",
-    "@adeira/sx": "^0.25.0",
+    "@adeira/sx": "^0.26.0",
     "@adeira/sx-design": "^0.12.0",
     "babel-plugin-fbt": "^0.20.0",
     "babel-plugin-fbt-runtime": "^0.9.17",

--- a/src/sx-design/package.json
+++ b/src/sx-design/package.json
@@ -17,12 +17,12 @@
     "react-device-detect": "^1.17.0"
   },
   "peerDependencies": {
-    "@adeira/sx": "^0.25.0",
+    "@adeira/sx": "^0.26.0",
     "react": "^17.0.0"
   },
   "devDependencies": {
     "@adeira/babel-preset-adeira": "^3.0.0",
-    "@adeira/sx": "^0.25.0",
+    "@adeira/sx": "^0.26.0",
     "@adeira/sx-jest-snapshot-serializer": "^0.1.0",
     "@babel/core": "^7.14.3",
     "@fbtjs/default-collection-transform": "^0.0.3",

--- a/src/sx-jest-snapshot-serializer/package.json
+++ b/src/sx-jest-snapshot-serializer/package.json
@@ -9,7 +9,7 @@
   "type": "commonjs",
   "sideEffects": true,
   "dependencies": {
-    "@adeira/sx": "^0.25.0",
+    "@adeira/sx": "^0.26.0",
     "@babel/runtime": "^7.14.0",
     "prettier": "^2.3.1",
     "pretty-format": "^27.0.2"

--- a/src/sx-tailwind-website/package.json
+++ b/src/sx-tailwind-website/package.json
@@ -4,7 +4,7 @@
   "license": "UNLICENSED",
   "private": true,
   "dependencies": {
-    "@adeira/sx": "^0.25.0",
+    "@adeira/sx": "^0.26.0",
     "hast-util-to-html": "^7.1.3",
     "next": "^10.2.3",
     "react": "^17.0.2",

--- a/src/sx-tailwind/package.json
+++ b/src/sx-tailwind/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@adeira/js": "^2.1.0",
     "@adeira/signed-source": "^2.0.0",
-    "@adeira/sx": "^0.25.0",
+    "@adeira/sx": "^0.26.0",
     "@babel/runtime": "^7.14.0",
     "change-case": "^4.1.2",
     "fast-levenshtein": "^3.0.0",

--- a/src/sx/package.json
+++ b/src/sx/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/adeira/universe/tree/master/src/sx",
   "license": "MIT",
   "private": false,
-  "version": "0.25.0",
+  "version": "0.26.0",
   "main": "./index.js",
   "type": "commonjs",
   "sideEffects": false,

--- a/src/sx/src/__tests__/create.test.js
+++ b/src/sx/src/__tests__/create.test.js
@@ -99,10 +99,9 @@ it('supports conditional calls', () => {
   expect(styles('button', isEnabled && 'disabled')).toMatchInlineSnapshot(`"_2dHaKY"`);
 
   // alternative syntax:
+  expect(() => styles({ button: false })).not.toThrowError();
+  expect(styles({ button: false })).toBeUndefined();
   expect(styles({ button: true })).toMatchInlineSnapshot(`"_324Crd"`);
-  expect(() => styles({ button: false })).toThrowErrorMatchingInlineSnapshot(
-    `"SX must be called with at least one stylesheet name."`,
-  );
   expect(styles({ button: true, disabled: isDisabled })).toMatchInlineSnapshot(`"_324Crd"`);
   expect(styles({ button: true, disabled: isEnabled })).toMatchInlineSnapshot(`"_2dHaKY"`);
 });
@@ -122,14 +121,22 @@ it('validates incorrect usage', () => {
     aaa: { color: 'red' },
     bbb: { color: 'blue' },
   });
+
+  // $FlowExpectedError[incompatible-call] unexpected yadada
+  expect(() => styles({}, 'yadada')).toThrowErrorMatchingInlineSnapshot(
+    `"SX accepts only one argument when using conditional objects. Either remove the second argument or switch to traditional syntax without conditional objects."`,
+  );
+  expect(() => styles({})).toThrowErrorMatchingInlineSnapshot(
+    `"SX must be called with at least one stylesheet selector (empty object given)."`,
+  );
   expect(() => styles()).toThrowErrorMatchingInlineSnapshot(
     `"SX must be called with at least one stylesheet name."`,
   );
-  // $FlowExpectedError[incompatible-call] ccc
+  // $FlowExpectedError[incompatible-call] unexpected bbc
   expect(() => styles('bbc')).toThrowErrorMatchingInlineSnapshot(
     `"SX was called with 'bbc' stylesheet name but it doesn't exist. Did you mean 'bbb' instead?"`,
   );
-  // $FlowExpectedError[incompatible-call] ccc
+  // $FlowExpectedError[incompatible-call] unexpected ccc
   expect(() => styles('ccc')).toThrowErrorMatchingInlineSnapshot(
     `"SX was called with 'ccc' stylesheet name but it doesn't exist. Did you mean 'aaa' instead?"`,
   );


### PR DESCRIPTION
Previously, we didn't allow conditional objects resulting in no styles, for example:

```
styles({ button: false })
```

This change modifies the invariant constraints to allow such situations and return `undefined`.