### PR TITLE
SX Design: improve `Button` children type

### DIFF
--- a/src/abacus-backoffice/src/pos/ProductsGridModalBody.js
+++ b/src/abacus-backoffice/src/pos/ProductsGridModalBody.js
@@ -78,7 +78,6 @@ export default function ProductsGridModalBody(props: Props): Node {
               size="large"
               tint={selectedProductAddons.has(addon.id) ? 'secondary' : 'default'}
               onClick={() => toggleSelectedAddon(addon.id, addon.name, addon.priceExtra.unitAmount)}
-              // $FlowFixMe[incompatible-type]: https://github.com/adeira/universe/pull/3091
             >
               {addon.name} (
               {MoneyFn({

--- a/src/sx-design/.npmignore
+++ b/src/sx-design/.npmignore
@@ -1,5 +1,7 @@
 .storybook
 __flowtests__
 __tests__
+src/stories
 
 **/*.stories.js
+**/*.stories.mdx

--- a/src/sx-design/__flowtests__/Button.js
+++ b/src/sx-design/__flowtests__/Button.js
@@ -29,15 +29,82 @@ export const testIcon = (): Node => {
   );
 };
 
-export const testInvalidTypes = (): Node => {
+export const testMultipleRestrictedNodes = (): Node => {
+  return (
+    <Button onClick={() => {}}>
+      {'test string A'} {-1} {'test string B'}
+    </Button>
+  );
+};
+
+export const testValidTints = (): Node => {
+  return (
+    <>
+      <Button onClick={() => {}} tint="default">
+        default
+      </Button>
+      <Button onClick={() => {}} tint="secondary">
+        secondary
+      </Button>
+      <Button onClick={() => {}} tint="success">
+        success
+      </Button>
+      <Button onClick={() => {}} tint="warning">
+        warning
+      </Button>
+      <Button onClick={() => {}} tint="error">
+        error
+      </Button>
+    </>
+  );
+};
+
+export const testValidProperties = (): Node => {
+  return (
+    <Button
+      onClick={() => {}}
+      isDisabled={true}
+      aria-label="ellipsis"
+      type="reset"
+      data-testid="test-button-id"
+      prefix={<Icon name="duplicate" />}
+      suffix={<Icon name="postcard" />}
+    >
+      …
+    </Button>
+  );
+};
+
+export const testInvalidChildrenTypes = (): Node => {
   return (
     <>
       {/* $FlowExpectedError[incompatible-type]: null is not valid */}
       <Button onClick={() => {}}>{null}</Button>
       {/* $FlowExpectedError[incompatible-type]: boolean is not valid */}
       <Button onClick={() => {}}>{true}</Button>
-      {/* $FlowExpectedError[incompatible-type]: number is not valid */}
-      <Button onClick={() => {}}>{-1}</Button>
+    </>
+  );
+};
+
+export const testInvalidProperties = (): Node => {
+  return (
+    <>
+      {/* $FlowExpectedError[incompatible-type]: invalid tint */}
+      <Button onClick={() => {}} tint="invalid">
+        invalid tint
+      </Button>
+      {/* $FlowExpectedError[incompatible-type]: invalid size */}
+      <Button onClick={() => {}} size="massive">
+        invalid size
+      </Button>
+      {/* $FlowExpectedError[incompatible-type]: invalid prefix */}
+      <Button onClick={() => {}} prefix="clipboard">
+        invalid prefix
+      </Button>
+      {/* $FlowExpectedError[incompatible-type]: invalid data-testid */}
+      <Button onClick={() => {}} data-testid={-1}>
+        invalid test id
+      </Button>
     </>
   );
 };

--- a/src/sx-design/src/Button/Button.js
+++ b/src/sx-design/src/Button/Button.js
@@ -6,8 +6,10 @@ import * as React from 'react';
 
 import sharedButtonStyles from './styles';
 
+type RestrictedReactNode = number | Fbt | Iterable<RestrictedReactNode>;
+
 type Props = {
-  +'children': Fbt | RestrictedElement<typeof Icon>,
+  +'children': RestrictedReactNode | RestrictedElement<typeof Icon>,
   +'onClick': (event: SyntheticEvent<HTMLButtonElement>) => void,
   +'type'?:
     | 'submit' // The button submits the form data to the server.

--- a/src/sx-design/src/Text/Text.js
+++ b/src/sx-design/src/Text/Text.js
@@ -34,7 +34,7 @@ type TextSupportedTypes =
 
 // In most of the cases, the `Text` children should be a translated string. However, we allow
 // somehow restricted React `Node` so that user can for example embed HTML links.
-type RestrictedReactNode = Fbt | Element<any> | Iterable<RestrictedReactNode> | number;
+type RestrictedReactNode = number | Fbt | Element<any> | Iterable<RestrictedReactNode>;
 
 type Props = {
   +'children': RestrictedReactNode,


### PR DESCRIPTION
Children should accept `number` nodes as well as iterable of the number
and FBT. I excluded `Icon` from the iterable because we accept icon
only when it's an exclusive children node (see the `Button` logic).