### PR TITLE
JS: release version 2.1.1

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@adeira/monorepo-npm-publisher": "^2.0.0",
     "@adeira/monorepo-utils": "^0.11.0",
     "chalk": "^4.1.2"

--- a/src/abacus-backoffice/package.json
+++ b/src/abacus-backoffice/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@adeira/icons": "^1.0.0",
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@adeira/relay": "^4.0.0",
     "@adeira/sx": "^0.28.0",
     "@adeira/sx-design": "^0.19.0",

--- a/src/abacus-kochka/package.json
+++ b/src/abacus-kochka/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@adeira/icons": "^1.0.0",
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@adeira/relay": "^4.0.0",
     "@adeira/sx": "^0.28.0",
     "@adeira/sx-design": "^0.19.0",

--- a/src/css-colors/package.json
+++ b/src/css-colors/package.json
@@ -15,7 +15,7 @@
   "type": "commonjs",
   "license": "MIT",
   "dependencies": {
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@babel/runtime": "^7.15.4"
   }
 }

--- a/src/eslint-fixtures-tester/package.json
+++ b/src/eslint-fixtures-tester/package.json
@@ -15,7 +15,7 @@
   "private": false,
   "dependencies": {
     "@adeira/flow-types-eslint": "0.0.0",
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@babel/eslint-parser": "^7.15.7",
     "@babel/runtime": "^7.15.4",
     "eslint": "^7.32.0",

--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -9,7 +9,7 @@
     "@adeira/graphql-global-id": "^2.0.0",
     "@adeira/graphql-relay": "^0.3.0",
     "@adeira/icons": "^1.0.0",
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@adeira/monorepo-utils": "^0.11.0",
     "@adeira/relay": "^4.0.0",
     "@adeira/sx": "^0.28.0",

--- a/src/fetch/package.json
+++ b/src/fetch/package.json
@@ -15,7 +15,7 @@
   },
   "description": "Production ready fetch function with advanced capabilities like retries with delay and request cancellation after timeout.",
   "dependencies": {
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@babel/runtime": "^7.15.4",
     "cross-fetch": "^3.1.4"
   },

--- a/src/fixtures-tester/package.json
+++ b/src/fixtures-tester/package.json
@@ -15,7 +15,7 @@
   "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@babel/runtime": "^7.15.4"
   }
 }

--- a/src/flow-config-parser/package.json
+++ b/src/flow-config-parser/package.json
@@ -15,7 +15,7 @@
   "type": "commonjs",
   "dependencies": {
     "@adeira/fixtures-tester": "^1.1.0",
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@babel/runtime": "^7.15.4"
   }
 }

--- a/src/graphql-global-id/package.json
+++ b/src/graphql-global-id/package.json
@@ -15,7 +15,7 @@
   "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@babel/runtime": "^7.15.4"
   },
   "peerDependencies": {

--- a/src/graphql-relay-fauna/package.json
+++ b/src/graphql-relay-fauna/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "@adeira/graphql-global-id": "^2.0.0",
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@babel/runtime": "^7.15.4",
     "faunadb": "^4.4.1"
   },

