### PR TITLE
SX Design: allow number to be a `Text` children

### DIFF
--- a/src/abacus-backoffice/src/pos/ProductsSelected.js
+++ b/src/abacus-backoffice/src/pos/ProductsSelected.js
@@ -27,7 +27,6 @@ export default function ProductsSelected(): React.Node {
             <div className={styles('selectedItemTitle')}>
               <strong>{selectedItem.itemTitle}</strong>
               <br />
-              {/* $FlowFixMe[incompatible-type-arg]: https://github.com/adeira/universe/pull/3085 */}
               <Text as="small">
                 {selectedItem.units} &times;{' '}
                 <Money

--- a/src/abacus-backoffice/translations/source_strings.json
+++ b/src/abacus-backoffice/translations/source_strings.json
@@ -733,9 +733,9 @@
     "EAFd1PD0L8GS/sTNRO5dzA==": "{totalSelectedItems} items for {totalPrice}"
    },
    "filepath": "src/pos/ProductsSelected.js",
-   "line_beg": 69,
+   "line_beg": 68,
    "col_beg": 8,
-   "line_end": 79,
+   "line_end": 78,
    "col_end": 14,
    "desc": "summary of selected items in POS",
    "project": "",
@@ -747,9 +747,9 @@
     "nIpABsKUotYCJOCxk8ZWTg==": "Proceed to checkout"
    },
    "filepath": "src/pos/ProductsSelected.js",
-   "line_beg": 88,
+   "line_beg": 87,
    "col_beg": 10,
-   "line_end": 88,
+   "line_end": 87,
    "col_end": 69,
    "desc": "checkout button title",
    "project": "",

--- a/src/sx-design/__flowtests__/Text.js
+++ b/src/sx-design/__flowtests__/Text.js
@@ -27,12 +27,19 @@ export const testAnchor = (): Node => {
   );
 };
 
-export const testTextInsideText = (): Node => {
+export const testStringWithNumber = (): Node => {
+  return <Text>test string with number: {-1}</Text>;
+};
+
+export const testTextInsideTextInsideText = (): Node => {
   return (
     <Text>
       text{' '}
       <Text>
-        inside <Text>text</Text>
+        inside{' '}
+        <Text>
+          inside <Text>text</Text>
+        </Text>
       </Text>
     </Text>
   );
@@ -45,8 +52,6 @@ export const testInvalidTypes = (): Node => {
       <Text>{null}</Text>
       {/* $FlowExpectedError[incompatible-type]: boolean is not valid */}
       <Text>{true}</Text>
-      {/* $FlowExpectedError[incompatible-type]: number is not valid */}
-      <Text>{-1}</Text>
     </>
   );
 };

--- a/src/sx-design/src/Text/Text.js
+++ b/src/sx-design/src/Text/Text.js
@@ -34,7 +34,7 @@ type TextSupportedTypes =
 
 // In most of the cases, the `Text` children should be a translated string. However, we allow
 // somehow restricted React `Node` so that user can for example embed HTML links.
-type RestrictedReactNode = Fbt | Element<any> | Iterable<RestrictedReactNode>;
+type RestrictedReactNode = Fbt | Element<any> | Iterable<RestrictedReactNode> | number;
 
 type Props = {
   +'children': RestrictedReactNode,


### PR DESCRIPTION
I have a use-case where this makes sense to allow.