### PR TITLE
Colors: add `calculateContrastRatio` and `isAccessible`

### DIFF
--- a/src/css-colors/CHANGELOG.md
+++ b/src/css-colors/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Unreleased
 
+# 2.1.0
+
 Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
+Other changes:
+
+- New functions `calculateContrastRatio` and `isAccessible` were added.
+- Functions `isDark` and `isBright` has been deprecated. You can use `isAccessible` function to make a better decision about colors contrast (for text and background colors for example). The following code snippets show possible migration strategy:
+
+  ```js
+  isDark(rgb);
+
+  // replace with:
+  isAccessible(rgb, [255, 255, 255]); // or better to use you actual bg/fg color
+  ```
+
+  ```js
+  isBright(rgb);
+
+  // replace with:
+  isAccessible(rgb, [0, 0, 0]); // or better to use you actual bg/fg color
+  ```
 
 # 2.0.0
 

--- a/src/css-colors/README.md
+++ b/src/css-colors/README.md
@@ -16,7 +16,7 @@ import { cssColorNames } from '@adeira/css-colors';
 cssColorNames.get('rebeccapurple'); // => #663399
 ```
 
-The imported `cssColorNames` is actually a `Map` of all CSS keywords.
+The imported `cssColorNames` is a [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of all CSS keywords, so you can use any available `Map` methods.
 
 ## Is it a color?
 
@@ -26,22 +26,40 @@ import { isColor } from '@adeira/css-colors';
 isColor('#663399'); // true
 isColor('rebeccapurple'); // true
 isColor('rgb(255, 255, 128)'); // true
-isColor('hsl(50, 33%, 25)'); // false (should be 25%)
+isColor('transparent'); // true
+isColor('currentcolor'); // true
+isColor('hsl(50, 33%, 25)'); // false (last number should be 25%)
 ```
 
-## Is the color bright or dark?
+## What is the color contrast ratio?
 
-This function can be used to detect whether the color is bright or dark so you can decide whether you should use white or black text for the color background (for example).
+This function takes triplet of colors for foreground and background colors and calculates their contrast ratio (from 1:1 for no contrast up to 25:1 for excellent contrast):
 
 ```js
-import { isDark, isBright } from '@adeira/css-colors';
+import { calculateContrastRatio } from '@adeira/css-colors';
 
-isDark([0, 0, 0]); // true (it's black)
-isBright([0, 0, 0]); // false
-
-isDark([255, 255, 255]); // false (it's white)
-isBright([255, 255, 255]); // true
+calculateContrastRatio([130, 242, 75], [119, 46, 242]); // 4.27 (4.27:1)
 ```
