### PR TITLE
Eslint config: move settings where they belong

### DIFF
--- a/src/eslint-config-adeira/__tests__/__snapshots__/presets.test.js.snap
+++ b/src/eslint-config-adeira/__tests__/__snapshots__/presets.test.js.snap
@@ -543,9 +543,6 @@ Object {
         ],
       },
     },
-    "react": Object {
-      "version": Any<String>,
-    },
   },
 }
 `;
@@ -642,23 +639,7 @@ Object {
       },
     ],
   },
-  "settings": Object {
-    "import/resolver": Object {
-      "node": Object {
-        "extensions": Array [
-          ".js",
-          ".jsx",
-          ".android.js",
-          ".ios.js",
-          ".native.js",
-          ".web.js",
-        ],
-      },
-    },
-    "react": Object {
-      "version": Any<String>,
-    },
-  },
+  "settings": Object {},
 }
 `;
 
@@ -743,23 +724,7 @@ Object {
       },
     ],
   },
-  "settings": Object {
-    "import/resolver": Object {
-      "node": Object {
-        "extensions": Array [
-          ".js",
-          ".jsx",
-          ".android.js",
-          ".ios.js",
-          ".native.js",
-          ".web.js",
-        ],
-      },
-    },
-    "react": Object {
-      "version": Any<String>,
-    },
-  },
+  "settings": Object {},
 }
 `;
 
@@ -805,23 +770,7 @@ Object {
       },
     ],
   },
-  "settings": Object {
-    "import/resolver": Object {
-      "node": Object {
-        "extensions": Array [
-          ".js",
-          ".jsx",
-          ".android.js",
-          ".ios.js",
-          ".native.js",
-          ".web.js",
-        ],
-      },
-    },
-    "react": Object {
-      "version": Any<String>,
-    },
-  },
+  "settings": Object {},
 }
 `;
 
