### PR TITLE
Colors: add new function `convertToRGBTriplet`

### DIFF
--- a/src/css-colors/CHANGELOG.md
+++ b/src/css-colors/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Added experimental function `convertToRGBTriplet`. Purpose of this function is to get any supported [color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) and convert it to the internal RGB triplet value.
+
 # 2.1.0
 
 Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.

--- a/src/css-colors/README.md
+++ b/src/css-colors/README.md
@@ -98,3 +98,7 @@ isBright([255, 255, 255]); // true
 ```
 
 _Please note that while this function is simple, it takes into account only one color. Consider using [`calculateContrastRatio`](#what-is-the-color-contrast-ratio) and/or [`isAccessible`](#is-the-pair-of-colors-accessible) described above where you can specify 2 colors (for example, text and its background)._
+
+## `convertToRGBTriplet`
+
+TKTK

--- a/src/css-colors/src/__tests__/__snapshots__/convertToRGBTriplet.test.js.snap
+++ b/src/css-colors/src/__tests__/__snapshots__/convertToRGBTriplet.test.js.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`converts #F09F => null 1`] = `"Conversion of color \\"#F09F\\" is currently not supported."`;
+
+exports[`converts #FF0099FF => null 1`] = `"Conversion of color \\"#FF0099FF\\" is currently not supported."`;
+
+exports[`converts #f09f => null 1`] = `"Conversion of color \\"#f09f\\" is currently not supported."`;
+
+exports[`converts #ff0099ff => null 1`] = `"Conversion of color \\"#ff0099ff\\" is currently not supported."`;
+
+exports[`converts currentcolor => null 1`] = `"Conversion of color \\"currentcolor\\" is currently not supported."`;
+
+exports[`converts hsl(.75turn, 60%, 70%) => null 1`] = `"Conversion of color \\"hsl(.75turn, 60%, 70%)\\" is currently not supported."`;
+
+exports[`converts hsl(4.71239rad, 60%, 70%) => null 1`] = `"Conversion of color \\"hsl(4.71239rad, 60%, 70%)\\" is currently not supported."`;
+
+exports[`converts hsl(270 60% 50% / .15) => null 1`] = `"Conversion of color \\"hsl(270 60% 50% / .15)\\" is currently not supported."`;
+
+exports[`converts hsl(270 60% 50% / 15%) => null 1`] = `"Conversion of color \\"hsl(270 60% 50% / 15%)\\" is currently not supported."`;
+
+exports[`converts hsl(270 60% 50%/.15) => null 1`] = `"Conversion of color \\"hsl(270 60% 50%/.15)\\" is currently not supported."`;
+
+exports[`converts hsl(270 60% 70%) => null 1`] = `"Conversion of color \\"hsl(270 60% 70%)\\" is currently not supported."`;
+
+exports[`converts hsl(270, 60%, 50%, .15) => null 1`] = `"Conversion of color \\"hsl(270, 60%, 50%, .15)\\" is currently not supported."`;
+
+exports[`converts hsl(270, 60%, 50%, 15%) => null 1`] = `"Conversion of color \\"hsl(270, 60%, 50%, 15%)\\" is currently not supported."`;
+
+exports[`converts hsl(270, 60%, 70%) => null 1`] = `"Conversion of color \\"hsl(270, 60%, 70%)\\" is currently not supported."`;
+
+exports[`converts hsl(270deg, 60%, 70%) => null 1`] = `"Conversion of color \\"hsl(270deg, 60%, 70%)\\" is currently not supported."`;
+
+exports[`converts hsla(.75turn, 60%, 70%) => null 1`] = `"Conversion of color \\"hsla(.75turn, 60%, 70%)\\" is currently not supported."`;
+
+exports[`converts hsla(4.71239rad, 60%, 70%) => null 1`] = `"Conversion of color \\"hsla(4.71239rad, 60%, 70%)\\" is currently not supported."`;
+
+exports[`converts hsla(270 60% 50% / .15) => null 1`] = `"Conversion of color \\"hsla(270 60% 50% / .15)\\" is currently not supported."`;
+
+exports[`converts hsla(270 60% 50% / 15%) => null 1`] = `"Conversion of color \\"hsla(270 60% 50% / 15%)\\" is currently not supported."`;
+
+exports[`converts hsla(270 60% 70%) => null 1`] = `"Conversion of color \\"hsla(270 60% 70%)\\" is currently not supported."`;
+
+exports[`converts hsla(270, 60%, 50%, .15) => null 1`] = `"Conversion of color \\"hsla(270, 60%, 50%, .15)\\" is currently not supported."`;
+
+exports[`converts hsla(270, 60%, 50%, 15%) => null 1`] = `"Conversion of color \\"hsla(270, 60%, 50%, 15%)\\" is currently not supported."`;
+
+exports[`converts hsla(270, 60%, 70%) => null 1`] = `"Conversion of color \\"hsla(270, 60%, 70%)\\" is currently not supported."`;
+
+exports[`converts hsla(270deg, 60%, 70%) => null 1`] = `"Conversion of color \\"hsla(270deg, 60%, 70%)\\" is currently not supported."`;
+
+exports[`converts transparent => null 1`] = `"Conversion of color \\"transparent\\" is currently not supported."`;

