### PR TITLE
Abacus BO: use the latest `next` version 11.0.2-canary.25

### DIFF
--- a/src/abacus-backoffice/package.json
+++ b/src/abacus-backoffice/package.json
@@ -23,7 +23,7 @@
     "fbt": "^0.16.6",
     "graphql": "^15.5.1",
     "immutable": "^4.0.0-rc.14",
-    "next": "^11.0.2-canary.24",
+    "next": "^11.0.2-canary.25",
     "next-plugin-custom-babel-config": "^1.0.4",
     "next-transpile-modules": "^8.0.0",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,20 +2514,20 @@
   resolved "https://registry.yarnpkg.com/@next/env/-/env-11.0.1.tgz#6dc96ac76f1663ab747340e907e8933f190cc8fd"
   integrity sha512-yZfKh2U6R9tEYyNUrs2V3SBvCMufkJ07xMH5uWy8wqcl5gAXoEw6A/1LDqwX3j7pUutF9d1ZxpdGDA3Uag+aQQ==
 
-"@next/env@11.0.2-canary.24":
-  version "11.0.2-canary.24"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-11.0.2-canary.24.tgz#6c449c1c1c7f1d9307b8646b597a6973846cb8b4"
-  integrity sha512-U/y19fzTZvVVCVSAukw7m2HYGs1SOZPYTuMIUqLIdYoi2V1IpXW/Clqi0U5Oxur/+EduzTipBXdkE91bHaxTcQ==
+"@next/env@11.0.2-canary.25":
+  version "11.0.2-canary.25"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-11.0.2-canary.25.tgz#25e09a8e7768149b585b4d15f88e855aa4d29f58"
+  integrity sha512-uE2q2Tyky8w5OTPynHPnVgiTXRgs7ER172/ftCGMKLlpOG1bqkWhEld2d0TG/NoKUj05CBcvEHbbOiwMNMM8aQ==
 
 "@next/polyfill-module@11.0.1":
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-11.0.1.tgz#ca2a110c1c44672cbcff6c2b983f0c0549d87291"
   integrity sha512-Cjs7rrKCg4CF4Jhri8PCKlBXhszTfOQNl9AjzdNy4K5jXFyxyoSzuX2rK4IuoyE+yGp5A3XJCBEmOQ4xbUp9Mg==
 
-"@next/polyfill-module@11.0.2-canary.24":
-  version "11.0.2-canary.24"
-  resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-11.0.2-canary.24.tgz#12add5c10da093cf472d1b913e10c02c66e9a597"
-  integrity sha512-MZoSb2RzMKvp6RnVBxewjxdWqMEBtGGtQDQzn2I/r2cBrv5tGNq/a87BxXaLM27A5Y+8xIXfLQmxdEODhG2zaw==
+"@next/polyfill-module@11.0.2-canary.25":
+  version "11.0.2-canary.25"
+  resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-11.0.2-canary.25.tgz#d324315152fff6b12583625c51c3f9031eb61407"
+  integrity sha512-UzTbaElZUYZpteXhdYeL9pReTAWdlLu8u+SVGDU1MPb9nZf9lFgQwnKsqIMa8ueuiW4dvuVUFgkEGhY4K0wf4A==
 
 "@next/react-dev-overlay@11.0.1":
   version "11.0.1"
@@ -2546,10 +2546,10 @@
     stacktrace-parser "0.1.10"
     strip-ansi "6.0.0"
 
