### PR TITLE
SX Design: throw on invalid `Text` nesting

### DIFF
--- a/src/abacus-backoffice/src/products/ProductsCategories.js
+++ b/src/abacus-backoffice/src/products/ProductsCategories.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { graphql, useLazyLoadQuery } from '@adeira/relay';
-import { Tabs, Text } from '@adeira/sx-design';
+import { Tabs, Text, type TabsType } from '@adeira/sx-design';
 import React, { type Node } from 'react';
 import fbt from 'fbt';
 
@@ -43,9 +43,11 @@ export default function ProductsCategories(props: Props): Node {
           title: <fbt desc="title of a button to filter products by all categories">All</fbt>,
           value: null,
         },
-        ...data.commerce.productCategories.reduce((acc, category) => {
+        ...data.commerce.productCategories.reduce<TabsType>((acc, category) => {
           if (category != null) {
             acc.push({
+              // TODO:
+              // Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.
               title: <Text transform="capitalize">{category.name}</Text>,
               value: category.id,
             });

--- a/src/sx-design/index.js
+++ b/src/sx-design/index.js
@@ -33,5 +33,6 @@ export { default as LayoutBlock } from './src/Layout/LayoutBlock';
 export { default as LayoutGrid } from './src/Layout/LayoutGrid';
 export { default as LayoutInline } from './src/Layout/LayoutInline';
 
-// Public SX Design Flow types:
+// Public SX Design Flow types (should be prefixed with the component name):
+export type { TabsType, TabValueType } from './src/Tabs/Tabs';
 export type { TextSupportedSize, TextSupportedWeight } from './src/Text/Text';

--- a/src/sx-design/src/Tabs/Tabs.js
+++ b/src/sx-design/src/Tabs/Tabs.js
@@ -5,11 +5,16 @@ import sx from '@adeira/sx';
 
 import Text from '../Text/Text';
 
-type TabValue = string | number | null;
+export type TabValueType = string | number | null;
+export type TabsType = Array<{
+  +title: Fbt | RestrictedElement<typeof Text>,
+  +value: TabValueType,
+}>;
+
 type Props = {
-  +tabs: $ReadOnlyArray<{ +title: Fbt, +value: TabValue }>,
-  +selected: TabValue,
-  +setSelected: (TabValue) => void,
+  +tabs: TabsType,
+  +selected: TabValueType,
+  +setSelected: (TabValueType) => void,
 };
 
 /**
@@ -42,7 +47,11 @@ export default function Tabs(props: Props): Node {
               props.setSelected(tab.value);
             }}
           >
-            <Text size={16} weight={700}>
+            <Text
+              size={16}
+              weight={700}
+              // as="span"
+            >
               {tab.title}
             </Text>
           </button>

--- a/src/sx-design/src/Text/TextContext.js
+++ b/src/sx-design/src/Text/TextContext.js
@@ -1,0 +1,5 @@
+// @flow strict
+
+import React from 'react';
+
+export default React.createContext(null);

--- a/src/sx-design/src/Text/__tests__/Text.test.js
+++ b/src/sx-design/src/Text/__tests__/Text.test.js
@@ -71,3 +71,94 @@ test.each(['p', 'small', 'code', 'span', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h
     expect(getByTestId('text_test_id')?.nodeName.toLowerCase()).toBe(as);
   },
 );
+
+describe('throw for situations resulting in invalid HTML', () => {
+  let consoleSpy;
+  beforeEach(() => {
+    // we ignore React "uncaught" errors for these tests
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  test('p inside p', () => {
+    expect(() =>
+      render(
+        <Text as="p">
+          <Text as="p">invalid nesting</Text>
+        </Text>,
+      ),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  test('p inside small', () => {
+    expect(() =>
+      render(
+        <Text as="small">
+          <Text as="p">invalid nesting</Text>
+        </Text>,
+      ),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  test('p inside h1', () => {
+    expect(() =>
+      render(
+        <Text as="h1">
+          <Text as="p">invalid nesting</Text>
+        </Text>,
+      ),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  test('h2 inside h1', () => {
+    expect(() =>
+      render(
+        <Text as="h1">
+          <Text as="h2">invalid nesting</Text>
+        </Text>,
+      ),
+    ).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('allow nesting resulting in valid HTML', () => {
+  it('div inside div', () => {
+    const { getByText } = render(
+      <Text as="div">
+        <Text as="div">valid nesting</Text>
+      </Text>,
+    );
+    expect(getByText('valid nesting')).toBeDefined();
+  });
+
+  it('small inside small', () => {
+    const { getByText } = render(
+      <Text as="small">
+        <Text as="small">valid nesting</Text>
+      </Text>,
+    );
+    expect(getByText('valid nesting')).toBeDefined();
+  });
+
+  test('small inside p', () => {
+    const { getByText } = render(
+      <Text as="p">
+        <Text as="small">valid nesting</Text>
+      </Text>,
+    );
+    expect(getByText('valid nesting')).toBeDefined();
+  });
+
+  // test('unknown inside unknown', () => {
+  //   // this is here just to make sure that we allow nesting by default (for some future HTML tags)
+  //   const { getByText } = render(
+  //     <Text as="unknown">
+  //       <Text as="unknown">valid nesting</Text>
+  //     </Text>,
+  //   );
+  //   expect(getByText('valid nesting')).toBeDefined();
+  // });
+});

--- a/src/sx-design/src/Text/__tests__/__snapshots__/Text.test.js.snap
+++ b/src/sx-design/src/Text/__tests__/__snapshots__/Text.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`throw for situations resulting in invalid HTML h2 inside h1 1`] = `"Nesting <h2/> inside <h1/> is not allowed in HTML. You can fix this error by changing the text type to some HTML element that allows nesting, for example: <Text as=\\"span\\" />"`;
+
+exports[`throw for situations resulting in invalid HTML p inside h1 1`] = `"Nesting <p/> inside <h1/> is not allowed in HTML. You can fix this error by changing the text type to some HTML element that allows nesting, for example: <Text as=\\"span\\" />"`;
+
+exports[`throw for situations resulting in invalid HTML p inside p 1`] = `"Nesting <p/> inside <p/> is not allowed in HTML. You can fix this error by changing the text type to some HTML element that allows nesting, for example: <Text as=\\"span\\" />"`;
+
+exports[`throw for situations resulting in invalid HTML p inside small 1`] = `"Nesting <p/> inside <small/> is not allowed in HTML. You can fix this error by changing the text type to some HTML element that allows nesting, for example: <Text as=\\"span\\" />"`;

--- a/src/sx-design/src/Text/validateDOMNesting.js
+++ b/src/sx-design/src/Text/validateDOMNesting.js
@@ -1,0 +1,3 @@
+// @flow strict
+
+// TODO?


### PR DESCRIPTION
**This PR is here only to show how it could be implemented. It's unfinished, very dirty and I am not planning to continue with it (see: https://github.com/adeira/universe/pull/3072 and https://github.com/adeira/universe/discussions/3036).**