### PR TITLE
Relay example: remove custom font

### DIFF
--- a/src/example-relay/src/pages/_document.js
+++ b/src/example-relay/src/pages/_document.js
@@ -23,10 +23,6 @@ export default class MyDocument extends Document {
     return (
       <html lang="en-US">
         <Head>
-          <link
-            href="https://fonts.googleapis.com/css?family=Roboto:400,400i,500,500i,700&display=optional"
-            rel="stylesheet"
-          />
           <link rel="icon" href="https://adeira.dev/img/favicon.ico" />
           <style dangerouslySetInnerHTML={{ __html: mediaStyles }} />
         </Head>


### PR DESCRIPTION
We are not using it anymore (SX Design takes care of it).
It was removed here: e6340e9143e9d1ecd992b2204ab40d7e36bb8fc3