### PR TITLE
Abacus: automatically register new users

### DIFF
--- a/src/abacus/src/auth/api/mod.rs
+++ b/src/abacus/src/auth/api/mod.rs
@@ -111,9 +111,9 @@ pub(crate) struct DeauthorizePayload {
 }
 
 /// Webapp is currently using very simplified and minimalistic flow: it basically allows only
-/// specific hardcoded Google subjects to be authorized (admins). The thinking is that webapp
-/// login is needed only for the backoffice and the access should be limited to admins. This should
-/// be easily changeable in the future.
+/// specific Google subjects to be authorized (admins). The thinking is that webapp login is needed
+/// only for the backoffice and the access should be limited to admins. This should be easily
+/// changeable in the future.
 pub(crate) async fn authorize_webapp(
     google_id_token: &str,
     context: &Context,

--- a/src/abacus/src/auth/session.rs
+++ b/src/abacus/src/auth/session.rs
@@ -1,5 +1,5 @@
 use rand::Rng;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 /// Generates sessions token which is compatible with RFC6750 - "Authorization Framework: Bearer
 /// Token Usage" syntax (https://tools.ietf.org/html/rfc6750).


### PR DESCRIPTION
This is so that other people can create an account. Obviously, I still
have to allow them to enter but this is the easiest way how to
"register".