@@ -1080,18 +1029,6 @@ Object {
     "react/void-dom-elements-no-children": 2,
   },
   "settings": Object {
-    "import/resolver": Object {
-      "node": Object {
-        "extensions": Array [
-          ".js",
-          ".jsx",
-          ".android.js",
-          ".ios.js",
-          ".native.js",
-          ".web.js",
-        ],
-      },
-    },
     "react": Object {
       "version": Any<String>,
     },
@@ -1138,22 +1075,6 @@ Object {
     "relay/no-future-added-value": 2,
     "relay/unused-fields": 2,
   },
-  "settings": Object {
-    "import/resolver": Object {
-      "node": Object {
-        "extensions": Array [
-          ".js",
-          ".jsx",
-          ".android.js",
-          ".ios.js",
-          ".native.js",
-          ".web.js",
-        ],
-      },
-    },
-    "react": Object {
-      "version": Any<String>,
-    },
-  },
+  "settings": Object {},
 }
 `;

--- a/src/eslint-config-adeira/__tests__/presets.test.js
+++ b/src/eslint-config-adeira/__tests__/presets.test.js
@@ -5,16 +5,17 @@ test.each([
   ['Flowtype preset', require('../flowtype')],
   ['Jest preset', require('../jest')],
   ['Next preset', require('../next')],
-  ['React preset', require('../react')],
   ['Relay preset', require('../relay')],
 ])('%s', (presetName, preset) => {
+  expect(preset).toMatchSnapshot(presetName);
+});
+
+test('React preset', () => {
   const propertyMatchers = {
     settings: {
-      react: {
-        version: expect.any(String),
-      },
+      react: { version: expect.any(String) },
     },
   };
 
-  expect(preset).toMatchSnapshot(propertyMatchers, presetName);
+  expect(require('../react')).toMatchSnapshot(propertyMatchers, 'React preset');
 });

--- a/src/eslint-config-adeira/index.js
+++ b/src/eslint-config-adeira/index.js
@@ -38,4 +38,12 @@ module.exports = (getCommonConfig(WARN, {
     ...(reactPreset.overrides ?? []),
     ...(relayPreset.overrides ?? []),
   ],
+  settings: {
+    ...basePreset.settings,
+    // $FlowFixMe[exponential-spread]
+    ...flowtypePreset.settings,
+    ...jestPreset.settings,
+    ...reactPreset.settings,
+    ...relayPreset.settings,
+  },
 }) /*: EslintConfig */);

--- a/src/eslint-config-adeira/src/EslintConfig.flow.js
+++ b/src/eslint-config-adeira/src/EslintConfig.flow.js
@@ -1,4 +1,4 @@
-// @flow strict
+// @flow
 
 // Level "3" is our NEXT_VERSION_ERROR speciality:
 type EslintConfigErrorLevel = 0 | 1 | 2 | 'off' | 'warn' | 'error' | 3;
@@ -16,10 +16,18 @@ type EslintConfigPlugins = $ReadOnlyArray<string>;
 
 type EslintConfigOverrides = $ReadOnlyArray<{ ... }>;
 
+type EslintConfigSettings = {
+  +[pluginIdentifier: string]: {
+    +[settingName: string]: any,
+  },
+};
+
+type EslintConfigGlobals = { +[string]: 'readonly' | 'writable' | 'off' };
+
 export type EslintConfig = {
   +rules: EslintConfigRules,
   +plugins: EslintConfigPlugins,
   +overrides?: EslintConfigOverrides,
-  +settings?: { +[string]: $FlowFixMe },
-  +globals?: { +[string]: 'readonly' | 'writable' | 'off' },
+  +settings?: EslintConfigSettings,
+  +globals?: EslintConfigGlobals,
 };

--- a/src/eslint-config-adeira/src/__tests__/changeNextVersionErrorLevel.test.js
+++ b/src/eslint-config-adeira/src/__tests__/changeNextVersionErrorLevel.test.js
@@ -1,4 +1,4 @@
-// @flow strict
+// @flow strict-local
 
 import changeNextVersionErrorLevel from '../changeNextVersionErrorLevel';
 

--- a/src/eslint-config-adeira/src/changeNextVersionErrorLevel.js
+++ b/src/eslint-config-adeira/src/changeNextVersionErrorLevel.js
@@ -1,4 +1,4 @@
-// @flow strict
+// @flow strict-local
 
 /*::
 

--- a/src/eslint-config-adeira/src/detectReactVersion.js
+++ b/src/eslint-config-adeira/src/detectReactVersion.js
@@ -1,0 +1,18 @@
+// @flow strict
+
+/**
+ * This is basically copy-pasted detection from the React plugin except it doesn't
+ * complain when React dependency is missing. It's because we expect non-React environments.
+ * See: https://github.com/yannickcr/eslint-plugin-react/blob/6bb160459383a2eeec5d65e3de07e37e997b5f1a/lib/util/version.js#L12
+ */
+module.exports = function detectReactVersion() /*: string */ {
+  try {
+    const react = require('react'); // eslint-disable-line import/no-extraneous-dependencies
+    return react.version;
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      return '999.999.999';
+    }
+    throw error;
+  }
+};

--- a/src/eslint-config-adeira/src/getCommonConfig.js
+++ b/src/eslint-config-adeira/src/getCommonConfig.js
@@ -9,23 +9,6 @@ import type { EslintConfig } from './EslintConfig.flow';
 
 */
 
-/**
- * This is basically copy-pasted detection from the React plugin except it doesn't
- * complain when React dependency is missing. It's because we expect non-React environments.
- * See: https://github.com/yannickcr/eslint-plugin-react/blob/6bb160459383a2eeec5d65e3de07e37e997b5f1a/lib/util/version.js#L12
- */
-function detectReactVersion() {
-  try {
-    const react = require('react'); // eslint-disable-line import/no-extraneous-dependencies
-    return react.version;
-  } catch (error) {
-    if (error.code === 'MODULE_NOT_FOUND') {
-      return '999.999.999';
-    }
-    throw error;
-  }
-}
-
 module.exports = function getCommonConfig(
   nextVersionErrorLevel /*: 0|1|2 */,
   baseConfig /*: EslintConfig */,
@@ -50,17 +33,7 @@ module.exports = function getCommonConfig(
       ],
     },
 
-    settings: {
-      'import/resolver': {
-        node: {
-          extensions: ['.js', '.jsx', '.android.js', '.ios.js', '.native.js', '.web.js'],
-        },
-      },
-      'react': {
-        // TODO: apply with "react" preset only
-        version: detectReactVersion(),
-      },
-    },
+    settings: { ...baseConfig.settings },
 
     globals: {
       global: 'readonly', // TODO: make it 'off'

--- a/src/eslint-config-adeira/src/presets/base.js
+++ b/src/eslint-config-adeira/src/presets/base.js
@@ -442,6 +442,13 @@ module.exports = ({
     'sx/use-logical-properties': NEXT_VERSION_ERROR,
     'sx/valid-usage': ERROR,
   },
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.jsx', '.android.js', '.ios.js', '.native.js', '.web.js'],
+      },
+    },
+  },
   overrides: [
     {
       files: ['**/__generated__/*.graphql.js'],

--- a/src/eslint-config-adeira/src/presets/react.js
+++ b/src/eslint-config-adeira/src/presets/react.js
@@ -1,6 +1,7 @@
 // @flow
 
 const { ERROR, OFF, WARN } = require('../constants');
+const detectReactVersion = require('../detectReactVersion');
 
 /*::
 
@@ -210,5 +211,10 @@ module.exports = ({
     'jsx-a11y/role-supports-aria-props': ERROR,
     'jsx-a11y/scope': ERROR,
     'jsx-a11y/tabindex-no-positive': ERROR,
+  },
+  settings: {
+    react: {
+      version: detectReactVersion(),
+    },
   },
 } /*: EslintConfig */);

--- a/src/eslint-config-adeira/strict.js
+++ b/src/eslint-config-adeira/strict.js
@@ -38,4 +38,12 @@ module.exports = (getCommonConfig(ERROR, {
     ...(reactPreset.overrides ?? []),
     ...(relayPreset.overrides ?? []),
   ],
+  settings: {
+    ...basePreset.settings,
+    // $FlowFixMe[exponential-spread]
+    ...flowtypePreset.settings,
+    ...jestPreset.settings,
+    ...reactPreset.settings,
+    ...relayPreset.settings,
+  },
 }) /*: EslintConfig */);


### PR DESCRIPTION
Same idea as in cf640a50fe6f2c85ebd2975f0b6d2ce00d1cc1f5

These settings belong to the `base` and `react` preset only and
_I think_ they should be removed from the other presets.