### PR TITLE
Eslint config: move overrides where they belong

### DIFF
--- a/src/eslint-config-adeira/__tests__/__snapshots__/presets.test.js.snap
+++ b/src/eslint-config-adeira/__tests__/__snapshots__/presets.test.js.snap
@@ -558,16 +558,7 @@ Object {
     "global": "readonly",
     "globalThis": "readonly",
   },
-  "overrides": Array [
-    Object {
-      "files": Array [
-        "**/__generated__/*.graphql.js",
-      ],
-      "rules": Object {
-        "eslint-comments/no-unlimited-disable": 0,
-      },
-    },
-  ],
+  "overrides": Array [],
   "plugins": Array [
     "eslint-plugin-flowtype",
     "eslint-plugin-fb-flow",
@@ -679,16 +670,7 @@ Object {
     "global": "readonly",
     "globalThis": "readonly",
   },
-  "overrides": Array [
-    Object {
-      "files": Array [
-        "**/__generated__/*.graphql.js",
-      ],
-      "rules": Object {
-        "eslint-comments/no-unlimited-disable": 0,
-      },
-    },
-  ],
+  "overrides": Array [],
   "plugins": Array [
     "eslint-plugin-jest",
     "eslint-plugin-prettier",
@@ -789,16 +771,7 @@ Object {
     "global": "readonly",
     "globalThis": "readonly",
   },
-  "overrides": Array [
-    Object {
-      "files": Array [
-        "**/__generated__/*.graphql.js",
-      ],
-      "rules": Object {
-        "eslint-comments/no-unlimited-disable": 0,
-      },
-    },
-  ],
+  "overrides": Array [],
   "plugins": Array [
     "@next/eslint-plugin-next",
     "eslint-plugin-prettier",
@@ -860,16 +833,7 @@ Object {
     "global": "readonly",
     "globalThis": "readonly",
   },
-  "overrides": Array [
-    Object {
-      "files": Array [
-        "**/__generated__/*.graphql.js",
-      ],
-      "rules": Object {
-        "eslint-comments/no-unlimited-disable": 0,
-      },
-    },
-  ],
+  "overrides": Array [],
   "plugins": Array [
     "eslint-plugin-react",
     "eslint-plugin-react-hooks",
@@ -1143,16 +1107,7 @@ Object {
     "global": "readonly",
     "globalThis": "readonly",
   },
-  "overrides": Array [
-    Object {
-      "files": Array [
-        "**/__generated__/*.graphql.js",
-      ],
-      "rules": Object {
-        "eslint-comments/no-unlimited-disable": 0,
-      },
-    },
-  ],
+  "overrides": Array [],
   "plugins": Array [
     "eslint-plugin-relay",
     "eslint-plugin-prettier",

--- a/src/eslint-config-adeira/base.js
+++ b/src/eslint-config-adeira/base.js
@@ -1,7 +1,6 @@
 // @flow
 
 const basePreset = require('./src/presets/base');
-const changeNextVersionErrorLevel = require('./src/changeNextVersionErrorLevel');
 const getCommonConfig = require('./src/getCommonConfig');
 const { WARN } = require('./src/constants');
 
@@ -11,7 +10,4 @@ import type { EslintConfig } from './src/EslintConfig.flow';
 
 */
 
-module.exports = (getCommonConfig(
-  changeNextVersionErrorLevel(basePreset.rules, WARN),
-  basePreset.plugins,
-) /*: EslintConfig */);
+module.exports = (getCommonConfig(WARN, basePreset) /*: EslintConfig */);

--- a/src/eslint-config-adeira/flowtype.js
+++ b/src/eslint-config-adeira/flowtype.js
@@ -1,6 +1,5 @@
 // @flow
 
-const changeNextVersionErrorLevel = require('./src/changeNextVersionErrorLevel');
 const flowtypePreset = require('./src/presets/flowtype');
 const getCommonConfig = require('./src/getCommonConfig');
 const { WARN } = require('./src/constants');
@@ -11,7 +10,4 @@ import type { EslintConfig } from './src/EslintConfig.flow';
 
 */
 
-module.exports = (getCommonConfig(
-  changeNextVersionErrorLevel(flowtypePreset.rules, WARN),
-  flowtypePreset.plugins,
-) /*: EslintConfig */);
+module.exports = (getCommonConfig(WARN, flowtypePreset) /*: EslintConfig */);

--- a/src/eslint-config-adeira/index.js
+++ b/src/eslint-config-adeira/index.js
@@ -1,6 +1,5 @@
 // @flow
 
-const changeNextVersionErrorLevel = require('./src/changeNextVersionErrorLevel');
 const getCommonConfig = require('./src/getCommonConfig');
 const prettierRules = require('./src/extraPrettierRules');
 const basePreset = require('./src/presets/base');
@@ -16,24 +15,27 @@ import type { EslintConfig } from './src/EslintConfig.flow';
 
 */
 
-module.exports = (getCommonConfig(
-  changeNextVersionErrorLevel(
-    {
-      ...basePreset.rules,
-      ...flowtypePreset.rules,
-      ...jestPreset.rules,
-      ...reactPreset.rules,
-      ...relayPreset.rules,
-      ...prettierRules,
-    },
-    WARN,
-  ),
-  [
-    //
+module.exports = (getCommonConfig(WARN, {
+  rules: {
+    ...basePreset.rules,
+    ...flowtypePreset.rules,
+    ...jestPreset.rules,
+    ...reactPreset.rules,
+    ...relayPreset.rules,
+    ...prettierRules,
+  },
+  plugins: [
     ...basePreset.plugins,
     ...flowtypePreset.plugins,
     ...jestPreset.plugins,
     ...reactPreset.plugins,
     ...relayPreset.plugins,
   ],
-) /*: EslintConfig */);
+  overrides: [
+    ...(basePreset.overrides ?? []),
+    ...(flowtypePreset.overrides ?? []),
+    ...(jestPreset.overrides ?? []),
+    ...(reactPreset.overrides ?? []),
+    ...(relayPreset.overrides ?? []),
+  ],
+}) /*: EslintConfig */);

--- a/src/eslint-config-adeira/jest.js
+++ b/src/eslint-config-adeira/jest.js
@@ -1,6 +1,5 @@
 // @flow
 
-const changeNextVersionErrorLevel = require('./src/changeNextVersionErrorLevel');
 const getCommonConfig = require('./src/getCommonConfig');
 const jestPreset = require('./src/presets/jest');
 const { WARN } = require('./src/constants');
@@ -11,7 +10,4 @@ import type { EslintConfig } from './src/EslintConfig.flow';
 
 */
 
-module.exports = (getCommonConfig(
-  changeNextVersionErrorLevel(jestPreset.rules, WARN),
-  jestPreset.plugins,
-) /*: EslintConfig */);
+module.exports = (getCommonConfig(WARN, jestPreset) /*: EslintConfig */);

--- a/src/eslint-config-adeira/next.js
+++ b/src/eslint-config-adeira/next.js
@@ -1,6 +1,5 @@
 // @flow
 
-const changeNextVersionErrorLevel = require('./src/changeNextVersionErrorLevel');
 const getCommonConfig = require('./src/getCommonConfig');
 const nextPreset = require('./src/presets/next');
 const { WARN } = require('./src/constants');
@@ -11,7 +10,4 @@ import type { EslintConfig } from './src/EslintConfig.flow';
 
 */
 
-module.exports = (getCommonConfig(
-  changeNextVersionErrorLevel(nextPreset.rules, WARN),
-  nextPreset.plugins,
-) /*: EslintConfig */);
+module.exports = (getCommonConfig(WARN, nextPreset) /*: EslintConfig */);

--- a/src/eslint-config-adeira/react.js
+++ b/src/eslint-config-adeira/react.js
@@ -1,6 +1,5 @@
 // @flow
 
-const changeNextVersionErrorLevel = require('./src/changeNextVersionErrorLevel');
 const getCommonConfig = require('./src/getCommonConfig');
 const reactPreset = require('./src/presets/react');
 const { WARN } = require('./src/constants');
@@ -11,7 +10,4 @@ import type { EslintConfig } from './src/EslintConfig.flow';
 
 */
 
-module.exports = (getCommonConfig(
-  changeNextVersionErrorLevel(reactPreset.rules, WARN),
-  reactPreset.plugins,
-) /*: EslintConfig */);
+module.exports = (getCommonConfig(WARN, reactPreset) /*: EslintConfig */);

--- a/src/eslint-config-adeira/relay.js
+++ b/src/eslint-config-adeira/relay.js
@@ -1,6 +1,5 @@
 // @flow
 
-const changeNextVersionErrorLevel = require('./src/changeNextVersionErrorLevel');
 const getCommonConfig = require('./src/getCommonConfig');
 const relayPreset = require('./src/presets/relay');
 const { WARN } = require('./src/constants');
@@ -11,7 +10,4 @@ import type { EslintConfig } from './src/EslintConfig.flow';
 
 */
 
-module.exports = (getCommonConfig(
-  changeNextVersionErrorLevel(relayPreset.rules, WARN),
-  relayPreset.plugins,
-) /*: EslintConfig */);
+module.exports = (getCommonConfig(WARN, relayPreset) /*: EslintConfig */);

--- a/src/eslint-config-adeira/src/EslintConfig.flow.js
+++ b/src/eslint-config-adeira/src/EslintConfig.flow.js
@@ -12,10 +12,14 @@ type EslintConfigValues =
 
 export type EslintConfigRules = { +[string]: EslintConfigValues };
 
+type EslintConfigPlugins = $ReadOnlyArray<string>;
+
+type EslintConfigOverrides = $ReadOnlyArray<{ ... }>;
+
 export type EslintConfig = {
   +rules: EslintConfigRules,
-  +plugins: $ReadOnlyArray<string>,
-  +overrides?: $ReadOnlyArray<{ ... }>,
+  +plugins: EslintConfigPlugins,
+  +overrides?: EslintConfigOverrides,
   +settings?: { +[string]: $FlowFixMe },
   +globals?: { +[string]: 'readonly' | 'writable' | 'off' },
 };

--- a/src/eslint-config-adeira/src/getCommonConfig.js
+++ b/src/eslint-config-adeira/src/getCommonConfig.js
@@ -1,10 +1,11 @@
 // @flow
 
-const { ERROR, OFF } = require('./constants');
+const { ERROR } = require('./constants');
+const changeNextVersionErrorLevel = require('./changeNextVersionErrorLevel');
 
 /*::
 
-import type { EslintConfig, EslintConfigRules } from './EslintConfig.flow';
+import type { EslintConfig } from './EslintConfig.flow';
 
 */
 
@@ -26,12 +27,12 @@ function detectReactVersion() {
 }
 
 module.exports = function getCommonConfig(
-  extraRules /*: EslintConfigRules */,
-  extraPlugins /*: $ReadOnlyArray<string> */,
+  nextVersionErrorLevel /*: 0|1|2 */,
+  baseConfig /*: EslintConfig */,
 ) /*: EslintConfig */ {
   return {
     rules: {
-      ...extraRules,
+      ...changeNextVersionErrorLevel(baseConfig.rules, nextVersionErrorLevel),
       // overwriting Prettier rules, see: https://github.com/prettier/eslint-config-prettier/blob/9444ee0b20f9af3ff364f62d6a9ab967ad673a9d/README.md#special-rules
       'curly': [ERROR, 'all'], // TODO: move to the "base" preset only
       // TODO: move to the "base" preset only:
@@ -69,18 +70,10 @@ module.exports = function getCommonConfig(
     },
 
     plugins: [
-      ...extraPlugins,
+      ...baseConfig.plugins,
       'eslint-plugin-prettier', // TODO: move to the "base" preset only
     ],
 
-    overrides: [
-      {
-        files: ['**/__generated__/*.graphql.js'],
-        rules: {
-          // Relay disables generated files with unlimited scope
-          'eslint-comments/no-unlimited-disable': OFF, // TODO: apply only with "base" preset
-        },
-      },
-    ],
+    overrides: [...(baseConfig.overrides ?? [])],
   };
 };

--- a/src/eslint-config-adeira/src/presets/base.js
+++ b/src/eslint-config-adeira/src/presets/base.js
@@ -442,4 +442,13 @@ module.exports = ({
     'sx/use-logical-properties': NEXT_VERSION_ERROR,
     'sx/valid-usage': ERROR,
   },
+  overrides: [
+    {
+      files: ['**/__generated__/*.graphql.js'],
+      rules: {
+        // Relay disables generated files with unlimited scope
+        'eslint-comments/no-unlimited-disable': OFF,
+      },
+    },
+  ],
 } /*: EslintConfig */);

--- a/src/eslint-config-adeira/strict.js
+++ b/src/eslint-config-adeira/strict.js
@@ -1,6 +1,5 @@
 // @flow
 
-const changeNextVersionErrorLevel = require('./src/changeNextVersionErrorLevel');
 const getCommonConfig = require('./src/getCommonConfig');
 const prettierRules = require('./src/extraPrettierRules');
 const basePreset = require('./src/presets/base');
@@ -16,24 +15,27 @@ import type { EslintConfig } from './src/EslintConfig.flow';
 
 */
 
-module.exports = (getCommonConfig(
-  changeNextVersionErrorLevel(
-    {
-      ...basePreset.rules,
-      ...flowtypePreset.rules,
-      ...jestPreset.rules,
-      ...reactPreset.rules,
-      ...relayPreset.rules,
-      ...prettierRules,
-    },
-    ERROR,
-  ),
-  [
-    //
+module.exports = (getCommonConfig(ERROR, {
+  rules: {
+    ...basePreset.rules,
+    ...flowtypePreset.rules,
+    ...jestPreset.rules,
+    ...reactPreset.rules,
+    ...relayPreset.rules,
+    ...prettierRules,
+  },
+  plugins: [
     ...basePreset.plugins,
     ...flowtypePreset.plugins,
     ...jestPreset.plugins,
     ...reactPreset.plugins,
     ...relayPreset.plugins,
   ],
-) /*: EslintConfig */);
+  overrides: [
+    ...(basePreset.overrides ?? []),
+    ...(flowtypePreset.overrides ?? []),
+    ...(jestPreset.overrides ?? []),
+    ...(reactPreset.overrides ?? []),
+    ...(relayPreset.overrides ?? []),
+  ],
+}) /*: EslintConfig */);


### PR DESCRIPTION
Previously, we were applying `overrides` settings to every preset even
though it should be applied only to the `base` one (`eslint-comments`
plugin is only part of the `base` preset). This change fixes it.