### PR TITLE
Abacus BO: use the latest `next` version 11.0.2-canary.24

### DIFF
--- a/src/abacus-backoffice/package.json
+++ b/src/abacus-backoffice/package.json
@@ -23,7 +23,7 @@
     "fbt": "^0.16.6",
     "graphql": "^15.5.1",
     "immutable": "^4.0.0-rc.14",
-    "next": "^11.0.2-canary.23",
+    "next": "^11.0.2-canary.24",
     "next-plugin-custom-babel-config": "^1.0.4",
     "next-transpile-modules": "^8.0.0",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2488,20 +2488,20 @@
   resolved "https://registry.yarnpkg.com/@next/env/-/env-11.0.1.tgz#6dc96ac76f1663ab747340e907e8933f190cc8fd"
   integrity sha512-yZfKh2U6R9tEYyNUrs2V3SBvCMufkJ07xMH5uWy8wqcl5gAXoEw6A/1LDqwX3j7pUutF9d1ZxpdGDA3Uag+aQQ==
 
-"@next/env@11.0.2-canary.23":
-  version "11.0.2-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-11.0.2-canary.23.tgz#407abc296f80824a33ef59f05d0aca5fcfdd8635"
-  integrity sha512-sUCIW5Z2yKD9dK6u76oakcj3yNDN5Gas0YJzW5JYRtF5YArtjmVfhrNM7znCVP2gXYvLMfiXIgGoN+ADfSp/8w==
+"@next/env@11.0.2-canary.24":
+  version "11.0.2-canary.24"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-11.0.2-canary.24.tgz#6c449c1c1c7f1d9307b8646b597a6973846cb8b4"
+  integrity sha512-U/y19fzTZvVVCVSAukw7m2HYGs1SOZPYTuMIUqLIdYoi2V1IpXW/Clqi0U5Oxur/+EduzTipBXdkE91bHaxTcQ==
 
 "@next/polyfill-module@11.0.1":
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-11.0.1.tgz#ca2a110c1c44672cbcff6c2b983f0c0549d87291"
   integrity sha512-Cjs7rrKCg4CF4Jhri8PCKlBXhszTfOQNl9AjzdNy4K5jXFyxyoSzuX2rK4IuoyE+yGp5A3XJCBEmOQ4xbUp9Mg==
 
-"@next/polyfill-module@11.0.2-canary.23":
-  version "11.0.2-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-11.0.2-canary.23.tgz#98fd993b17555a1277c65511496a7423411c93ac"
-  integrity sha512-R6JeEeU7oVPrfM9p/NwlyHzJv90gxEhubl+1dejGLE+o8hQ8eGzRlpHRUsvDpxCB8HU4A171V1gS7wR4x46SIA==
+"@next/polyfill-module@11.0.2-canary.24":
+  version "11.0.2-canary.24"
+  resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-11.0.2-canary.24.tgz#12add5c10da093cf472d1b913e10c02c66e9a597"
+  integrity sha512-MZoSb2RzMKvp6RnVBxewjxdWqMEBtGGtQDQzn2I/r2cBrv5tGNq/a87BxXaLM27A5Y+8xIXfLQmxdEODhG2zaw==
 
 "@next/react-dev-overlay@11.0.1":
   version "11.0.1"
@@ -2520,10 +2520,10 @@
     stacktrace-parser "0.1.10"
     strip-ansi "6.0.0"
 
-"@next/react-dev-overlay@11.0.2-canary.23":
-  version "11.0.2-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-11.0.2-canary.23.tgz#d362be9902a888b518271840f35bc82d3fa33a4a"
-  integrity sha512-YPxF8AXnWq9ca2G9tZSBM599L0X+v2txpcuzTc2FSXwm1fiQkjtk7R5CaVB4eEH5Zbr9319FggUmT9iqK3E+Hw==
+"@next/react-dev-overlay@11.0.2-canary.24":
+  version "11.0.2-canary.24"
+  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-11.0.2-canary.24.tgz#bac3c41d00d79854b0ea7b7e6675d2f3df901645"
+  integrity sha512-SCUu4Kml8kRpFrxkieYWyggd7SwMS+TL2yWhSjqVmOjoWhdug05GsJiqmtByE+OjDnpOFwH7KFtAr1HDVxYcvQ==
   dependencies:
     "@babel/code-frame" "7.12.11"
     anser "1.4.9"
@@ -2542,10 +2542,10 @@
   resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-11.0.1.tgz#a7509f22b6f70c13101a26573afd295295f1c020"
   integrity sha512-K347DM6Z7gBSE+TfUaTTceWvbj0B6iNAsFZXbFZOlfg3uyz2sbKpzPYYFocCc27yjLaS8OfR8DEdS2mZXi8Saw==
 
-"@next/react-refresh-utils@11.0.2-canary.23":
-  version "11.0.2-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-11.0.2-canary.23.tgz#6f1066d20816fa1130c459ac57e98e4565b77eb6"
-  integrity sha512-wmYYLpIHxdkEKgmfWW/F4VXkOr2y4uecTwGjm73jJRsnE3bC950d0iBJxEBmUbrV/r96KSttAFe/KgTLP91QOw==
+"@next/react-refresh-utils@11.0.2-canary.24":
+  version "11.0.2-canary.24"
+  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-11.0.2-canary.24.tgz#4dbb6f1df22f768fde5a9c38c64715f24c76fd5a"
+  integrity sha512-FhukxTVHOgvwTRhsM3I4a1ymXIOpD+2OTgDNK+uqTJgWo/IwwMqGK+qEt0jYIOCMFxuJbwPBxWim8PgH88eoYg==
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.2":
   version "2.1.8-no-fsevents.2"
@@ -12942,17 +12942,17 @@ next@^11.0.1:
     vm-browserify "1.1.2"
     watchpack "2.1.1"
 
-next@^11.0.2-canary.23:
-  version "11.0.2-canary.23"
-  resolved "https://registry.yarnpkg.com/next/-/next-11.0.2-canary.23.tgz#57465a42260e4e1f01eebbba321824339885d6e5"
-  integrity sha512-hmO0lQo5E/TGVhawCrMJqtShJvxyFcRbK7rxE6jd51J39sQjPbAT6cJewRFf0ggHqrY0keTij7vcJpcaDn1RkA==
+next@^11.0.2-canary.24:
+  version "11.0.2-canary.24"
+  resolved "https://registry.yarnpkg.com/next/-/next-11.0.2-canary.24.tgz#91202f27e5d49d2bb27ff3c7134c033ad5fd10f4"
+  integrity sha512-C7hic1IuxRc5gShyXHNdcpubD4l4XKN9mPLJtAmgzYpu4WsHWPY9DyRmlH9ydSRPFSbK8C4+NrEML35PGWQ4QA==
   dependencies:
     "@babel/runtime" "7.12.5"
     "@hapi/accept" "5.0.2"
-    "@next/env" "11.0.2-canary.23"
-    "@next/polyfill-module" "11.0.2-canary.23"
-    "@next/react-dev-overlay" "11.0.2-canary.23"
-    "@next/react-refresh-utils" "11.0.2-canary.23"
+    "@next/env" "11.0.2-canary.24"
+    "@next/polyfill-module" "11.0.2-canary.24"
+    "@next/react-dev-overlay" "11.0.2-canary.24"
+    "@next/react-refresh-utils" "11.0.2-canary.24"
     "@node-rs/helper" "1.2.1"
     assert "2.0.0"
     ast-types "0.13.2"


### PR DESCRIPTION
See: https://github.com/vercel/next.js/releases/tag/v11.0.2-canary.24