### PR TITLE
SX Design: use `--sx-radius` in `Badge` component

### DIFF
--- a/src/sx-design/.storybook/preview.js
+++ b/src/sx-design/.storybook/preview.js
@@ -12,7 +12,7 @@ export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   backgrounds: {
     disable: false,
-    default: 'dark mode',
+    default: 'light mode',
     values: [
       { name: 'light mode', value: '#fff' },
       { name: 'dark mode', value: DARK_MODE_BACKGROUND },

--- a/src/sx-design/src/Badge/Badge.js
+++ b/src/sx-design/src/Badge/Badge.js
@@ -29,9 +29,9 @@ export default function Badge(props: Props): React.Node {
 const styles = sx.create({
   badgeBase: {
     padding: '2px 7px',
-    borderRadius: 16,
+    borderRadius: 'var(--sx-radius)',
     lineHeight: 1,
-    fontSize: 14,
+    fontSize: 'smaller',
   },
   badgeTintDefault: {
     backgroundColor: 'rgba(var(--sx-foreground), 0.1)',


### PR DESCRIPTION
I also reverted back the default light theme for Storybook - it has issues with triggering the dark mode correctly when it's set by default.