+
+See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast
+
+## Is the pair of colors accessible?
+
+Allows you to decide whether a pair of two colors (typically foreground and background) is accessible:
+
+```js
+import { isAccessible } from '@adeira/css-colors';
+
+isAccessible([0, 0, 0], [255, 255, 255]); // true (black and white combo)
+
+// optionally, you can specify context of these colors and success criteria for accessibility:
+isAccessible([64, 32, 17], [201, 120, 136], 'NORMAL_TEXT', 'AAA'); // false
+isAccessible([64, 32, 17], [201, 120, 136], 'NORMAL_TEXT', 'AA'); // true
+isAccessible([64, 32, 17], [201, 120, 136], 'LARGE_TEXT', 'AAA'); // true
+isAccessible([64, 32, 17], [201, 120, 136], 'GRAPHICAL_OBJECTS'); // true
+```
+
+Note on colors accessibility: it can happen that some backgrounds are never accessible under **AAA** criteria. For example [`#FF1A1A`](https://webaim.org/resources/contrastchecker/?fcolor=000000&bcolor=FF1A1A) always fails "normal text" test for **AAA** criteria (no matter whether you choose completely white or completely black font).
 
 ## Normalize colors
 
@@ -61,3 +79,22 @@ import { hex3ToHex6, hex6ToHex3 } from '@adeira/css-colors';
 hex3ToHex6('#639'); // #663399
 hex6ToHex3('#663399'); // #639
 ```
+
+## Is the color bright or dark? (DEPRECATED)
+
+This function can be used to detect whether the color is bright or dark, so you can decide whether you should use white or black text for the color background (or vice versa):
+
+```js
+import { isDark, isBright } from '@adeira/css-colors';
+
+isDark([0, 0, 0]); // true (it's black)
+isBright([0, 0, 0]); // false
+
+isDark([144, 238, 144]); // false (lightgreen)
+isBright([144, 238, 144]); // true
+
+isDark([255, 255, 255]); // false (it's white)
+isBright([255, 255, 255]); // true
+```
+
+_Please note that while this function is simple, it takes into account only one color. Consider using [`calculateContrastRatio`](#what-is-the-color-contrast-ratio) and/or [`isAccessible`](#is-the-pair-of-colors-accessible) described above where you can specify 2 colors (for example, text and its background)._

--- a/src/css-colors/package.json
+++ b/src/css-colors/package.json
@@ -2,7 +2,7 @@
   "name": "@adeira/css-colors",
   "description": "Utility functions for working with CSS/HTML colors.",
   "homepage": "https://github.com/adeira/universe/tree/master/src/css-colors",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "sideEffects": false,
   "private": false,
   "main": "./src/index.js",

--- a/src/css-colors/src/__tests__/calculateContrastRatio.test.js
+++ b/src/css-colors/src/__tests__/calculateContrastRatio.test.js
@@ -1,0 +1,47 @@
+// @flow
+
+import calculateContrastRatio from '../calculateContrastRatio';
+
+it.each([
+  [
+    [0, 0, 0], // black foreground
+    [255, 255, 255], // on white background
+    21, // 21:1
+  ],
+  [
+    [255, 255, 255], // white foreground
+    [0, 0, 0], // on black background
+    21, // 21:1
+  ],
+  [
+    [255, 255, 255], // white foreground
+    [255, 255, 255], // on white background
+    1, // 1:1
+  ],
+  [
+    [0, 0, 0], // black foreground
+    [0, 0, 0], // on black background
+    1, // 1:1
+  ],
+  // Some random samples:
+  [
+    [231, 115, 37],
+    [82, 161, 81],
+    1.05, // 1.05:1
+  ],
+  [
+    [130, 242, 75],
+    [119, 46, 242],
+    4.27, // 4.27:1
+  ],
+  [
+    [104, 50, 28],
+    [243, 225, 229],
+    8.11, // 8.11:1
+  ],
+])(
+  'takes %s RGB triplet and %s RGB triplet and calculates %s:1 contrast ratio',
+  (foreground, background, ratio) => {
+    expect(calculateContrastRatio(foreground, background)).toBe(ratio);
+  },
+);

--- a/src/css-colors/src/__tests__/isAccessible.test.js
+++ b/src/css-colors/src/__tests__/isAccessible.test.js
@@ -1,0 +1,31 @@
+// @flow
+
+import isAccessible from '../isAccessible';
+
+it.each`
+  foreground         | background         | context                | AA       | AAA
+  ${[0, 0, 0]}       | ${[255, 255, 255]} | ${'NORMAL_TEXT'}       | ${true}  | ${true}
+  ${[0, 0, 0]}       | ${[255, 255, 255]} | ${'LARGE_TEXT'}        | ${true}  | ${true}
+  ${[0, 0, 0]}       | ${[255, 255, 255]} | ${'GRAPHICAL_OBJECTS'} | ${true}  | ${true}
+  ${[255, 255, 255]} | ${[0, 0, 0]}       | ${'NORMAL_TEXT'}       | ${true}  | ${true}
+  ${[255, 255, 255]} | ${[0, 0, 0]}       | ${'LARGE_TEXT'}        | ${true}  | ${true}
+  ${[255, 255, 255]} | ${[0, 0, 0]}       | ${'GRAPHICAL_OBJECTS'} | ${true}  | ${true}
+  ${[0, 0, 0]}       | ${[0, 0, 0]}       | ${'NORMAL_TEXT'}       | ${false} | ${false}
+  ${[0, 0, 0]}       | ${[0, 0, 0]}       | ${'LARGE_TEXT'}        | ${false} | ${false}
+  ${[0, 0, 0]}       | ${[0, 0, 0]}       | ${'GRAPHICAL_OBJECTS'} | ${false} | ${false}
+  ${[255, 255, 255]} | ${[255, 255, 255]} | ${'NORMAL_TEXT'}       | ${false} | ${false}
+  ${[255, 255, 255]} | ${[255, 255, 255]} | ${'LARGE_TEXT'}        | ${false} | ${false}
+  ${[255, 255, 255]} | ${[255, 255, 255]} | ${'GRAPHICAL_OBJECTS'} | ${false} | ${false}
+  ${[64, 32, 17]}    | ${[201, 120, 136]} | ${'NORMAL_TEXT'}       | ${true}  | ${false}
+  ${[64, 32, 17]}    | ${[201, 120, 136]} | ${'LARGE_TEXT'}        | ${true}  | ${true}
+  ${[64, 32, 17]}    | ${[201, 120, 136]} | ${'GRAPHICAL_OBJECTS'} | ${true}  | ${true}
+  ${[77, 38, 20]}    | ${[201, 120, 136]} | ${'NORMAL_TEXT'}       | ${false} | ${false}
+  ${[77, 38, 20]}    | ${[201, 120, 136]} | ${'LARGE_TEXT'}        | ${true}  | ${false}
+  ${[77, 38, 20]}    | ${[201, 120, 136]} | ${'GRAPHICAL_OBJECTS'} | ${true}  | ${true}
+`(
+  '$foreground on $background in $context context results in AA:$AA and AAA:$AAA',
+  ({ foreground, background, context, AA, AAA }) => {
+    expect(isAccessible(foreground, background, context, 'AA')).toBe(AA);
+    expect(isAccessible(foreground, background, context, 'AAA')).toBe(AAA);
+  },
+);

--- a/src/css-colors/src/calculateContrastRatio.js
+++ b/src/css-colors/src/calculateContrastRatio.js
@@ -1,0 +1,44 @@
+// @flow strict
+
+/**
+ * Contrast ratio is defined as:
+ *  (L1 + 0.05) / (L2 + 0.05), where:
+ *    L1 is the relative luminance of the lighter of the colors, and
+ *    L2 is the relative luminance of the darker of the colors.
+ *
+ * Relative luminance is defined as:
+ *  L = 0.2126 * R + 0.7152 * G + 0.0722 * B, where:
+ *    if RsRGB <= 0.03928 then R = RsRGB/12.92 else R = ((RsRGB+0.055)/1.055) ^ 2.4
+ *    if GsRGB <= 0.03928 then G = GsRGB/12.92 else G = ((GsRGB+0.055)/1.055) ^ 2.4
+ *    if BsRGB <= 0.03928 then B = BsRGB/12.92 else B = ((BsRGB+0.055)/1.055) ^ 2.4, where:
+ *      RsRGB = R8bit/255
+ *      GsRGB = G8bit/255
+ *      BsRGB = B8bit/255
+ *
+ * See: https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio
+ * See: https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+ * See: https://webaim.org/resources/contrastchecker/
+ */
+export default function calculateContrastRatio(
+  rgbForeground: [number, number, number],
+  rgbBackground: [number, number, number],
+): number {
+  const L1 = calculateRelativeLuminance(...rgbForeground);
+  const L2 = calculateRelativeLuminance(...rgbBackground);
+  const ratio = (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
+  return Math.round(ratio * 100) / 100;
+}
+
+function calculateRelativeLuminance(R8bit: number, G8bit: number, B8bit: number): number {
+  const R = calculateRelativeLuminancePart(R8bit / 255);
+  const G = calculateRelativeLuminancePart(G8bit / 255);
+  const B = calculateRelativeLuminancePart(B8bit / 255);
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+}
+
+function calculateRelativeLuminancePart(sRGB: number): number {
+  if (sRGB <= 0.03928) {
+    return sRGB / 12.92;
+  }
+  return ((sRGB + 0.055) / 1.055) ** 2.4;
+}

--- a/src/css-colors/src/index.js
+++ b/src/css-colors/src/index.js
@@ -1,8 +1,10 @@
 // @flow strict
 
+export { default as calculateContrastRatio } from './calculateContrastRatio';
 export { default as cssColorNames } from './cssColorNames';
 export { default as hex3ToHex6 } from './hex3ToHex6';
 export { default as hex6ToHex3 } from './hex6ToHex3';
+export { default as isAccessible } from './isAccessible';
 export { default as isBright } from './isBright';
 export { default as isColor } from './isColor';
 export { default as isDark } from './isDark';

--- a/src/css-colors/src/isAccessible.js
+++ b/src/css-colors/src/isAccessible.js
@@ -1,0 +1,52 @@
+// @flow strict
+
+import calculateContrastRatio from './calculateContrastRatio';
+
+type ContrastContext =
+  | 'NORMAL_TEXT' // body text
+  | 'LARGE_TEXT' // large-scale text (120-150% larger than body text)
+  | 'GRAPHICAL_OBJECTS'; // active user interface components and graphical objects such as icons and graphs
+
+type SuccessCriteria =
+  | 'AA' // minimum ratio (AA rating)
+  | 'AAA'; // enhanced ratio (AAA rating)
+
+/**
+ * WCAG 2.0 level AA requires a contrast ratio of at least 4.5:1 for normal text and 3:1 for large
+ * text. WCAG 2.1 requires a contrast ratio of at least 3:1 for graphics and user interface
+ * components (such as form input borders). WCAG Level AAA requires a contrast ratio of at least 7:1
+ * for normal text and 4.5:1 for large text.
+ *
+ * Enhanced ratio for graphical objects is not defined.
+ */
+export default function isAccessible(
+  rgbForeground: [number, number, number],
+  rgbBackground: [number, number, number],
+  context: ContrastContext = 'NORMAL_TEXT',
+  successCriteria: SuccessCriteria = 'AA',
+): boolean {
+  const contrast = calculateContrastRatio(rgbForeground, rgbBackground);
+
+  if (successCriteria === 'AA') {
+    if (context === 'NORMAL_TEXT') {
+      return contrast >= 4.5;
+    } else if (context === 'LARGE_TEXT' || context === 'GRAPHICAL_OBJECTS') {
+      return contrast >= 3.0;
+    }
+    (context: empty);
+    return false;
+  } else if (successCriteria === 'AAA') {
+    if (context === 'NORMAL_TEXT') {
+      return contrast >= 7.0;
+    } else if (context === 'LARGE_TEXT') {
+      return contrast >= 4.5;
+    } else if (context === 'GRAPHICAL_OBJECTS') {
+      // technically, this is not defined so we use the value from AA rating
+      return contrast >= 3.0;
+    }
+    (context: empty);
+    return false;
+  }
+  (successCriteria: empty);
+  return false;
+}

--- a/src/css-colors/src/isBright.js
+++ b/src/css-colors/src/isBright.js
@@ -2,6 +2,18 @@
 
 import calculateBrightness from './calculateBrightness';
 
+/**
+ * @deprecated It's a bit funky to take into account only one color and decide whether it's bright
+ * or not. While one color might be bright, it doesn't say much about colors accessibility and it
+ * doesn't allow to compare text vs. background colors for example. These two calls are basically
+ * equivalent:
+ *
+ * ```js
+ * isBright(rgb);
+ *
+ * isAccessible(rgb, [0, 0, 0]); // comparing with black background
+ * ```
+ */
 export default function isBright(rgb: [number, number, number]): boolean {
   return calculateBrightness(rgb) >= 128;
 }

--- a/src/css-colors/src/isDark.js
+++ b/src/css-colors/src/isDark.js
@@ -2,6 +2,18 @@
 
 import calculateBrightness from './calculateBrightness';
 
+/**
+ * @deprecated It's a bit funky to take into account only one color and decide whether it's bright
+ * or not. While one color might be bright, it doesn't say much about colors accessibility and it
+ * doesn't allow to compare text vs. background colors for example. These two calls are basically
+ * equivalent:
+ *
+ * ```js
+ * isDark(rgb);
+ *
+ * isAccessible(rgb, [255, 255, 255]); // comparing with white background
+ * ```
+ */
 export default function isDark(rgb: [number, number, number]): boolean {
   return calculateBrightness(rgb) < 128;
 }

--- a/src/sx-design/.storybook/SxDesignTheme.js
+++ b/src/sx-design/.storybook/SxDesignTheme.js
@@ -1,0 +1,9 @@
+// @flow
+
+import { create } from '@storybook/theming';
+
+export default (create({
+  base: 'light',
+  brandTitle: 'SX Design Storybook',
+  brandUrl: 'https://github.com/adeira/sx-design',
+}): $FlowFixMe);

--- a/src/sx-design/.storybook/manager.js
+++ b/src/sx-design/.storybook/manager.js
@@ -2,6 +2,9 @@
 
 import { addons } from '@storybook/addons';
 
+import SxDesignTheme from './SxDesignTheme';
+
 addons.setConfig({
   panelPosition: 'right',
+  theme: SxDesignTheme,
 });

--- a/src/sx-design/package.json
+++ b/src/sx-design/package.json
@@ -9,6 +9,7 @@
   "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
+    "@adeira/css-colors": "^2.1.0",
     "@adeira/icons": "^0.3.0",
     "@adeira/js": "^2.1.0",
     "@babel/runtime": "^7.14.6",
@@ -35,6 +36,7 @@
     "@storybook/addon-viewport": "^6.3.4",
     "@storybook/addons": "^6.3.4",
     "@storybook/react": "^6.3.4",
+    "@storybook/theming": "^6.3.4",
     "@testing-library/react": "^12.0.0",
     "babel-loader": "^8.2.2",
     "babel-plugin-fbt": "^0.20.0",

--- a/src/sx-design/src/stories/ColorShowcase.js
+++ b/src/sx-design/src/stories/ColorShowcase.js
@@ -1,23 +1,42 @@
-// @flow strict
+// @flow
 
+import { isAccessible } from '@adeira/css-colors';
+import { useEffect, useState } from 'react';
 import * as React from 'react';
 
+import { SX_DESIGN_REACT_PORTAL_ID } from '../SxDesignPortal';
+
 type Props = {
-  +color: string,
+  +colorVar: string,
 };
 
 export default function ColorShowcase(props: Props): React.Node {
+  const [shouldUseForeground, setShouldUseForeground] = useState(true);
+
+  useEffect(() => {
+    const root = document.querySelector(`#${SX_DESIGN_REACT_PORTAL_ID}`);
+    if (root) {
+      const style = window.getComputedStyle(root);
+      const foregroundColor = style.getPropertyValue('--sx-foreground');
+      const backgroundColor = style.getPropertyValue(props.colorVar);
+      setShouldUseForeground(
+        isAccessible(foregroundColor.split(','), backgroundColor.split(','), 'NORMAL_TEXT'),
+      );
+    }
+  }, [props.colorVar]);
+
   return (
     <div
       style={{
-        backgroundColor: props.color,
+        color: shouldUseForeground ? 'rgba(var(--sx-foreground))' : 'rgba(var(--sx-background))',
+        backgroundColor: `rgba(var(${props.colorVar}))`,
         paddingTop: 5,
         paddingBottom: 5,
         paddingLeft: 10,
         paddingRight: 10,
       }}
     >
-      {props.color}
+      rgba(var({props.colorVar}))
     </div>
   );
 }

