### PR TITLE
CI: enable Yarn dependencies cache

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
       - name: Install Yarn dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
See: https://github.com/actions/setup-node/releases/tag/v2.2.0