### PR TITLE
Eslint config: install new `eslint-plugin-fb-flow`

### DIFF
--- a/src/eslint-config-adeira/README.md
+++ b/src/eslint-config-adeira/README.md
@@ -63,11 +63,11 @@ Also please note that **you should not ignore Eslint warnings**! These warnings 
 
 The standard config contains a large number of rules, which may not always work for specific projects. There is no need to use the full package only, smaller configs are also available:
 
-- `@adeira/eslint-config/base`
-- `@adeira/eslint-config/jest`
-- `@adeira/eslint-config/react`
-- `@adeira/eslint-config/flowtype`
-- `@adeira/eslint-config/relay`
+- `@adeira/eslint-config/base` - only the basic and most important JavaScript rules
+- `@adeira/eslint-config/jest` - [Jest](https://jestjs.io/) related rules
+- `@adeira/eslint-config/react` - [React](https://reactjs.org/) related rules (React, RN, Hooks, accessibility)
+- `@adeira/eslint-config/flowtype` - [Flow](https://flow.org/) related rules
+- `@adeira/eslint-config/relay` - [Relay](https://relay.dev/) related rules
 
 Use them in your `.eslintrc.js`:
 

--- a/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
+++ b/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
@@ -20,6 +20,7 @@ Object {
   ],
   "plugins": Array [
     "eslint-plugin-flowtype",
+    "eslint-plugin-fb-flow",
     "eslint-plugin-jest",
     "eslint-plugin-react",
     "eslint-plugin-react-hooks",
@@ -125,6 +126,7 @@ Object {
     "eslint-comments/no-unused-enable": 2,
     "eslint-comments/no-use": 0,
     "eslint-comments/require-description": 0,
+    "fb-flow/use-indexed-access-type": 0,
     "flowtype/array-style-complex-type": 0,
     "flowtype/array-style-simple-type": 0,
     "flowtype/arrow-parens": 0,

--- a/src/eslint-config-adeira/__tests__/__snapshots__/presets.test.js.snap
+++ b/src/eslint-config-adeira/__tests__/__snapshots__/presets.test.js.snap
@@ -570,12 +570,14 @@ Object {
   ],
   "plugins": Array [
     "eslint-plugin-flowtype",
+    "eslint-plugin-fb-flow",
   ],
   "rules": Object {
     "curly": Array [
       2,
       "all",
     ],
+    "fb-flow/use-indexed-access-type": 0,
     "flowtype/array-style-complex-type": 0,
     "flowtype/array-style-simple-type": 0,
     "flowtype/arrow-parens": 0,

--- a/src/eslint-config-adeira/getCommonConfig.js
+++ b/src/eslint-config-adeira/getCommonConfig.js
@@ -71,6 +71,7 @@ module.exports = function getCommonConfig(rules /*: EslintConfigRules */) /*: Es
 
     plugins: [
       'eslint-plugin-flowtype',
+      'eslint-plugin-fb-flow',
       'eslint-plugin-jest',
       'eslint-plugin-react',
       'eslint-plugin-react-hooks',

--- a/src/eslint-config-adeira/ourRules.js
+++ b/src/eslint-config-adeira/ourRules.js
@@ -537,6 +537,9 @@ const groupedRules = ({
     'flowtype/use-flow-type': WARN,
     'flowtype/use-read-only-spread': ERROR,
     'flowtype/valid-syntax': OFF,
+
+    // Flow FB: https://github.com/facebook/flow/tree/master/packages/eslint-plugin-fb-flow
+    'fb-flow/use-indexed-access-type': OFF, // TODO (revert https://github.com/adeira/universe/pull/2662)
   },
   react: {
     // React (https://github.com/yannickcr/eslint-plugin-react)

--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -13,6 +13,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-adeira": "^0.13.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-fb-flow": "^0.0.1",
     "eslint-plugin-flowtype": "^5.8.2",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-jest": "^24.4.0",

--- a/src/eslint-config-adeira/presetsConfig.js
+++ b/src/eslint-config-adeira/presetsConfig.js
@@ -21,7 +21,7 @@ module.exports = {
     rules: groupedRules.jest,
   },
   flowtype: {
-    plugins: ['eslint-plugin-flowtype'],
+    plugins: ['eslint-plugin-flowtype', 'eslint-plugin-fb-flow'],
     rules: groupedRules.flowtype,
   },
   react: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8279,6 +8279,11 @@ eslint-plugin-eslint-comments@^3.2.0:
     escape-string-regexp "^1.0.5"
     ignore "^5.0.5"
 
+eslint-plugin-fb-flow@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-flow/-/eslint-plugin-fb-flow-0.0.1.tgz#c326eca9a3f6c957c8adcfd5e28bbaf4e8d33b43"
+  integrity sha512-Vx7M50CtsNtHHPz9EJMuMhxgUsTasUdBj07w7xz2t5F5MCAHjRxebmNZFi2k0NIdWZJAhHc/mRbsh4jJ8iCXQA==
+
 eslint-plugin-flowtype@^5.8.2:
   version "5.8.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.8.2.tgz#e8c4429f2d39d93ccb0732f581b159da16fa0bda"


### PR DESCRIPTION
It's currently unused (even though the rule should eventually be enabled)
 but new rules are coming.

 See:

 - https://www.npmjs.com/package/eslint-plugin-fb-flow
 - https://github.com/facebook/flow/tree/master/packages/eslint-plugin-fb-flow