--- a/src/icons/package.json
+++ b/src/icons/package.json
@@ -19,7 +19,7 @@
     "@loadable/component": "^5.15.0"
   },
   "devDependencies": {
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@svgr/core": "^5.5.0",
     "@svgr/plugin-svgo": "^5.5.0",
     "change-case": "^4.1.2",

--- a/src/js/CHANGELOG.md
+++ b/src/js/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Unreleased
 
+# 2.1.1
+
 Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
+- Dependency requirements were updated.
+- Minor internal changes.
 
 # 2.1.0
 

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "private": false,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "./src/index.js",
   "type": "commonjs",
   "sideEffects": false,

--- a/src/monorepo-scanner/package.json
+++ b/src/monorepo-scanner/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "sideEffects": false,
   "dependencies": {
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@adeira/monorepo-utils": "^0.11.0",
     "semver": "^7.3.5"
   },

--- a/src/monorepo-shipit/package.json
+++ b/src/monorepo-shipit/package.json
@@ -11,7 +11,7 @@
   "sideEffects": false,
   "dependencies": {
     "@adeira/fixtures-tester": "^1.1.0",
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@adeira/monorepo-utils": "^0.11.0",
     "chalk": "^4.1.2",
     "command-line-args": "^5.2.0",

--- a/src/monorepo-utils/package.json
+++ b/src/monorepo-utils/package.json
@@ -19,7 +19,7 @@
     "monorepo-run-tests": "bin/monorepo-run-tests.js"
   },
   "dependencies": {
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@babel/register": "^7.15.3",
     "@babel/runtime": "^7.15.4",
     "glob": "^7.2.0",

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@adeira/fetch": "^2.1.0",
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@adeira/monorepo-utils": "^0.11.0",
     "@adeira/signed-source": "^2.0.0",
     "@babel/register": "^7.15.3",

--- a/src/sx-design/package.json
+++ b/src/sx-design/package.json
@@ -16,7 +16,7 @@
   "sideEffects": false,
   "dependencies": {
     "@adeira/icons": "^1.0.0",
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@babel/runtime": "^7.15.4",
     "blurhash": "^1.1.4",
     "fbt": "^0.16.6",

--- a/src/sx-tailwind/package.json
+++ b/src/sx-tailwind/package.json
@@ -15,7 +15,7 @@
   "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@adeira/signed-source": "^2.0.0",
     "@adeira/sx": "^0.28.0",
     "@babel/runtime": "^7.15.4",

--- a/src/sx/package.json
+++ b/src/sx/package.json
@@ -16,7 +16,7 @@
   "sideEffects": false,
   "dependencies": {
     "@adeira/css-colors": "^2.2.0",
-    "@adeira/js": "^2.1.0",
+    "@adeira/js": "^2.1.1",
     "@adeira/murmur-hash": "^2.0.0",
     "@babel/runtime": "^7.15.4",
     "change-case": "^4.1.2",


### PR DESCRIPTION
Full diff:

```diff
diff --git a/src/js/.npmignore b/src/js/.npmignore
index 1d2c8b25f..c912533dd 100644
--- a/src/js/.npmignore
+++ b/src/js/.npmignore
@@ -1,3 +1 @@
 __tests__
-BUILD.bazel
-BUILD
diff --git a/src/js/BUILD.bazel b/src/js/BUILD.bazel
deleted file mode 100644
index 3e2c4c16f..000000000
--- a/src/js/BUILD.bazel
+++ /dev/null
@@ -1,11 +0,0 @@
-load("//:bazel/macros/build_yarn_workspace.bzl", "build_yarn_workspace")
-load("//:bazel/macros/test_yarn_workspace.bzl", "test_yarn_workspace")
-
-build_yarn_workspace(
-    name = "js",
-    package_name = "@adeira/js",
-)
-
-test_yarn_workspace(
-    name = "test",
-)
diff --git a/src/js/CHANGELOG.md b/src/js/CHANGELOG.md
index 9d43dacf4..30d885a13 100644
--- a/src/js/CHANGELOG.md
+++ b/src/js/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+# 2.1.1
+
+Note for all Flow users: all projects in [`adeira/universe`](https://github.com/adeira/universe) now use implicit exact Flow types (`{}` for strict objects and `{ ... }` for open objects, syntax `{||}` is deprecated). We do not expect any issues as long as you are using `exact_by_default=true` Flow option.
+
+- Dependency requirements were updated.
+- Minor internal changes.
+
 # 2.1.0
 
 - Added a new function `rangeMap` which helps with creating an array of elements with predefined length.
diff --git a/src/js/package.json b/src/js/package.json
index 1398ef7c8..4a2ae4865 100644
--- a/src/js/package.json
+++ b/src/js/package.json
@@ -1,13 +1,20 @@
 {
   "name": "@adeira/js",
   "description": "Useful JS functions used in Adeira ecosystem",
-  "homepage": "https://github.com/adeira/universe/tree/master/src/js",
+  "homepage": "https://github.com/adeira/js",
+  "bugs": "https://github.com/adeira/universe/issues",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:adeira/universe.git",
+    "directory": "src/js"
+  },
   "license": "MIT",
   "private": false,
-  "version": "2.1.0",
-  "main": "src/index",
+  "version": "2.1.1",
+  "main": "./src/index.js",
+  "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
-    "@babel/runtime": "^7.12.13"
+    "@babel/runtime": "^7.15.4"
   }
 }
diff --git a/src/js/src/__tests__/isBrowser.test.js b/src/js/src/__tests__/isBrowser.test.js
index 569e700cb..533a211e8 100644
--- a/src/js/src/__tests__/isBrowser.test.js
+++ b/src/js/src/__tests__/isBrowser.test.js
@@ -1,7 +1,7 @@
 /**
- * @jest-environment  jsdom
+ * @flow strict
+ * @jest-environment jsdom
  */
-// @flow strict
 
 import isBrowser from '../isBrowser';
```