### PR TITLE
Relay: use new version of `fetchQuery` from v11

### DIFF
--- a/src/example-relay/src/pages/ssr.js
+++ b/src/example-relay/src/pages/ssr.js
@@ -16,10 +16,11 @@ function Ssr(props: Props): Node {
 
 Ssr.getInitialProps = async function (): Promise<{ +ssrData: any }> {
   const environment = createRelayEnvironment(undefined);
-  await fetchQuery(environment, query, variables);
-  const ssrData = environment.getStore().getSource().toJSON();
+  await fetchQuery(environment, query, variables).toPromise();
 
-  return { ssrData };
+  return {
+    ssrData: environment.getStore().getSource().toJSON(),
+  };
 };
 
 export default Ssr;

--- a/src/relay/CHANGELOG.md
+++ b/src/relay/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 - **Breaking**: Relay version upgraded to 12.0.0, for more information please visit: https://github.com/facebook/relay/releases/tag/v12.0.0
 - **Breaking**: All previous loggers (`RelayEagerLogger`, `RelayLazyLogger` and `RelayDebugLogger`) were replaced with one simple `RelayLogger`. This allows us to focus better on one solution that is more friendly with the new Relay Hooks development workflow.
+- **Breaking**: new version of `fetchQuery` from Relay 11 (returns observable instead of promise). For more information please visit: https://github.com/facebook/relay/releases/tag/v11.0.0. Easiest migration path (BUT be aware of [the limitations](https://relay.dev/docs/api-reference/fetch-query/#behavior-with-topromise):
+
+  ```diff
+  - await fetchQuery(environment, query, variables);
+  + await fetchQuery(environment, query, variables).toPromise();
+  ```
 
 # 3.3.0
 

--- a/src/relay/src/__flowtests__/fetchQuery.js
+++ b/src/relay/src/__flowtests__/fetchQuery.js
@@ -12,12 +12,26 @@ const variables = {};
 
 module.exports = ({
   validUsage: () => {
-    return fetchQuery(environment, query, variables);
+    return fetchQuery(environment, query);
+  },
+  validUsagePromise: () => {
+    return fetchQuery(environment, query, variables).toPromise();
+  },
+  validUsageObservable: () => {
+    return fetchQuery(environment, query, variables).subscribe({
+      next: () => {},
+    });
   },
 
   // Invalid usages:
-  missingVariables: () => {
-    // $FlowExpectedError[incompatible-call]: Cannot call fetchQuery because function [1] requires another argument.
-    return fetchQuery(environment, query);
+  missingQuery: () => {
+    // $FlowExpectedError[incompatible-call]: missing query
+    return fetchQuery(environment);
+  },
+  invalidObservable: () => {
+    // $FlowExpectedError[incompatible-call]: wtf
+    return fetchQuery(environment, query).subscribe({
+      wtf: () => {},
+    });
   },
 }: $FlowFixMe);

--- a/src/relay/src/index.js
+++ b/src/relay/src/index.js
@@ -39,8 +39,6 @@ export {
   requestSubscription,
   commitLocalUpdate,
   ConnectionHandler,
-  // eslint-disable-next-line camelcase
-  fetchQuery_DEPRECATED as fetchQuery,
 } from 'react-relay/legacy';
 export type { Environment } from 'react-relay';
 export type {
@@ -58,6 +56,7 @@ export type { RecordObjectMap as RecordMap } from 'relay-runtime/store/RelayStor
 // Relay Hooks (re-exported):
 export {
   EntryPointContainer,
+  fetchQuery,
   loadEntryPoint,
   loadQuery,
   RelayEnvironmentProvider,


### PR DESCRIPTION
See: https://github.com/facebook/relay/releases/tag/v11.0.0