### PR TITLE
Abacus: implement product image editations

### DIFF
--- a/src/abacus/schema.graphql
+++ b/src/abacus/schema.graphql
@@ -1,4 +1,4 @@
-# @generated SignedSource<<aad952ec561b05d563f22a0283081c52>>
+# @generated SignedSource<<f8ce14359ad4616ecbd3bf9e481a2a6d>>
 
 enum PriceSortDirection {
   LOW_TO_HIGH
@@ -66,10 +66,35 @@ type ProductMultilingualTranslations {
 }
 
 type CommerceMutation {
+  """
+    Creates a new product.
+
+    Note on uploading product images: image names specified in the GraphQL input must correspond
+    to the uploadables (multipart/form-data) and vice versa. Requests with invalid uploadables
+    will be rejected.
+  """
   productCreate(productMultilingualInput: ProductMultilingualInput!): ProductOrError!
+  """
+    Updates already existing product with new values. It requires not only product KEY but also
+    product REVISION to avoid lost update situations (when someone else tried to update the
+    product and this update would overwrite the latest changes).
+
+    Note on updating product images: already existing image names must be send to the server
+    otherwise they will be deleted. You can optionally specify some extra (new) images to upload
+    them via uploadables. This feature will eventually be used even for images re-ordering.
+  """
   productUpdate(productKey: ID!, productRevision: ID!, productMultilingualInput: ProductMultilingualInput!): ProductOrError!
+  "Deletes product based on the product KEY."
   productDelete(productKey: ID!): ProductOrError!
+  """
+    Publishes product based on the product KEY. Various validation requirements must be met
+    before the product can be published. Published product is available outside of backoffice.
+  """
   productPublish(productKey: ID!): ProductOrError!
+  """
+    Unpublishes product based on the product KEY. Unpublished products are available only inside
+    the backoffice.
+  """
   productUnpublish(productKey: ID!): ProductOrError!
 }
 

--- a/src/abacus/src/commerce/api/mod.rs
+++ b/src/abacus/src/commerce/api/mod.rs
@@ -91,6 +91,11 @@ impl CommerceQuery {
 
 #[juniper::graphql_object(context = Context)]
 impl CommerceMutation {
+    /// Creates a new product.
+    ///
+    /// Note on uploading product images: image names specified in the GraphQL input must correspond
+    /// to the uploadables (multipart/form-data) and vice versa. Requests with invalid uploadables
+    /// will be rejected.
     async fn product_create(
         context: &Context,
         product_multilingual_input: ProductMultilingualInput,
@@ -109,6 +114,13 @@ impl CommerceMutation {
         }
     }
 
+    /// Updates already existing product with new values. It requires not only product KEY but also
+    /// product REVISION to avoid lost update situations (when someone else tried to update the
+    /// product and this update would overwrite the latest changes).
+    ///
+    /// Note on updating product images: already existing image names must be send to the server
+    /// otherwise they will be deleted. You can optionally specify some extra (new) images to upload
+    /// them via uploadables. This feature will eventually be used even for images re-ordering.
     async fn product_update(
         context: &Context,
         product_key: juniper::ID,
@@ -131,6 +143,7 @@ impl CommerceMutation {
         }
     }
 
+    /// Deletes product based on the product KEY.
     async fn product_delete(context: &Context, product_key: juniper::ID) -> ProductOrError {
         match crate::commerce::model::products::delete_product(&context, &product_key).await {
             Ok(product) => ProductOrError::Product(product),
@@ -141,6 +154,8 @@ impl CommerceMutation {
         }
     }
 
+    /// Publishes product based on the product KEY. Various validation requirements must be met
+    /// before the product can be published. Published product is available outside of backoffice.
     async fn product_publish(context: &Context, product_key: juniper::ID) -> ProductOrError {
         match crate::commerce::model::products::publish_product(&context, &product_key).await {
             Ok(product) => ProductOrError::Product(product),
@@ -151,6 +166,8 @@ impl CommerceMutation {
         }
     }
 
+    /// Unpublishes product based on the product KEY. Unpublished products are available only inside
+    /// the backoffice.
     async fn product_unpublish(context: &Context, product_key: juniper::ID) -> ProductOrError {
         match crate::commerce::model::products::unpublish_product(&context, &product_key).await {
             Ok(product) => ProductOrError::Product(product),

--- a/src/abacus/src/commerce/dal/products.rs
+++ b/src/abacus/src/commerce/dal/products.rs
@@ -113,6 +113,7 @@ pub(in crate::commerce) async fn update_product(
             UPDATE {
               _key: @product_key,
               _rev: @product_rev,
+              images: @product_images,
               visibility: @product_visibility,
               updated: DATE_ISO8601(DATE_NOW()),
               price: {
@@ -139,7 +140,7 @@ pub(in crate::commerce) async fn update_product(
         .bind_var("product_key", product_key)
         .bind_var("product_rev", product_revision)
         .bind_var("eshop_locale", String::from("en_US")) // TODO
-        // TODO: product images
+        .bind_var("product_images", json!(images))
         .bind_var(
             "product_visibility",
             json!(product_multilingual_input.visibility),


### PR DESCRIPTION
- all images are uploaded when creating a product
- all new images are uploaded when editing a product
- images which are no longer specified in the GraphQL input are deleted (during product edit)