--- a/src/css-colors/src/__tests__/convertToRGBTriplet.test.js
+++ b/src/css-colors/src/__tests__/convertToRGBTriplet.test.js
@@ -1,0 +1,16 @@
+// @flow strict
+
+import convertToRGBTriplet from '../convertToRGBTriplet';
+import { validColors } from './fixtures/validColors';
+
+test.each([
+  ...validColors.keywords.map(([color, colorTriplet]) => [color, colorTriplet]),
+  ...validColors.hexadecimal.map(([color, colorTriplet]) => [color, colorTriplet]),
+  ...validColors.functional.map(([color, colorTriplet]) => [color, colorTriplet]),
+])('converts %s => %s', (color, colorTriplet) => {
+  if (colorTriplet === null) {
+    expect(() => convertToRGBTriplet(color)).toThrowErrorMatchingSnapshot();
+  } else {
+    expect(convertToRGBTriplet(color)).toEqual(colorTriplet);
+  }
+});

--- a/src/css-colors/src/__tests__/fixtures/validColors.js
+++ b/src/css-colors/src/__tests__/fixtures/validColors.js
@@ -1,0 +1,69 @@
+// @flow strict
+
+// All these colors are valid according to:
+// https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
+export const validColors = {
+  keywords: [
+    ['blue', [0, 0, 255]],
+    ['aliceblue', [240, 248, 255]],
+    ['transparent', null],
+    ['currentcolor', null],
+  ],
+  hexadecimal: [
+    ['#f09', [255, 0, 153]],
+    ['#F09', [255, 0, 153]],
+    ['#ff0099', [255, 0, 153]],
+    ['#FF0099', [255, 0, 153]],
+    ['#f09f', null],
+    ['#F09F', null],
+    ['#ff0099ff', null],
+    ['#FF0099FF', null],
+  ],
+  functional: [
+    // RGB:
+    ['rgb(255, 0, 153)', [255, 0, 153]],
+    ['rgb(255, 0, 153.0)', [255, 0, 153]],
+    ['rgb(100%, 0%, 60%)', [255, 0, 153]],
+    ['rgb(255 0 153)', [255, 0, 153]],
+    ['rgb(255, 0, 153, 1)', [255, 0, 153]], // TODO: we ignore the alpha channel
+    ['rgb(255, 0, 153, 100%)', [255, 0, 153]], // TODO: we ignore the alpha channel
+    ['rgb(255 0 153/1)', [255, 0, 153]], // TODO: we ignore the alpha channel
+    ['rgb(255 0 153 / 1)', [255, 0, 153]], // TODO: we ignore the alpha channel
+    ['rgb(255 0 153 / 100%)', [255, 0, 153]], // TODO: we ignore the alpha channel
+    ['rgb(255, 0, 153.6, 1)', [255, 0, 153.6]], // TODO: we ignore the alpha channel
+    ['rgb(1e2, .5e1, .5e0, +.25e2%)', [100, 5, 0.5]], // TODO: we ignore the alpha channel
+
+    // RGBA:
+    ['rgba(51, 170, 51, .1)', [51, 170, 51]], // TODO: we ignore the alpha channel
+    ['rgba(51, 170, 51, .4)', [51, 170, 51]], // TODO: we ignore the alpha channel
+    ['rgba(51, 170, 51, .7)', [51, 170, 51]], // TODO: we ignore the alpha channel
+    ['rgba(51, 170, 51, 1)', [51, 170, 51]], // TODO: we ignore the alpha channel
+    ['rgba(51 170 51 / 0.4)', [51, 170, 51]], // TODO: we ignore the alpha channel
+    ['rgba(51 170 51 / 40%)', [51, 170, 51]], // TODO: we ignore the alpha channel
+    ['rgba(255, 0, 153.6, 1)', [255, 0, 153.6]], // TODO: we ignore the alpha channel
+    ['rgba(1e2, .5e1, .5e0, +.25e2%)', [100, 5, 0.5]], // TODO: we ignore the alpha channel
+
+    // HSL:
+    ['hsl(270, 60%, 70%)', null],
+    ['hsl(270 60% 70%)', null],
+    ['hsl(270deg, 60%, 70%)', null],
+    ['hsl(4.71239rad, 60%, 70%)', null],
+    ['hsl(.75turn, 60%, 70%)', null],
+    ['hsl(270, 60%, 50%, .15)', null],
+    ['hsl(270, 60%, 50%, 15%)', null],
+    ['hsl(270 60% 50%/.15)', null],
+    ['hsl(270 60% 50% / .15)', null],
+    ['hsl(270 60% 50% / 15%)', null],
+
+    // HSLA:
+    ['hsla(270, 60%, 70%)', null],
+    ['hsla(270 60% 70%)', null],
+    ['hsla(270deg, 60%, 70%)', null],
+    ['hsla(4.71239rad, 60%, 70%)', null],
+    ['hsla(.75turn, 60%, 70%)', null],
+    ['hsla(270, 60%, 50%, .15)', null],
+    ['hsla(270, 60%, 50%, 15%)', null],
+    ['hsla(270 60% 50% / .15)', null],
+    ['hsla(270 60% 50% / 15%)', null],
+  ],
+};

