### PR TITLE
eslint-config: set jsx-a11y/accessible-emoji to off

### DIFF
--- a/src/eslint-config-adeira/CHANGELOG.md
+++ b/src/eslint-config-adeira/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- set `jsx-a11y/accessible-emoji` rule to off, since it is deprecated and creates a degraded experience: [see](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/627)
 - New rules `@next/next/inline-script-id`, `@next/next/no-script-in-document` and `@next/next/no-script-in-head` enabled (as warnings). For more information visit: https://nextjs.org/docs/basic-features/eslint#eslint-plugin
 - We clarified what to do when you are using `@adeira/eslint-config/next` preset inside monorepo (check our readme). Basically, you might encounter the following warning:
 

--- a/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
+++ b/src/eslint-config-adeira/__tests__/__snapshots__/index.test.js.snap
@@ -366,7 +366,7 @@ Object {
     "jest/valid-expect": 2,
     "jest/valid-expect-in-promise": 2,
     "jest/valid-title": 2,
-    "jsx-a11y/accessible-emoji": 2,
+    "jsx-a11y/accessible-emoji": 0,
     "jsx-a11y/alt-text": 2,
     "jsx-a11y/anchor-has-content": 2,
     "jsx-a11y/anchor-is-valid": 2,

--- a/src/eslint-config-adeira/__tests__/__snapshots__/presets.test.js.snap
+++ b/src/eslint-config-adeira/__tests__/__snapshots__/presets.test.js.snap
@@ -800,7 +800,7 @@ Object {
       2,
       "all",
     ],
-    "jsx-a11y/accessible-emoji": 2,
+    "jsx-a11y/accessible-emoji": 0,
     "jsx-a11y/alt-text": 2,
     "jsx-a11y/anchor-has-content": 2,
     "jsx-a11y/anchor-is-valid": 2,

--- a/src/eslint-config-adeira/src/presets/react.js
+++ b/src/eslint-config-adeira/src/presets/react.js
@@ -176,7 +176,7 @@ module.exports = ({
     'react-native/split-platform-components': OFF,
 
     // React Accessibility (https://github.com/evcohen/eslint-plugin-jsx-a11y)
-    'jsx-a11y/accessible-emoji': ERROR,
+    'jsx-a11y/accessible-emoji': OFF,
     'jsx-a11y/alt-text': ERROR,
     'jsx-a11y/anchor-has-content': ERROR,
     'jsx-a11y/anchor-is-valid': ERROR,


### PR DESCRIPTION
From some testing on os x with VoiceOver, it seems the guidance
provided in the rule jsx-a11y/accessible-emoji leads to a degraded
experience with the label not being announced to the user.

See [issue here](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/627)