### PR TITLE
Shipit: allow specifying glob pattern via CLI

### DIFF
--- a/src/monorepo-shipit/bin/importit.js
+++ b/src/monorepo-shipit/bin/importit.js
@@ -29,7 +29,7 @@ const match = exportedRepoURL.match(gitRegex);
 const packageName = match?.groups?.packageName;
 invariant(packageName != null, 'Cannot figure out package name from: %s', exportedRepoURL);
 
-iterateConfigs((config) => {
+iterateConfigs('/*.js', (config) => {
   if (config.exportedRepoURL === exportedRepoURL) {
     new Set<() => void>([
       createClonePhase(config.exportedRepoURL, config.destinationPath),

--- a/src/monorepo-shipit/bin/shipit.js
+++ b/src/monorepo-shipit/bin/shipit.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
-// @flow strict-local
+// @flow
 
 import chalk from 'chalk';
+import commandLineArgs from 'command-line-args';
 
 import iterateConfigs from '../src/iterateConfigs';
 import createClonePhase from '../src/phases/createClonePhase';
@@ -13,13 +14,24 @@ import createVerifyRepoPhase from '../src/phases/createVerifyRepoPhase';
 import createPushPhase from '../src/phases/createPushPhase';
 
 // yarn monorepo-babel-node src/monorepo-shipit/bin/shipit.js
+// yarn monorepo-babel-node src/monorepo-shipit/bin/shipit.js --glob-pattern="/abacus.js"
 
 type Phase = {
   (): void,
   +readableName: string,
 };
 
-iterateConfigs((config) => {
+const options = commandLineArgs([
+  {
+    // This option allows us to grep subset of config files. Especially useful when running the
+    // Shipit binary locally for testing purposes.
+    name: 'glob-pattern',
+    type: String,
+    defaultValue: '/*.js',
+  },
+]);
+
+iterateConfigs(options['glob-pattern'], (config) => {
   new Set<Phase>([
     createClonePhase(config.exportedRepoURL, config.destinationPath),
     createCheckCorruptedRepoPhase(config.destinationPath),

--- a/src/monorepo-shipit/package.json
+++ b/src/monorepo-shipit/package.json
@@ -14,6 +14,7 @@
     "@adeira/js": "^2.1.0",
     "@adeira/monorepo-utils": "^0.11.0",
     "chalk": "^4.1.1",
+    "command-line-args": "^5.1.2",
     "fast-levenshtein": "^3.0.0"
   }
 }

--- a/src/monorepo-shipit/src/iterateConfigs.js
+++ b/src/monorepo-shipit/src/iterateConfigs.js
@@ -6,8 +6,12 @@ import { findMonorepoRoot, globSync } from '@adeira/monorepo-utils';
 import requireAndValidateConfig from './requireAndValidateConfig';
 import ShipitConfig from './ShipitConfig';
 
-function iterateConfigsInPath(rootPath: string, callback: (ShipitConfig) => void): void {
-  const configFiles = globSync('/*.js', {
+function iterateConfigsInPath(
+  globPattern: string,
+  rootPath: string,
+  callback: (ShipitConfig) => void,
+): void {
+  const configFiles = globSync(globPattern, {
     root: rootPath,
     ignore: [
       '**/node_modules/**',
@@ -59,6 +63,9 @@ function iterateConfigsInPath(rootPath: string, callback: (ShipitConfig) => void
   }
 }
 
-export default function iterateConfigs(callback: (ShipitConfig) => void): void {
-  iterateConfigsInPath(path.join(__dirname, '..', 'config'), callback);
+export default function iterateConfigs(
+  globPattern: string,
+  callback: (ShipitConfig) => void,
+): void {
+  iterateConfigsInPath(globPattern, path.join(__dirname, '..', 'config'), callback);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5128,6 +5128,16 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
+array-back@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
+array-back@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-6.1.2.tgz#e57a39091b3e8bf5dd1ad335155f81fd9e792106"
+  integrity sha512-V/+UG3q3273RgjbayqQrWbdCEFJqGXa5gnvaBnDtmrFlMXQoTypYpu1DVSSrHytX1U72LzL8CkoQS9N86LV9Cw==
+
 array-filter@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-1.0.0.tgz#baf79e62e6ef4c2a4c0b831232daffec251f9d83"
@@ -6629,6 +6639,16 @@ comma-separated-tokens@^1.0.0:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
+
+command-line-args@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.1.2.tgz#25908e573d2214bc23a8437e3df853b02dffa425"
+  integrity sha512-fytTsbndLbl+pPWtS0CxLV3BEWw9wJayB8NnU2cbQqVPsNdYezQeT+uIQv009m+GShnMNyuoBrRo8DTmuTfSCA==
+  dependencies:
+    array-back "^6.1.2"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
 
 commander@^2.19.0, commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
@@ -9058,6 +9078,13 @@ find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
     commondir "^1.0.1"
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
+
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
 
 find-root@^1.1.0:
   version "1.1.0"
@@ -12204,6 +12231,11 @@ lodash.bind@^4.1.4:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
   integrity sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
@@ -17364,6 +17396,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
 
 ua-parser-js@^0.7.18, ua-parser-js@^0.7.24:
   version "0.7.24"


### PR DESCRIPTION
This allows us to filter only a subset of config files when needed. I found this to be a recurring problem when working with Shipit manually.