-"@next/react-dev-overlay@11.0.2-canary.24":
-  version "11.0.2-canary.24"
-  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-11.0.2-canary.24.tgz#bac3c41d00d79854b0ea7b7e6675d2f3df901645"
-  integrity sha512-SCUu4Kml8kRpFrxkieYWyggd7SwMS+TL2yWhSjqVmOjoWhdug05GsJiqmtByE+OjDnpOFwH7KFtAr1HDVxYcvQ==
+"@next/react-dev-overlay@11.0.2-canary.25":
+  version "11.0.2-canary.25"
+  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-11.0.2-canary.25.tgz#4c0e1a9f2276bebfb38fb028a99879dd0fc977b2"
+  integrity sha512-l/panDVfbjNnJLusYyzCkOVu04IEClLDh2QBXDYGPO4AoEghavCE3vctT98ZiiuPdry0esgpQIL3MrAQ01mA4g==
   dependencies:
     "@babel/code-frame" "7.12.11"
     anser "1.4.9"
@@ -2568,10 +2568,10 @@
   resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-11.0.1.tgz#a7509f22b6f70c13101a26573afd295295f1c020"
   integrity sha512-K347DM6Z7gBSE+TfUaTTceWvbj0B6iNAsFZXbFZOlfg3uyz2sbKpzPYYFocCc27yjLaS8OfR8DEdS2mZXi8Saw==
 
-"@next/react-refresh-utils@11.0.2-canary.24":
-  version "11.0.2-canary.24"
-  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-11.0.2-canary.24.tgz#4dbb6f1df22f768fde5a9c38c64715f24c76fd5a"
-  integrity sha512-FhukxTVHOgvwTRhsM3I4a1ymXIOpD+2OTgDNK+uqTJgWo/IwwMqGK+qEt0jYIOCMFxuJbwPBxWim8PgH88eoYg==
+"@next/react-refresh-utils@11.0.2-canary.25":
+  version "11.0.2-canary.25"
+  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-11.0.2-canary.25.tgz#51eb566fbcd2fe7653a0269bd858fd130a747047"
+  integrity sha512-h4UG1PkIbo8CnideBx6pg4s6AVSdC0mTYM1PNI7Nb26d7UHPK8siMwlEAxVocs61MNdHE1sb/NUB+j/2nO1U1w==
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.2":
   version "2.1.8-no-fsevents.2"
@@ -13003,17 +13003,17 @@ next@^11.0.1:
     vm-browserify "1.1.2"
     watchpack "2.1.1"
 
-next@^11.0.2-canary.24:
-  version "11.0.2-canary.24"
-  resolved "https://registry.yarnpkg.com/next/-/next-11.0.2-canary.24.tgz#91202f27e5d49d2bb27ff3c7134c033ad5fd10f4"
-  integrity sha512-C7hic1IuxRc5gShyXHNdcpubD4l4XKN9mPLJtAmgzYpu4WsHWPY9DyRmlH9ydSRPFSbK8C4+NrEML35PGWQ4QA==
+next@^11.0.2-canary.25:
+  version "11.0.2-canary.25"
+  resolved "https://registry.yarnpkg.com/next/-/next-11.0.2-canary.25.tgz#75e3b70c79f0ee5178b29ed1d37e8a7cdde3f0c6"
+  integrity sha512-EflK9lVrHoBUMSp7Y0rQurBcAdOgDJ+srUPitbNkS7B9RuCOMaLl+xFBy1O0lvXY37zD+WW1k+HElyNZnCMTAw==
   dependencies:
     "@babel/runtime" "7.12.5"
     "@hapi/accept" "5.0.2"
-    "@next/env" "11.0.2-canary.24"
-    "@next/polyfill-module" "11.0.2-canary.24"
-    "@next/react-dev-overlay" "11.0.2-canary.24"
-    "@next/react-refresh-utils" "11.0.2-canary.24"
+    "@next/env" "11.0.2-canary.25"
+    "@next/polyfill-module" "11.0.2-canary.25"
+    "@next/react-dev-overlay" "11.0.2-canary.25"
+    "@next/react-refresh-utils" "11.0.2-canary.25"
     "@node-rs/helper" "1.2.1"
     assert "2.0.0"
     ast-types "0.13.2"


### PR DESCRIPTION
See: https://github.com/vercel/next.js/releases/tag/v11.0.2-canary.25