### PR TITLE
CI: Rust CI path filter

### DIFF
--- a/.github/workflows/continuous-integration-rust.yml
+++ b/.github/workflows/continuous-integration-rust.yml
@@ -24,8 +24,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'src/signedsource-rs/**'
+              - 'src/abacus/**'
+
       # https://github.com/actions-rs/toolchain
       - uses: actions-rs/toolchain@v1.0.7
+        if: steps.changes.outputs.src == 'true'
         with:
           profile: minimal
           components: clippy
@@ -34,6 +43,7 @@ jobs:
 
       # https://github.com/actions-rs/cargo
       - uses: actions-rs/cargo@v1.0.3
+        if: steps.changes.outputs.src == 'true'
         with:
           command: clippy
           # `--all-targets` + `--all-features`   (in order to also check tests and non-default crate features)
@@ -46,6 +56,7 @@ jobs:
       # https://github.com/actions-rs/cargo
       - name: Run all tests
         uses: actions-rs/cargo@v1.0.3
+        if: steps.changes.outputs.src == 'true'
         with:
           command: test
           args: >-


### PR DESCRIPTION
Run CI for Rust projects only when there are changed files in the pull request