### PR TITLE
SX Design: remove `Entity` margin block end

### DIFF
--- a/src/sx-design/src/Entity/Entity.js
+++ b/src/sx-design/src/Entity/Entity.js
@@ -24,7 +24,6 @@ const styles = sx.create({
     alignItems: 'center',
     border: '1px solid rgba(var(--sx-accent-1))',
     borderRadius: 'var(--sx-radius)',
-    padding: 16,
-    marginBlockEnd: 5,
+    padding: '1rem',
   },
 });

--- a/src/sx-design/src/Entity/Entity.stories.js
+++ b/src/sx-design/src/Entity/Entity.stories.js
@@ -6,8 +6,9 @@
 import React from 'react';
 
 import Entity from './Entity';
-import type { StoryTemplate } from '../types';
 import EntityField from './EntityField';
+import LayoutBlock from '../Layout/LayoutBlock';
+import type { StoryTemplate } from '../types';
 
 // 👇 This default export determines where your story goes in the story list
 export default {
@@ -25,11 +26,13 @@ export default {
 
 // 👇 We create a "template" of how args map to rendering
 const Template = (args) => (
-  <>
+  <LayoutBlock>
     <Entity {...args} />
     <Entity {...args} />
     <Entity {...args} />
-  </>
+    <Entity {...args} />
+    <Entity {...args} />
+  </LayoutBlock>
 );
 
 // 👇 Each story then reuses that template


### PR DESCRIPTION
It's not a responsibility of the `Entity` component to deal with the
layout composition. Instead, users should wrap the `Entity` lines into
`LayoutBlock` and adjust the spacing as needed.