--- a/src/sx-design/src/stories/Colors.stories.mdx
+++ b/src/sx-design/src/stories/Colors.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import SxDesignProvider from '../SxDesignProvider';
 import ColorShowcase from './ColorShowcase';
 
@@ -8,57 +8,57 @@ import ColorShowcase from './ColorShowcase';
 
 <Canvas>
   <SxDesignProvider>
-    <ColorShowcase color="rgba(var(--sx-error-lighter))" />
-    <ColorShowcase color="rgba(var(--sx-error-light))" />
-    <ColorShowcase color="rgba(var(--sx-error))" />
-    <ColorShowcase color="rgba(var(--sx-error-dark))" />
+    <ColorShowcase colorVar="--sx-error-lighter" />
+    <ColorShowcase colorVar="--sx-error-light" />
+    <ColorShowcase colorVar="--sx-error" />
+    <ColorShowcase colorVar="--sx-error-dark" />
   </SxDesignProvider>
 </Canvas>
 
 <Canvas>
   <SxDesignProvider>
-    <ColorShowcase color="rgba(var(--sx-success-lighter))" />
-    <ColorShowcase color="rgba(var(--sx-success-light))" />
-    <ColorShowcase color="rgba(var(--sx-success))" />
-    <ColorShowcase color="rgba(var(--sx-success-dark))" />
+    <ColorShowcase colorVar="--sx-success-lighter" />
+    <ColorShowcase colorVar="--sx-success-light" />
+    <ColorShowcase colorVar="--sx-success" />
+    <ColorShowcase colorVar="--sx-success-dark" />
   </SxDesignProvider>
 </Canvas>
 
 <Canvas>
   <SxDesignProvider>
