### PR TITLE
SX Design: add new component `LayoutGrid` with a default spacing

### DIFF
--- a/src/sx-design/README.md
+++ b/src/sx-design/README.md
@@ -102,21 +102,21 @@ Legend:
 
 There is an additional set of so-called "Layout" components that are responsible for rendering the components above in a correct order, with correct spacing and so on:
 
-- [`<LayoutBlock />`](https://sx-design.vercel.app/?path=/story/layout-layoutblock)
-- [`<LayoutInline />`](https://sx-design.vercel.app/?path=/story/layout-layoutinline)
+- [`<LayoutBlock />`](https://sx-design.vercel.app/?path=/story/layout-layoutblock) - typically⁶ vertical stacking
+- [`<LayoutGrid />`](https://sx-design.vercel.app/?path=/story/layout-layoutgrid) - children in a [CSS grid](https://developer.mozilla.org/en-US/docs/Web/CSS/grid)
+- [`<LayoutInline />`](https://sx-design.vercel.app/?path=/story/layout-layoutinline) - typically⁶ horizontal stacking
 - … 🚧
 
 _Did you find a mistake in this table? Please, [report is as an issue](https://github.com/adeira/universe/issues/new)._
 
-¹ Localized means that it's either translated by us or the component inputs are (Flow) typed in a way that encourages passing translated strings instead of plain strings.
-
-² Component should look fine in both light and dark mode.
-
-³ There are stories in the [Storybook](https://sx-design.vercel.app/) and these stories are somehow useful and explanatory.
-
-⁴ There are tests available to make sure that the component works as expected and we won't break it by accident.
-
-⁵ Component correctly supports right-to-left (RTL) as well as traditional left-to-right (LTR) layouts
+<sub>
+¹ Localized means that it's either translated by us or the component inputs are (Flow) typed in a way that encourages passing translated strings instead of plain strings.<br />
+² Component should look fine in both light and dark mode.<br />
+³ There are stories in the Storybook (https://sx-design.vercel.app/) and these stories are somehow useful and explanatory.<br />
+⁴ There are tests available to make sure that the component works as expected and we won't break it by accident.<br />
+⁵ Component correctly supports right-to-left (RTL) as well as traditional left-to-right (LTR) layouts<br />
+⁶ https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties#block_vs._inline
+</sub>
 
 # Styles customization
 

--- a/src/sx-design/src/Layout/LayoutBlock.stories.js
+++ b/src/sx-design/src/Layout/LayoutBlock.stories.js
@@ -3,6 +3,7 @@
  * @flow
  */
 
+import fbt from 'fbt';
 import React from 'react';
 
 import LayoutBlock from './LayoutBlock';
@@ -20,13 +21,21 @@ export default {
 const BasicTemplate = (args) => (
   <LayoutBlock {...args}>
     {/* 1..5 */}
-    <Placeholder width={200} height={50} />
+    <Placeholder
+      width={200}
+      height={50}
+      label={
+        <fbt desc="1" doNotExtract={true}>
+          1
+        </fbt>
+      }
+    />
     <Placeholder width={200} height={50} />
     <Placeholder width={200} height={50} />
     <Placeholder width={200} height={50} />
     <Placeholder width={200} height={50} />
 
-    {/* 5..10 */}
+    {/* 6..10 */}
     <Placeholder width={200} height={50} />
     <Placeholder width={200} height={50} />
     <Placeholder width={200} height={50} />

--- a/src/sx-design/src/Layout/LayoutGrid.js
+++ b/src/sx-design/src/Layout/LayoutGrid.js
@@ -1,0 +1,33 @@
+// @flow
+
+import React, { type Node } from 'react';
+import sx from '@adeira/sx';
+
+type Props = {
+  +children: Node,
+  +minColumnWidth?: string,
+};
+
+/**
+ * Responsibility of a `LayoutGrid` component is to render given children with appropriate spacing
+ * in a CSS grid.
+ */
+export default function LayoutGrid(props: Props): Node {
+  return (
+    <div
+      style={{
+        gridTemplateColumns: `repeat(auto-fill, minmax(${props.minColumnWidth ?? '200px'}, 1fr))`,
+      }}
+      className={styles('grid')}
+    >
+      {props.children}
+    </div>
+  );
+}
+
+const styles = sx.create({
+  grid: {
+    display: 'grid',
+    gap: 'var(--sx-spacing-default)',
+  },
+});

--- a/src/sx-design/src/Layout/LayoutGrid.stories.js
+++ b/src/sx-design/src/Layout/LayoutGrid.stories.js
@@ -1,0 +1,57 @@
+/**
+ * https://storybook.js.org/docs/react/writing-stories/introduction
+ * @flow
+ */
+
+import fbt from 'fbt';
+import React from 'react';
+
+import LayoutGrid from './LayoutGrid';
+import Placeholder from '../Placeholder/Placeholder';
+import { initFbt } from '../test-utils';
+import type { StoryTemplate } from '../types';
+
+// 👇 This default export determines where your story goes in the story list
+export default {
+  title: 'Layout/LayoutGrid',
+  component: LayoutGrid,
+};
+
+// 👇 We create a "template" of how args map to rendering
+const BasicTemplate = (args) => (
+  <LayoutGrid {...args}>
+    {/* 1..5 */}
+    <Placeholder
+      width="100%"
+      height="100%"
+      label={
+        <fbt desc="1" doNotExtract={true}>
+          1
+        </fbt>
+      }
+    />
+    <Placeholder width="100%" height="100%" />
+    <Placeholder width="100%" height="100%" />
+    <Placeholder width="100%" height="100%" />
+    <Placeholder width="100%" height="100%" />
+
+    {/* 6..10 */}
+    <Placeholder width="100%" height="100%" />
+    <Placeholder width="100%" height="100%" />
+    <Placeholder width="100%" height="100%" />
+    <Placeholder width="100%" height="100%" />
+    <Placeholder width="100%" height="100%" />
+  </LayoutGrid>
+);
+
+initFbt();
+
+// 👇 Each story then reuses that template
+export const Default: StoryTemplate<typeof LayoutGrid> = BasicTemplate.bind({});
+Default.storyName = 'Default';
+
+export const WithCustomWidth: StoryTemplate<typeof LayoutGrid> = BasicTemplate.bind({});
+WithCustomWidth.storyName = 'With custom column width';
+WithCustomWidth.args = {
+  minColumnWidth: '300px',
+};

--- a/src/sx-design/src/Layout/LayoutInline.stories.js
+++ b/src/sx-design/src/Layout/LayoutInline.stories.js
@@ -3,6 +3,7 @@
  * @flow
  */
 
+import fbt from 'fbt';
 import React from 'react';
 
 import LayoutInline from './LayoutInline';
@@ -20,13 +21,21 @@ export default {
 const BasicTemplate = (args) => (
   <LayoutInline {...args}>
     {/* 1..5 */}
-    <Placeholder width={100} height={100} />
+    <Placeholder
+      width={100}
+      height={100}
+      label={
+        <fbt desc="1" doNotExtract={true}>
+          1
+        </fbt>
+      }
+    />
     <Placeholder width={100} height={100} />
     <Placeholder width={100} height={100} />
     <Placeholder width={100} height={100} />
     <Placeholder width={100} height={100} />
 
-    {/* 5..10 */}
+    {/* 6..10 */}
     <Placeholder width={100} height={100} />
     <Placeholder width={100} height={100} />
     <Placeholder width={100} height={100} />


### PR DESCRIPTION
I first version of a layout component creating a traditional CSS grid.
This is a very common pattern (at least in my apps), so I would like to
extract it and make it available amongst other layout components.

Ideas for the future development is to make it more customizable and
improve responsibility when it comes to mobiles and tablets (basically
change grid and spacing sizes).