### PR TITLE
SX Design: allow `children` in `Skeleton`

### DIFF
--- a/src/sx-design/src/Skeleton/Skeleton.js
+++ b/src/sx-design/src/Skeleton/Skeleton.js
@@ -1,15 +1,71 @@
 // @flow
 
-import * as React from 'react';
+import { invariant } from '@adeira/js';
+import React, { useRef, useLayoutEffect, useState, type Node } from 'react';
 import sx from '@adeira/sx';
 
 type Props = {
+  +'children'?: Node,
   +'data-testid'?: string,
+  +'show'?: boolean,
 };
 
-// Component to be used as a placeholder when loading list of cards.
-export default function Skeleton(props: Props): React.Node {
-  return <div data-testid={props['data-testid']} className={styles('skeleton')} />;
+/**
+ * Component to be used as a placeholder when loading list of cards. It matches well with
+ * `ProductCard` component so it can be used as a loader for grid of products.
+ *
+ * Optionally, you can specify `children` property in which case the `Skeleton` component tries to
+ * calculate the height and width of this children.
+ */
+export default function Skeleton(props: Props): Node {
+  const childrenRef = useRef(null);
+  const [childrenRect, setChildrenRect] = useState(null);
+
+  if (props.show != null) {
+    // Property `show` makes only sense when there is a children. It's commonly used for hiding the
+    // skeleton when children loaded successfully (by setting the property to `false`).
+    invariant(props.children != null, 'Property `show` can be used only with `children`.');
+  }
+
+  useLayoutEffect(() => {
+    if (childrenRef.current != null) {
+      const rect = childrenRef.current.getBoundingClientRect();
+      setChildrenRect({
+        width: rect.width,
+        height: rect.height,
+      });
+    }
+  }, []);
+
+  return (
+    <div
+      className={styles({
+        skeleton: true,
+        aspectRatioBox: props.children == null,
+      })}
+      style={
+        childrenRect != null
+          ? {
+              width: childrenRect.width,
+              height: childrenRect.height,
+            }
+          : undefined
+      }
+      data-testid={props['data-testid']}
+    >
+      {props.children != null ? (
+        <div
+          ref={childrenRef}
+          style={{
+            display: 'inline-block',
+            visibility: props.show === true ? 'visible' : 'hidden',
+          }}
+        >
+          {React.Children.only(props.children)}
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 const loading = sx.keyframes({
@@ -18,8 +74,12 @@ const loading = sx.keyframes({
 });
 
 const styles = sx.create({
+  aspectRatioBox: {
+    position: 'relative',
+    width: '100%',
+    paddingBlockEnd: '100%', // = width for a 1:1 aspect ratio (https://css-tricks.com/aspect-ratio-boxes/)
+  },
   skeleton: {
-    height: 250, // TODO: remove this hardcoded value
     backgroundSize: '400% 100%',
     backgroundImage: `
       linear-gradient(

--- a/src/sx-design/src/Skeleton/Skeleton.stories.js
+++ b/src/sx-design/src/Skeleton/Skeleton.stories.js
@@ -6,7 +6,10 @@
 import sx from '@adeira/sx';
 import React from 'react';
 import { rangeMap } from '@adeira/js';
+import fbt from 'fbt';
 
+import Button from '../Button/Button';
+import { initFbt } from '../test-utils';
 import Skeleton from './Skeleton';
 import type { StoryTemplate } from '../types';
 
@@ -14,25 +17,47 @@ import type { StoryTemplate } from '../types';
 export default {
   title: 'Example/Skeleton',
   component: Skeleton,
+  argTypes: {
+    'children': { table: { disable: true } },
+    'data-testid': { table: { disable: true } },
+  },
 };
 
 const styles = sx.create({
   productsGrid: {
     display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))',
     gap: '1rem',
   },
 });
 
+initFbt();
+
 // 👇 We create a "template" of how args map to rendering
-const Template = (args) => (
+const StandaloneTemplate = (args) => <Skeleton {...args} />;
+const GridTemplate = (args) => (
   <div className={styles('productsGrid')}>
-    {rangeMap(12, (i) => (
+    {rangeMap(16, (i) => (
       <Skeleton key={i} {...args} />
     ))}
   </div>
 );
 
 // 👇 Each story then reuses that template
-export const DefaultSkeleton: StoryTemplate<typeof Skeleton> = Template.bind({});
-DefaultSkeleton.storyName = 'Default';
+export const StandaloneSkeleton: StoryTemplate<typeof Skeleton> = StandaloneTemplate.bind({});
+StandaloneSkeleton.storyName = 'Standalone';
+
+export const InGridSkeleton: StoryTemplate<typeof Skeleton> = GridTemplate.bind({});
+InGridSkeleton.storyName = 'In a CSS grid';
+
+export const WithChildrenSkeleton: StoryTemplate<typeof Skeleton> = StandaloneTemplate.bind({});
+WithChildrenSkeleton.storyName = 'With children';
+WithChildrenSkeleton.args = {
+  children: (
+    <Button onClick={() => {}}>
+      <fbt desc="button title" doNotExtract={true}>
+        test button
+      </fbt>
+    </Button>
+  ),
+};

--- a/src/sx-design/src/Skeleton/__tests__/Skeleton.test.js
+++ b/src/sx-design/src/Skeleton/__tests__/Skeleton.test.js
@@ -12,3 +12,23 @@ it('renders default Skeleton component without any problems', () => {
   const { getByTestId } = render(<Skeleton data-testid="default_skeleton" />);
   expect(getByTestId('default_skeleton')).toBeDefined();
 });
+
+it('renders Skeleton component with children without any problems', () => {
+  const { getByTestId } = render(
+    <Skeleton data-testid="skeleton_with_children">
+      <div data-testid="children">children</div>
+    </Skeleton>,
+  );
+  expect(getByTestId('skeleton_with_children')).toBeDefined();
+  expect(getByTestId('children')).toBeDefined();
+});
+
+it('throws when `show` property is used incorrectly', () => {
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  expect(() => {
+    render(<Skeleton data-testid="default_skeleton" show={false} />);
+  }).toThrowErrorMatchingInlineSnapshot(`"Property \`show\` can be used only with \`children\`."`);
+
+  spy.mockRestore();
+});


### PR DESCRIPTION
Skeleton component can optionally have a children component in which case the Skeleton tries to measure dimensions of this child and render itself accordingly.