-    <ColorShowcase color="rgba(var(--sx-warning-lighter))" />
-    <ColorShowcase color="rgba(var(--sx-warning-light))" />
-    <ColorShowcase color="rgba(var(--sx-warning))" />
-    <ColorShowcase color="rgba(var(--sx-warning-dark))" />
+    <ColorShowcase colorVar="--sx-warning-lighter" />
+    <ColorShowcase colorVar="--sx-warning-light" />
+    <ColorShowcase colorVar="--sx-warning" />
+    <ColorShowcase colorVar="--sx-warning-dark" />
   </SxDesignProvider>
 </Canvas>
 
 <Canvas>
   <SxDesignProvider theme="light">
     <em>colors for light theme</em>
-    <ColorShowcase color="rgba(var(--sx-background))" />
-    <ColorShowcase color="rgba(var(--sx-accent-1))" />
-    <ColorShowcase color="rgba(var(--sx-accent-2))" />
-    <ColorShowcase color="rgba(var(--sx-accent-3))" />
-    <ColorShowcase color="rgba(var(--sx-accent-4))" />
-    <ColorShowcase color="rgba(var(--sx-accent-5))" />
-    <ColorShowcase color="rgba(var(--sx-accent-6))" />
-    <ColorShowcase color="rgba(var(--sx-accent-7))" />
-    <ColorShowcase color="rgba(var(--sx-foreground))" />
+    <ColorShowcase colorVar="--sx-background" />
+    <ColorShowcase colorVar="--sx-accent-1" />
+    <ColorShowcase colorVar="--sx-accent-2" />
+    <ColorShowcase colorVar="--sx-accent-3" />
+    <ColorShowcase colorVar="--sx-accent-4" />
+    <ColorShowcase colorVar="--sx-accent-5" />
+    <ColorShowcase colorVar="--sx-accent-6" />
+    <ColorShowcase colorVar="--sx-accent-7" />
+    <ColorShowcase colorVar="--sx-foreground" />
   </SxDesignProvider>
 </Canvas>
 
 <Canvas>
   <SxDesignProvider theme="dark">
     <em>colors for dark theme (it's not a simple reverse of light mode)</em>
-    <ColorShowcase color="rgba(var(--sx-background))" />
-    <ColorShowcase color="rgba(var(--sx-accent-1))" />
-    <ColorShowcase color="rgba(var(--sx-accent-2))" />
-    <ColorShowcase color="rgba(var(--sx-accent-3))" />
-    <ColorShowcase color="rgba(var(--sx-accent-4))" />
-    <ColorShowcase color="rgba(var(--sx-accent-5))" />
-    <ColorShowcase color="rgba(var(--sx-accent-6))" />
-    <ColorShowcase color="rgba(var(--sx-accent-7))" />
-    <ColorShowcase color="rgba(var(--sx-foreground))" />
+    <ColorShowcase colorVar="--sx-background" />
+    <ColorShowcase colorVar="--sx-accent-1" />
+    <ColorShowcase colorVar="--sx-accent-2" />
+    <ColorShowcase colorVar="--sx-accent-3" />
+    <ColorShowcase colorVar="--sx-accent-4" />
+    <ColorShowcase colorVar="--sx-accent-5" />
+    <ColorShowcase colorVar="--sx-accent-6" />
+    <ColorShowcase colorVar="--sx-accent-7" />
+    <ColorShowcase colorVar="--sx-foreground" />
   </SxDesignProvider>
 </Canvas>

--- a/src/sx-design/src/stories/Introduction.stories.mdx
+++ b/src/sx-design/src/stories/Introduction.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Meta } from '@storybook/addon-docs';
 import Code from './assets/code-brackets.svg';
 import Colors from './assets/colors.svg';
 import Comments from './assets/comments.svg';