--- a/src/css-colors/src/__tests__/isColor.test.js
+++ b/src/css-colors/src/__tests__/isColor.test.js
@@ -1,127 +1,38 @@
 // @flow strict
 
-import isColor, { _number } from '../isColor';
-
-// https://developer.mozilla.org/en-US/docs/Web/CSS/number
-test.each([
-  ['0', true],
-  ['12', true],
-  ['4.01', true],
-  ['-456.8', true],
-  ['0.0', true],
-  ['+0.0', true],
-  ['-0.0', true],
-  ['.60', true],
-  ['10e3', true],
-  ['-3.4e-2', true],
-  ['-3.4e+2', true],
-  ['.60.8', false],
-  ['12.', false],
-  ['+-12.2', false],
-  ['12.1.1', false],
-])('is %s a number? (%s)', (number, result) => {
-  expect(new RegExp(`^${_number}$`).test(number)).toBe(result);
-});
+import isColor from '../isColor';
+import { validColors } from './fixtures/validColors';
 
 // See: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Examples
 test.each([
   [1, false],
   [true, false],
   ['unknown', false],
-  ['blue', true],
-  ['aliceblue', true],
-  ['transparent', true],
-  ['currentcolor', true],
-])('detects keyword color "%s" correctly (%s)', (color, result) => {
+  ...validColors.keywords.map(([color]) => [color, true]),
+])('detects keyword colors "%s" correctly (%s)', (color, result) => {
   expect(isColor(color)).toBe(result);
 });
 
 test.each([
-  ['#f09', true],
-  ['#F09', true],
-  ['#ff0099', true],
-  ['#FF0099', true],
-  ['#f09f', true],
-  ['#F09F', true],
-  ['#ff0099ff', true],
-  ['#FF0099FF', true],
+  ['#aa', false],
   ['#xxxxxx', false],
-])('detects hexadecimal color "%s" correctly (%s)', (color, result) => {
+  ...validColors.hexadecimal.map(([color]) => [color, true]),
+])('detects hexadecimal colors "%s" correctly (%s)', (color, result) => {
   expect(isColor(color)).toBe(result);
 });
 
 test.each([
-  ['rgb(255, 0, 153)', true],
-  ['rgb(255, 0, 153.0)', true],
-  ['rgb(100%, 0%, 60%)', true],
-  ['rgb(100%, 0, 60%)', true], // normally, this would be an error (but we are benevolent)
-  ['rgb(255 0 153)', true],
-  ['rgb(255, 0, 153, 1)', true],
-  ['rgb(255, 0, 153, 100%)', true],
-  ['rgb(255 0 153/1)', true],
-  ['rgb(255 0 153 / 1)', true],
-  ['rgb(255 0 153 / 100%)', true],
-  ['rgb(255, 0, 153.6, 1)', true],
-  ['rgb(1e2, .5e1, .5e0, +.25e2%)', true],
+  ['rgb(100%, 0, 60%)', true], // normally, this would be an error (but we are benevolent), TODO: stop being benevolent
+  ['hsl(270, 60%, 70)', true], // normally, this would be an error (but we are benevolent), TODO: stop being benevolent
+  ['hsl(270, 60, 70%)', true], // normally, this would be an error (but we are benevolent), TODO: stop being benevolent
+  ['hsla(270, 60%, 70)', true], // normally, this would be an error (but we are benevolent), TODO: stop being benevolent
+  ['hsla(270, 60, 70%)', true], // normally, this would be an error (but we are benevolent), TODO: stop being benevolent
   ['rgb(tada)', false],
   ['rgb(a, b, c)', false],
-])('detects RGB color "%s" correctly (%s)', (color, result) => {
-  expect(isColor(color)).toBe(result);
-  expect(isColor(color.toUpperCase())).toBe(result);
-  expect(isColor(color.replace(/,\s/, ','))).toBe(result);
-});
-
-test.each([
-  ['rgba(51, 170, 51, .1)', true],
-  ['rgba(51, 170, 51, .4)', true],
-  ['rgba(51, 170, 51, .7)', true],
-  ['rgba(51, 170, 51, 1)', true],
-  ['rgba(51 170 51 / 0.4)', true],
-  ['rgba(51 170 51 / 40%)', true],
-  ['rgba(255, 0, 153.6, 1)', true],
-  ['rgba(1e2, .5e1, .5e0, +.25e2%)', true],
-  ['rgba(tada)', false],
-  ['rgba(a, b, c)', false],
-])('detects RGBA color "%s" correctly (%s)', (color, result) => {
-  expect(isColor(color)).toBe(result);
-  expect(isColor(color.toUpperCase())).toBe(result);
-  expect(isColor(color.replace(/,\s/, ','))).toBe(result);
-});
-
-test.each([
-  ['hsl(270, 60%, 70%)', true],
-  ['hsl(270 60% 70%)', true],
-  ['hsl(270deg, 60%, 70%)', true],
-  ['hsl(4.71239rad, 60%, 70%)', true],
-  ['hsl(.75turn, 60%, 70%)', true],
-  ['hsl(270, 60%, 50%, .15)', true],
-  ['hsl(270, 60%, 50%, 15%)', true],
-  ['hsl(270 60% 50%/.15)', true],
-  ['hsl(270 60% 50% / .15)', true],
-  ['hsl(270 60% 50% / 15%)', true],
-  ['hsl(270, 60%, 70)', true], // normally, this would be an error (but we are benevolent)
-  ['hsl(270, 60, 70%)', true], // normally, this would be an error (but we are benevolent)
   ['hsl(a, b, c)', false],
-])('detects HSL color "%s" correctly (%s)', (color, result) => {
-  expect(isColor(color)).toBe(result);
-  expect(isColor(color.toUpperCase())).toBe(result);
-  expect(isColor(color.replace(/,\s/, ','))).toBe(result);
-});
-
-test.each([
-  ['hsla(270, 60%, 70%)', true],
-  ['hsla(270 60% 70%)', true],
-  ['hsla(270deg, 60%, 70%)', true],
-  ['hsla(4.71239rad, 60%, 70%)', true],
-  ['hsla(.75turn, 60%, 70%)', true],
-  ['hsla(270, 60%, 50%, .15)', true],
-  ['hsla(270, 60%, 50%, 15%)', true],
-  ['hsla(270 60% 50% / .15)', true],
-  ['hsla(270 60% 50% / 15%)', true],
-  ['hsla(270, 60%, 70)', true], // normally, this would be an error (but we are benevolent)
-  ['hsla(270, 60, 70%)', true], // normally, this would be an error (but we are benevolent)
   ['hsla(a, b, c)', false],
-])('detects HSLA color "%s" correctly (%s)', (color, result) => {
+  ...validColors.functional.map(([color]) => [color, true]),
+])('detects functional (RGBA, HSLA) colors "%s" correctly (%s)', (color, result) => {
   expect(isColor(color)).toBe(result);
   expect(isColor(color.toUpperCase())).toBe(result);
   expect(isColor(color.replace(/,\s/, ','))).toBe(result);

--- a/src/css-colors/src/calculateContrastRatio.js
+++ b/src/css-colors/src/calculateContrastRatio.js
@@ -17,7 +17,11 @@
  *
  * See: https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio
  * See: https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+ * See: https://webaim.org/articles/contrast/
  * See: https://webaim.org/resources/contrastchecker/
+ *
+ * TODO: We are not taking colors transparency (alpha channel into account) because WCAG does not
+ *  provide any guidance on how to measure their contrast. How to deal with this?
  */
 export default function calculateContrastRatio(
   rgbForeground: [number, number, number],

--- a/src/css-colors/src/convertToRGBTriplet.js
+++ b/src/css-colors/src/convertToRGBTriplet.js
@@ -1,0 +1,70 @@
+// @flow strict
+
+import { sprintf } from '@adeira/js';
+
+import cssColorNames from './cssColorNames';
+import hex3ToHex6 from './hex3ToHex6';
+import isColor from './isColor';
+import { RGBA_PATTERN } from './utils/isRGBA';
+
+const HEX_REGEXP_SHORT = /^#(?<R>[a-f0-9])(?<G>[a-f0-9])(?<B>[a-f0-9])$/i;
+const HEX_REGEXP_LONG = /^#(?<R>[a-f0-9]{2})(?<G>[a-f0-9]{2})(?<B>[a-f0-9]{2})$/i;
+
+/**
+ * Tries to convert the input value into RGB triplet which is commonly used throughout this library
+ * for further calculations (brightness, accessibility, …). The input value can be anything that is
+ * valid in CSS/HTML.
+ *
+ * See: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
+ *
+ * It throws an error when the conversion is not implemented yet.
+ *
+ * TODO: How to deal with alpha channel (not supported in the triplet). Should we introduce custom
+ *  object to keep all the extracted values?
+ */
+export default function convertToRGBTriplet(value: string): [number, number, number] {
+  if (isColor(value)) {
+    const rgbaColorMatch = value.match(RGBA_PATTERN);
+    if (cssColorNames.has(value)) {
+      const hexColor = cssColorNames.get(value);
+      // $FlowIssue[incompatible-call]: `hexColor` should not be undefined after calling `has` above
+      return convertHexToRGBTriplet(hexColor);
+    } else if (HEX_REGEXP_LONG.test(value)) {
+      return convertHexToRGBTriplet(value);
+    } else if (HEX_REGEXP_SHORT.test(value)) {
+      return convertHexToRGBTriplet(hex3ToHex6(value));
+    } else if (rgbaColorMatch) {
+      return convertRGBToTriplet(
+        rgbaColorMatch.groups?.R,
+        rgbaColorMatch.groups?.G,
+        rgbaColorMatch.groups?.B,
+      );
+    }
+    throw new Error(sprintf('Conversion of color "%s" is currently not supported.', value));
+  } else {
+    throw new Error(sprintf('Value "%s" is not a color!', value));
+  }
+}
+
+function convertHexToRGBTriplet(hexColor: string): [number, number, number] {
+  // TODO: we currently ignore alpha channels of the #RGB colors (#RGBA)
+  const hexColorMatch = hexColor.match(HEX_REGEXP_LONG);
+  return [
+    parseInt(hexColorMatch?.groups?.R, 16),
+    parseInt(hexColorMatch?.groups?.G, 16),
+    parseInt(hexColorMatch?.groups?.B, 16),
+  ];
+}
+
+function convertRGBToTriplet(r, g, b): [number, number, number] {
+  return [
+    Number(r?.endsWith('%') ? convertPercentageToNumber(r) : r),
+    Number(g?.endsWith('%') ? convertPercentageToNumber(g) : g),
+    Number(b?.endsWith('%') ? convertPercentageToNumber(b) : b),
+  ];
+}
+
+function convertPercentageToNumber(percentage) {
+  const match = percentage?.match(/^(?<number>\d+)%$/)?.groups;
+  return Math.round((255 / 100) * Number(match?.number));
+}

--- a/src/css-colors/src/index.js
+++ b/src/css-colors/src/index.js
@@ -1,6 +1,7 @@
 // @flow strict
 
 export { default as calculateContrastRatio } from './calculateContrastRatio';
+export { default as convertToRGBTriplet } from './convertToRGBTriplet';
 export { default as cssColorNames } from './cssColorNames';
 export { default as hex3ToHex6 } from './hex3ToHex6';
 export { default as hex6ToHex3 } from './hex6ToHex3';

--- a/src/css-colors/src/isColor.js
+++ b/src/css-colors/src/isColor.js
@@ -1,65 +1,22 @@
 // @flow strict
 
 import cssColorNames from './cssColorNames';
+import isHSLA from './utils/isHSLA';
+import isRGBA from './utils/isRGBA';
 
-const _optional = (arr) => {
-  return ['(?:', ...arr, ')?'].join('');
-};
-
-const _or = (arr) => {
-  return ['(?:', arr.join('|'), ')'].join('');
-};
-
-const _spaceOrComma = _or(['\\s', ',\\s?']);
-
-// https://developer.mozilla.org/en-US/docs/Web/CSS/number
-export const _number = '[+-]?\\d*(?:\\.\\d+)?(?:e[+-]?\\d+)?';
-// https://developer.mozilla.org/en-US/docs/Web/CSS/percentage
-const _percentage = `${_number}%`;
-// https://developer.mozilla.org/en-US/docs/Web/CSS/angle
-const _angle = `${_number}(?:deg|grad|rad|turn)?`;
-
-// https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Syntax
-function isRGBA(value: string): boolean %checks {
-  return new RegExp(
-    [
-      '^rgba?\\(',
-      _or([_number, _percentage]), // red
-      _spaceOrComma,
-      _or([_number, _percentage]), // green
-      _spaceOrComma,
-      _or([_number, _percentage]), // blue
-      _optional([
-        _or(['\\s?/\\s?', ',\\s?']), // " / " or comma
-        _or([_number, _percentage]), // alpha
-      ]),
-      '\\)$',
-    ].join(''),
-    'i',
-  ).test(value);
-}
-
-// https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Syntax
-function isHSLA(value: string): boolean %checks {
-  return new RegExp(
-    [
-      '^hsla?\\(',
-      _angle, // hue
-      _spaceOrComma,
-      _or([_number, _percentage]), // saturation
-      _spaceOrComma,
-      _or([_number, _percentage]), // lightness
-      _optional([
-        _or(['\\s?/\\s?', ',\\s?']), // " / " or comma
-        _or([_number, _percentage]), // alpha
-      ]),
-      '\\)$',
-    ].join(''),
-    'i',
-  ).test(value);
-}
-
-// https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
+/**
+ * Detects whether the specified values is a CSS/HTML valid color. It currently supports:
+ *  - color keywords
+ *  - RGB (#-hexadecimal, rgb(…), rgba(…))
+ *  - HSL (hsl(…) and hsla(…))
+ *
+ * TODO (currently not suported):
+ *  - lch(…) - https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/lch()
+ *  - lab(…) - https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/lab()
+ *  - color(…) - https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color()
+ *
+ * See: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
+ */
 export default function isColor(value: string | number): boolean {
   if (typeof value !== 'string') {
     return false;

--- a/src/css-colors/src/utils/__tests__/regexp.test.js
+++ b/src/css-colors/src/utils/__tests__/regexp.test.js
@@ -1,0 +1,24 @@
+// @flow strict
+
+import { _number } from '../regexp';
+
+// https://developer.mozilla.org/en-US/docs/Web/CSS/number
+test.each([
+  ['0', true],
+  ['12', true],
+  ['4.01', true],
+  ['-456.8', true],
+  ['0.0', true],
+  ['+0.0', true],
+  ['-0.0', true],
+  ['.60', true],
+  ['10e3', true],
+  ['-3.4e-2', true],
+  ['-3.4e+2', true],
+  ['.60.8', false],
+  ['12.', false],
+  ['+-12.2', false],
+  ['12.1.1', false],
+])('is %s a number? (%s)', (number, result) => {
+  expect(new RegExp(`^${_number}$`).test(number)).toBe(result);
+});

--- a/src/css-colors/src/utils/isHSLA.js
+++ b/src/css-colors/src/utils/isHSLA.js
@@ -1,0 +1,22 @@
+// @flow strict
+
+import { _angle, _or, _number, _percentage, _optional, _spaceOrComma } from './regexp';
+
+export const HSLA_PATTERN: string = [
+  '^hsla?\\(',
+  _angle, // hue
+  _spaceOrComma,
+  _or([_number, _percentage]), // saturation
+  _spaceOrComma,
+  _or([_number, _percentage]), // lightness
+  _optional([
+    _or(['\\s?/\\s?', ',\\s?']), // " / " or comma
+    _or([_number, _percentage]), // alpha
+  ]),
+  '\\)$',
+].join('');
+
+// https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Syntax
+export default function isHSLA(value: string): boolean {
+  return new RegExp(HSLA_PATTERN, 'i').test(value);
+}

--- a/src/css-colors/src/utils/isRGBA.js
+++ b/src/css-colors/src/utils/isRGBA.js
@@ -1,0 +1,22 @@
+// @flow strict
+
+import { _or, _number, _percentage, _optional, _spaceOrComma } from './regexp';
+
+export const RGBA_PATTERN: string = [
+  '^rgba?\\(',
+  _or([_number, _percentage], 'R'), // red
+  _spaceOrComma,
+  _or([_number, _percentage], 'G'), // green
+  _spaceOrComma,
+  _or([_number, _percentage], 'B'), // blue
+  _optional([
+    _or(['\\s?/\\s?', ',\\s?']), // " / " or comma
+    _or([_number, _percentage], 'A'), // alpha
+  ]),
+  '\\)$',
+].join('');
+
+// https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Syntax
+export default function isRGBA(value: string): boolean {
+  return new RegExp(RGBA_PATTERN, 'i').test(value);
+}

--- a/src/css-colors/src/utils/regexp.js
+++ b/src/css-colors/src/utils/regexp.js
@@ -1,0 +1,30 @@
+// @flow strict
+
+// https://developer.mozilla.org/en-US/docs/Web/CSS/number
+export const _number = '[+-]?\\d*(?:\\.\\d+)?(?:e[+-]?\\d+)?';
+
+// https://developer.mozilla.org/en-US/docs/Web/CSS/percentage
+export const _percentage = `${_number}%`;
+
+// https://developer.mozilla.org/en-US/docs/Web/CSS/angle
+export const _angle = `${_number}(?:deg|grad|rad|turn)?`;
+
+// Helper functions to construct complex regular expressions:
+
+export const _optional = (arr: $ReadOnlyArray<string>, captureGroupName?: string): string => {
+  return [
+    captureGroupName != null ? `(?<${captureGroupName}>` : '(?:', // group start
+    ...arr,
+    ')?',
+  ].join('');
+};
+
+export const _or = (arr: $ReadOnlyArray<string>, captureGroupName?: string): string => {
+  return [
+    captureGroupName != null ? `(?<${captureGroupName}>` : '(?:', // group start
+    arr.join('|'),
+    ')',
+  ].join('');
+};
+
+export const _spaceOrComma: string = _or(['\\s', ',\\s?']);


### PR DESCRIPTION
This commit adds new experimental function `convertToRGBTriplet` that takes any valid CSS/HTML color notation and converts it into RGB triplet that we use for internal calculations of accessibility, brightness and so on.

Use-case: I am building a `Text` component that renders accessible color based on the background. Internally, this component needs to access computed styles (background color) and browsers are returning the color in `rgb(…)` and `rgba(…)` formats (any maybe other formats as well?) and it's challenging to do these conversions in user code.

During the CSS Colors editations I discovered some limitations (most notably the triplet is not a great friend with alpha channel) but I will address these limitations later.