### PR TITLE
Abacus BO: use the latest `next` version 11.0.2-canary.27

### DIFF
--- a/src/abacus-backoffice/package.json
+++ b/src/abacus-backoffice/package.json
@@ -23,7 +23,7 @@
     "fbt": "^0.16.6",
     "graphql": "^15.5.1",
     "immutable": "^4.0.0-rc.14",
-    "next": "^11.0.2-canary.26",
+    "next": "^11.0.2-canary.27",
     "next-plugin-custom-babel-config": "^1.0.4",
     "next-transpile-modules": "^8.0.0",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2524,10 +2524,10 @@
   resolved "https://registry.yarnpkg.com/@next/env/-/env-11.0.1.tgz#6dc96ac76f1663ab747340e907e8933f190cc8fd"
   integrity sha512-yZfKh2U6R9tEYyNUrs2V3SBvCMufkJ07xMH5uWy8wqcl5gAXoEw6A/1LDqwX3j7pUutF9d1ZxpdGDA3Uag+aQQ==
 
-"@next/env@11.0.2-canary.26":
-  version "11.0.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-11.0.2-canary.26.tgz#20327fc9c06a75223de46a367d7bbc1dfe002632"
-  integrity sha512-JlL0CwA8Xw0605UkyNMR0q3yxIzxANHEB89UF2DlcGuZIay8UbKfH9WNdgHJSQwH4nedVgULNO0BFy3u6ThhfA==
+"@next/env@11.0.2-canary.27":
+  version "11.0.2-canary.27"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-11.0.2-canary.27.tgz#c8c5af0d0301568e9a746c31759ceb8447b678fb"
+  integrity sha512-4ZF70pJtQ5w968lwPkz+hgSJaTtoDd/AGeN5b+TFNB90fF6Siw8rf4oZalji2AInwIMZGH4URXE3sBslaQ/Fqw==
 
 "@next/eslint-plugin-next@^11.0.1":
   version "11.0.1"
@@ -2539,10 +2539,10 @@
   resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-11.0.1.tgz#ca2a110c1c44672cbcff6c2b983f0c0549d87291"
   integrity sha512-Cjs7rrKCg4CF4Jhri8PCKlBXhszTfOQNl9AjzdNy4K5jXFyxyoSzuX2rK4IuoyE+yGp5A3XJCBEmOQ4xbUp9Mg==
 
-"@next/polyfill-module@11.0.2-canary.26":
-  version "11.0.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-11.0.2-canary.26.tgz#32e0cfff90f6db9ee54684713060c3a599e6d159"
-  integrity sha512-AIF/5wTMZ34Kev8cY2yXwiN2Ao206wtoegZ7sW8DU9+h9fQDyY89Dzh2NuA+K1+RnWT8KuucsO5kShw0k8Es0g==
+"@next/polyfill-module@11.0.2-canary.27":
+  version "11.0.2-canary.27"
+  resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-11.0.2-canary.27.tgz#e8c10738813b7e9ee4cf0e7f839c015b83551e32"
+  integrity sha512-XAoe9lFrgtT40Uv+FHIvGUHiSvNm6gu63j883AS03WWjBu+fu5BJnthLjOnjTUXOyQ+ZoXyfTjufrG4gZhaReQ==
 
 "@next/react-dev-overlay@11.0.1":
   version "11.0.1"
@@ -2561,10 +2561,10 @@
     stacktrace-parser "0.1.10"
     strip-ansi "6.0.0"
 
-"@next/react-dev-overlay@11.0.2-canary.26":
-  version "11.0.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-11.0.2-canary.26.tgz#311e387108a3a778efe409115979da8cbe5418a8"
-  integrity sha512-G0pP7EW9rpjKaFUE5APqbjtDHFWYVlgeTlG6btSwuc+GSn/FWb5IKP4VSVjx3M3zkj1S3a6qDjXe1duLXTZv1g==
+"@next/react-dev-overlay@11.0.2-canary.27":
+  version "11.0.2-canary.27"
+  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-11.0.2-canary.27.tgz#9e66d9ae430f3fded4ad8b7123596332a9467140"
+  integrity sha512-WuGYzTpdzP7buDgtxHBonpShUfRMBlMOnH6x4qvcXmTlRSdc+vii7xsH1C7yLqY81Cht0c8aIhcL+55wcEhv7Q==
   dependencies:
     "@babel/code-frame" "7.12.11"
     anser "1.4.9"
@@ -2583,10 +2583,10 @@
   resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-11.0.1.tgz#a7509f22b6f70c13101a26573afd295295f1c020"
   integrity sha512-K347DM6Z7gBSE+TfUaTTceWvbj0B6iNAsFZXbFZOlfg3uyz2sbKpzPYYFocCc27yjLaS8OfR8DEdS2mZXi8Saw==
 
