### PR TITLE
SX Design: use rounded edges (`Image`, `ProductCard`)

### DIFF
--- a/src/sx-design/src/Image/Image.js
+++ b/src/sx-design/src/Image/Image.js
@@ -6,8 +6,6 @@ import sx from '@adeira/sx';
 import { Blurhash } from 'react-blurhash';
 import { isBlurhashValid } from 'blurhash';
 
-import useSxDesignContext from '../useSxDesignContext';
-
 type Props = {
   +'width': number,
   +'height': number,
@@ -21,7 +19,6 @@ type Props = {
 
 export default function Image(props: Props): Element<'div'> {
   const [isImageLoaded, setImageLoaded] = useState(false);
-  const { theme } = useSxDesignContext();
 
   if (props.src != null) {
     warning(
@@ -34,12 +31,11 @@ export default function Image(props: Props): Element<'div'> {
 
   return (
     <div
-      className={styles({
-        background: true,
-        backgroundLight: theme === 'light',
-        backgroundDark: theme !== 'light',
-      })}
-      style={{ width: props.width, height: props.height }}
+      className={styles('background')}
+      style={{
+        width: props.width,
+        height: props.height,
+      }}
     >
       {isImageLoaded === false && isBlurhashValid(props.blurhash).result === true ? (
         <Blurhash hash={props.blurhash} width={props.width} height={props.height} />
@@ -76,12 +72,8 @@ const styles = sx.create({
   background: {
     display: 'flex',
     flexDirection: 'column',
-  },
-  backgroundLight: {
-    backgroundColor: 'lightgrey',
-  },
-  backgroundDark: {
-    backgroundColor: 'grey',
+    backgroundColor: 'rgba(var(--sx-accent-2))',
+    borderRadius: 'var(--sx-radius)',
   },
   imgSrcLoading: {
     display: 'none',
@@ -89,5 +81,6 @@ const styles = sx.create({
   imgSrc: {
     objectFit: 'cover',
     objectPosition: 'center center',
+    borderRadius: 'var(--sx-radius)',
   },
 });

--- a/src/sx-design/src/ProductCard/ProductCard.js
+++ b/src/sx-design/src/ProductCard/ProductCard.js
@@ -57,7 +57,13 @@ export default function ProductCard(props: Props): Element<'div'> {
     >
       <div className={styles('highlightWrapper')}>
         <Heading xstyle={styles.heading}>
-          <span className={styles(isHovered ? 'highlightHover' : 'highlight', 'highlightBase')}>
+          <span
+            className={styles(
+              isHovered ? 'highlightHover' : 'highlight',
+              'highlightBase',
+              'highlightBaseRounded', // applies only to this highlight
+            )}
+          >
             {props.title}
           </span>
         </Heading>
@@ -87,8 +93,9 @@ const styles = sx.create({
   wrapper: {
     display: 'flex',
     flexDirection: 'column',
-    backgroundColor: 'lightgrey',
+    backgroundColor: 'rgba(var(--sx-accent-2))',
     position: 'relative',
+    borderRadius: 'var(--sx-radius)',
   },
   highlightWrapper: {
     position: 'absolute',
@@ -103,6 +110,9 @@ const styles = sx.create({
     display: 'inline-block',
     marginBottom: 1,
     padding: '1rem',
+  },
+  highlightBaseRounded: {
+    borderStartStartRadius: 'var(--sx-radius)',
   },
   highlight: {
     'color': 'rgba(var(--sx-foreground))',

--- a/src/sx-design/src/Skeleton/Skeleton.js
+++ b/src/sx-design/src/Skeleton/Skeleton.js
@@ -4,21 +4,12 @@ import * as React from 'react';
 import sx from '@adeira/sx';
 
 type Props = {
-  +'squared'?: boolean,
   +'data-testid'?: string,
 };
 
 // Component to be used as a placeholder when loading list of cards.
 export default function Skeleton(props: Props): React.Node {
-  return (
-    <div
-      data-testid={props['data-testid']}
-      className={styles({
-        skeleton: true,
-        skeletonSquared: props.squared === true,
-      })}
-    />
-  );
+  return <div data-testid={props['data-testid']} className={styles('skeleton')} />;
 }
 
 const loading = sx.keyframes({
@@ -44,8 +35,5 @@ const styles = sx.create({
     animationDuration: '8s',
     animationTimingFunction: 'ease-in-out',
     animationIterationCount: 'infinite',
-  },
-  skeletonSquared: {
-    borderRadius: 0,
   },
 });

--- a/src/sx-design/src/Skeleton/Skeleton.stories.js
+++ b/src/sx-design/src/Skeleton/Skeleton.stories.js
@@ -36,9 +36,3 @@ const Template = (args) => (
 // 👇 Each story then reuses that template
 export const DefaultSkeleton: StoryTemplate<typeof Skeleton> = Template.bind({});
 DefaultSkeleton.storyName = 'Default';
-
-export const SquaredSkeleton: StoryTemplate<typeof Skeleton> = Template.bind({});
-SquaredSkeleton.storyName = 'Squared';
-SquaredSkeleton.args = {
-  squared: true,
-};

--- a/src/sx-design/src/Skeleton/__tests__/Skeleton.test.js
+++ b/src/sx-design/src/Skeleton/__tests__/Skeleton.test.js
@@ -12,8 +12,3 @@ it('renders default Skeleton component without any problems', () => {
   const { getByTestId } = render(<Skeleton data-testid="default_skeleton" />);
   expect(getByTestId('default_skeleton')).toBeDefined();
 });
-
-it('renders squared Skeleton component without any problems', () => {
-  const { getByTestId } = render(<Skeleton data-testid="squared_skeleton" squared={true} />);
-  expect(getByTestId('squared_skeleton')).toBeDefined();
-});


### PR DESCRIPTION
Using rounded edges makes it more uniform with the rest of the design system. I also removed `squared` option from `Skeleton` component. It's because this option is not being used and SX Design should implement only what's actually needed and used.