### PR TITLE
CI Rust: use `stable` toolchain instead of hardcoded version

### DIFF
--- a/.github/workflows/continuous-integration-rust.yml
+++ b/.github/workflows/continuous-integration-rust.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           profile: minimal
           components: clippy
-          toolchain: 1.53.0
+          toolchain: stable
           override: true
           target: ${{ matrix.target }}
 


### PR DESCRIPTION
In the past I changed it in the opposite direction. However, seems like
it's common practice to use `stable` toolchain instead of the hardcoded
version ([1]) as long as it's not for MSRV ([2]).

Moreover, Dependabot cannot keep this version up to date.

[1]: https://github.com/actions-rs/meta/blob/master/recipes/matrix.md
[2]: https://github.com/rust-lang/rfcs/blob/aba44c12231515c380191f2df2eae993a805735f/text/2495-min-rust-version.md