### PR TITLE
Revert "CI: enable Yarn dependencies cache"

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
 
       - name: Install Yarn dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
This reverts commit 772daf96

Seems like it's not working as expected (https://github.com/adeira/universe/runs/2972556811?check_suite_focus=true#step:3:19).