-"@next/react-refresh-utils@11.0.2-canary.26":
-  version "11.0.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-11.0.2-canary.26.tgz#c2acbdbfb9ef01a9a5b5bb9a0cc2a58badb1214a"
-  integrity sha512-gInmZbaZ/OJVSYe//ptoTw/476Wx6A7FLgOeVZQ9Z/vTNaL9zz5r7EKJYFV3KIo04VlBS9LoOS7zWnrjlP60TA==
+"@next/react-refresh-utils@11.0.2-canary.27":
+  version "11.0.2-canary.27"
+  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-11.0.2-canary.27.tgz#72224abf4ab36c5fe921436db28762db9dd13694"
+  integrity sha512-B5ugBpSK7E5gZ8EpGjJI/RhhFFySiqGgTzH5lpGV7Ldbah8xIH3xHT+y6d/O568p22VvNN5EZox43VJKsMporA==
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.2":
   version "2.1.8-no-fsevents.2"
@@ -13018,17 +13018,17 @@ next@^11.0.1:
     vm-browserify "1.1.2"
     watchpack "2.1.1"
 
-next@^11.0.2-canary.26:
-  version "11.0.2-canary.26"
-  resolved "https://registry.yarnpkg.com/next/-/next-11.0.2-canary.26.tgz#38d16704ed8eea14cb2f1bfc3c7b662675a92692"
-  integrity sha512-B/Zhs5EIJTlYnGZie0VaZps8hJ7TEdP1p0uHiIjD7Gdm1gkrJj7NOsFqJIb+XZGvdKRsYxxKp0+q8442Um3NFw==
+next@^11.0.2-canary.27:
+  version "11.0.2-canary.27"
+  resolved "https://registry.yarnpkg.com/next/-/next-11.0.2-canary.27.tgz#6d8a01c6ad39f78e05b651d8ddfd9369fe035dc8"
+  integrity sha512-qBbIR0u4Uyh8GuBma4sD/pKPvaANUOeXCJyjBhnLx9G7cegtomx1CX+FWYDPvV6Y9CJUhaOYrsZnOzTPhyx2+w==
   dependencies:
     "@babel/runtime" "7.12.5"
     "@hapi/accept" "5.0.2"
-    "@next/env" "11.0.2-canary.26"
-    "@next/polyfill-module" "11.0.2-canary.26"
-    "@next/react-dev-overlay" "11.0.2-canary.26"
-    "@next/react-refresh-utils" "11.0.2-canary.26"
+    "@next/env" "11.0.2-canary.27"
+    "@next/polyfill-module" "11.0.2-canary.27"
+    "@next/react-dev-overlay" "11.0.2-canary.27"
+    "@next/react-refresh-utils" "11.0.2-canary.27"
     "@node-rs/helper" "1.2.1"
     assert "2.0.0"
     ast-types "0.13.2"
@@ -13066,7 +13066,7 @@ next@^11.0.2-canary.26:
     stream-browserify "3.0.0"
     stream-http "3.1.1"
     string_decoder "1.3.0"
-    styled-jsx "3.3.2"
+    styled-jsx "3.4.7"
     timers-browserify "2.0.12"
     tty-browserify "0.0.1"
     use-subscription "1.5.1"
@@ -16818,6 +16818,20 @@ styled-jsx@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.3.2.tgz#2474601a26670a6049fb4d3f94bd91695b3ce018"
   integrity sha512-daAkGd5mqhbBhLd6jYAjYBa9LpxYCzsgo/f6qzPdFxVB8yoGbhxvzQgkC0pfmCVvW3JuAEBn0UzFLBfkHVZG1g==
+  dependencies:
+    "@babel/types" "7.8.3"
+    babel-plugin-syntax-jsx "6.18.0"
+    convert-source-map "1.7.0"
+    loader-utils "1.2.3"
+    source-map "0.7.3"
+    string-hash "1.1.3"
+    stylis "3.5.4"
+    stylis-rule-sheet "0.0.10"
+
+styled-jsx@3.4.7:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.4.7.tgz#803bc8a36f1c359cc99691b6db6e0791ea3e1e31"
+  integrity sha512-PkImcCsovR39byv4Tz83tAPsYs2CiTPOmDSplhe0lsIFVYJyd7rzJ7fbm41vSNsF/lnO+Ob5n/jgMookwY0pww==
   dependencies:
     "@babel/types" "7.8.3"
     babel-plugin-syntax-jsx "6.18.0"


### PR DESCRIPTION
https://github.com/vercel/next.js/releases/tag/v11.0.2-canary.27