--- a/src/sx/package.json
+++ b/src/sx/package.json
@@ -9,7 +9,7 @@
   "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
-    "@adeira/css-colors": "^2.0.0",
+    "@adeira/css-colors": "^2.1.0",
     "@adeira/js": "^2.1.0",
     "@adeira/murmur-hash": "^2.0.0",
     "@adeira/signed-source": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3494,7 +3494,7 @@
     resolve-from "^5.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/theming@6.3.4":
+"@storybook/theming@6.3.4", "@storybook/theming@^6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.3.4.tgz#69d3f912c74a7b6ba78c1c95fac3315356468bdd"
   integrity sha512-L0lJcwUi7mse+U7EBAv5NVt81mH1MtUzk9paik8hMAc68vDtR/X0Cq4+zPsgykCROOTtEGrQ/JUUrpcEqeprTQ==


### PR DESCRIPTION
The main change in this commit are 2 new functions `calculateContrastRatio` and `isAccessible` (+ deprecation of `isDark` and `isBright`). Function `isAccessible` is better for making decisions about color contrast when it comes to font and background because it takes the actual font and background into account (`isDark` and `isBright` are taking only one color into account completely ignoring the other).

I've shown the use-case in `ColorShowcase` inside SX Design. This commit is a first step towards a new `<Text />` for SX Design. This component should be able to render accessible color based on the background color of its parent.