### PR TITLE
SX Design: finish `Tabs` accessibility implementation

### DIFF
--- a/src/sx-design/src/Tabs/Tabs.js
+++ b/src/sx-design/src/Tabs/Tabs.js
@@ -1,9 +1,10 @@
 // @flow
 
-import React, { type Node } from 'react';
+import React, { useRef, type Node } from 'react';
 import sx from '@adeira/sx';
 
 import Text from '../Text/Text';
+import useKeyPress from '../useKeyPress';
 
 export type TabValueType = string | number | null;
 export type TabsType = Array<{
@@ -22,23 +23,84 @@ type Props = {
  * content at a time. Each tab panel has an associated tab element, that when activated, displays
  * the panel. The list of tab elements is arranged along one edge of the currently displayed panel.
  *
- * TODO: improve accessibility
+ * ## Accessibility
+ *
+ * When focus moves into the tab list, places focus on the active tab element. When the tab list
+ * contains the focus, moves focus to the next element in the page tab sequence outside the tablist,
+ * which is typically either the first focusable element inside the tab panel or the tab panel itself.
+ *
+ * When focus is on a tab element in a horizontal tab list:
+ *  - Left Arrow: moves focus to the previous tab. If focus is on the first tab, moves focus to the
+ *   last tab.
+ *  - Right Arrow: moves focus to the next tab. If focus is on the last tab element, moves focus to
+ *   the first tab.
+ *
+ * When focus is on a tab in a tablist:
+ *  - Space or Enter: activates the tab if it was not activated automatically on focus.
+ *
+ * For more information about accessibility please visit:
  *  - https://www.w3.org/TR/wai-aria-practices/#tabpanel
  *  - https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-2/tabs.html
  */
 export default function Tabs(props: Props): Node {
+  const tabRefs = useRef([]);
+
+  // The following function takes care of switching the tabs based on the pressed arrows (left/right).
+  // We could emulate this behavior by simply using radiogroup which does this by default. However,
+  // it's convenient to implement it manually because we want to delay the tabpanel activation on
+  // spacebar/enter press. This way we can preload the tabpanel content in case the panel is not
+  // loading instantly (for example: https://relay.dev/docs/api-reference/use-preloaded-query/).
+  //
+  // TODO: add ability to activate the tabs instantly when the preloading is not needed (?)
+  const switchTabOnArrowPress = (direction: 'left' | 'right') => {
+    const activeIndex = tabRefs.current.findIndex((tab) => tab === document.activeElement);
+
+    if (activeIndex === -1) {
+      // none of the tabs is focused so we have to ignore all attempts to change the tab with arrows
+      return;
+    }
+
+    const nextTab = tabRefs.current[activeIndex + (direction === 'left' ? -1 : +1)];
+    if (nextTab != null) {
+      nextTab.focus();
+    } else if (direction === 'left') {
+      // focus LAST tab (going from the left card to the end)
+      tabRefs.current[tabRefs.current.length - 1]?.focus();
+    } else if (direction === 'right') {
+      // focus FIST tab (going from the right card to the beginning)
+      tabRefs.current[0]?.focus();
+    } else {
+      (direction: empty);
+    }
+  };
+
+  useKeyPress({
+    key: 'ArrowLeft',
+    onKeyDown: () => {
+      switchTabOnArrowPress('left');
+    },
+  });
+
+  useKeyPress({
+    key: 'ArrowRight',
+    onKeyDown: () => {
+      switchTabOnArrowPress('right');
+    },
+  });
+
   return (
-    <div className={styles('tabs')} role="tablist">
-      {props.tabs.map((tab) => {
+    <div className={styles('tabs')} role="tablist" aria-orientation="horizontal">
+      {props.tabs.map((tab, index) => {
         const isTabSelected = props.selected === tab.value;
         return (
           // eslint-disable-next-line react/forbid-elements
           <button
+            data-testid={tab.value != null ? `TabsButton-${tab.value}` : 'TabsButton'}
             role="tab"
             type="button"
             key={tab.value}
             aria-selected={isTabSelected}
-            // tabIndex={isTabSelected ? 0 : -1} // TODO (when we can navigate tabs with arrows)
+            tabIndex={isTabSelected ? 0 : -1} // only the selected tab can be "tabbable", use arrows to navigate to the other tabs
             className={styles({
               tabDefault: true,
               tabSelected: isTabSelected,
@@ -46,6 +108,7 @@ export default function Tabs(props: Props): Node {
             onClick={() => {
               props.setSelected(tab.value);
             }}
+            ref={(element) => (tabRefs.current[index] = element)}
           >
             <Text size={16} weight={700} as="span">
               {tab.title}

--- a/src/sx-design/src/Tabs/__tests__/Tabs.test.js
+++ b/src/sx-design/src/Tabs/__tests__/Tabs.test.js
@@ -127,3 +127,73 @@ it('supports null and number values', () => {
   expect(getByText('1 (selected)')).toBeDefined();
   expect(getByText('2')).toBeDefined();
 });
+
+it('correctly handles focus when navigating with right arrow ->', () => {
+  const { getByTestId } = render(<TestComponentFruits />);
+
+  expect(getByTestId('TabsButton-apple')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-orange')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-mango')).not.toHaveFocus();
+
+  // we press right arrow (->) but it should not have any effect because no tab is currently focused
+  fireEvent.keyDown(getByTestId('TabsButton-orange'), { key: 'ArrowRight' });
+
+  // we have to focus the button directly - `getByText('Apple…')` would not work
+  getByTestId('TabsButton-apple').focus();
+  expect(getByTestId('TabsButton-apple')).toHaveFocus();
+  expect(getByTestId('TabsButton-orange')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-mango')).not.toHaveFocus();
+
+  // ->
+  fireEvent.keyDown(getByTestId('TabsButton-orange'), { key: 'ArrowRight' });
+  expect(getByTestId('TabsButton-apple')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-orange')).toHaveFocus();
+  expect(getByTestId('TabsButton-mango')).not.toHaveFocus();
+
+  // ->
+  fireEvent.keyDown(getByTestId('TabsButton-orange'), { key: 'ArrowRight' });
+  expect(getByTestId('TabsButton-apple')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-orange')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-mango')).toHaveFocus();
+
+  // -> (should jump back to the first tab)
+  fireEvent.keyDown(getByTestId('TabsButton-orange'), { key: 'ArrowRight' });
+  expect(getByTestId('TabsButton-apple')).toHaveFocus();
+  expect(getByTestId('TabsButton-orange')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-mango')).not.toHaveFocus();
+});
+
+it('correctly handles focus when navigating with left arrow <-', () => {
+  const { getByTestId } = render(<TestComponentFruits />);
+
+  expect(getByTestId('TabsButton-apple')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-orange')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-mango')).not.toHaveFocus();
+
+  // we press left arrow (<-) but it should not have any effect because no tab is currently focused
+  fireEvent.keyDown(getByTestId('TabsButton-orange'), { key: 'ArrowLeft' });
+
+  // we have to focus the button directly - `getByText('Apple…')` would not work
+  getByTestId('TabsButton-mango').focus();
+  expect(getByTestId('TabsButton-apple')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-orange')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-mango')).toHaveFocus();
+
+  // <-
+  fireEvent.keyDown(getByTestId('TabsButton-orange'), { key: 'ArrowLeft' });
+  expect(getByTestId('TabsButton-apple')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-orange')).toHaveFocus();
+  expect(getByTestId('TabsButton-mango')).not.toHaveFocus();
+
+  // <-
+  fireEvent.keyDown(getByTestId('TabsButton-orange'), { key: 'ArrowLeft' });
+  expect(getByTestId('TabsButton-apple')).toHaveFocus();
+  expect(getByTestId('TabsButton-orange')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-mango')).not.toHaveFocus();
+
+  // <- (should jump back to the last tab)
+  fireEvent.keyDown(getByTestId('TabsButton-orange'), { key: 'ArrowLeft' });
+  expect(getByTestId('TabsButton-apple')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-orange')).not.toHaveFocus();
+  expect(getByTestId('TabsButton-mango')).toHaveFocus();
+});


### PR DESCRIPTION
This commit corrects accessibility implementation of the `Tabs`
component. Basically, you can focus the active tab via `Tab` key and
then you can navigate the tabs using arrows (not via `Tab` key).

This implementation should follow recommendations as per: https://www.w3.org/TR/wai-aria-practices/#tabpanel