### PR TITLE
SX Design: remove abundant button from aria-label

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 
 **/ios/Pods
+**/.next

--- a/src/sx-design/src/Modal/ModalDialog.js
+++ b/src/sx-design/src/Modal/ModalDialog.js
@@ -37,9 +37,7 @@ export default function ModalDialog(props: Props): Node {
                 tint="secondary"
                 size="small"
                 onClick={props.onClose}
-                aria-label={
-                  <fbt desc="close modal button ARIA description">close modal button</fbt>
-                }
+                aria-label={<fbt desc="close modal button ARIA description">close modal</fbt>}
               >
                 <Icon name="cross" data-testid="ModalDialogCloseButton" />
               </Button>

--- a/src/sx-design/src/Modal/ModalDrawer.js
+++ b/src/sx-design/src/Modal/ModalDrawer.js
@@ -37,9 +37,7 @@ export default function ModalDrawer(props: Props): Node {
                 tint="secondary"
                 size="small"
                 onClick={props.onClose}
-                aria-label={
-                  <fbt desc="close modal button ARIA description">close modal button</fbt>
-                }
+                aria-label={<fbt desc="close modal button ARIA description">close modal</fbt>}
               >
                 <Icon name="cross" data-testid="ModalDrawerCloseButton" />
               </Button>

--- a/src/sx-design/translations/out/ar-AR.json
+++ b/src/sx-design/translations/out/ar-AR.json
@@ -7,7 +7,7 @@
     "3BjGb7": "open menu",
     "t3fdO": "Unable to load data or missing data.",
     "2vc7TY": "N/A",
-    "3Ts5m8": "close modal button",
+    "4k944r": "close modal",
     "2kqQC3": "تم بنجاح",
     "3IzWFC": "خطأ",
     "1pft9x": "تحذير",

--- a/src/sx-design/translations/out/cs-CZ.json
+++ b/src/sx-design/translations/out/cs-CZ.json
@@ -7,7 +7,7 @@
     "3BjGb7": "open menu",
     "t3fdO": "Nelze načíst data nebo chybějící data.",
     "2vc7TY": "N/A",
-    "3Ts5m8": "close modal button",
+    "4k944r": "close modal",
     "2kqQC3": "Úspěch",
     "3IzWFC": "Chyba",
     "1pft9x": "Upozornění",

--- a/src/sx-design/translations/out/es-MX.json
+++ b/src/sx-design/translations/out/es-MX.json
@@ -7,7 +7,7 @@
     "3BjGb7": "open menu",
     "t3fdO": "No se pueden cargar los datos o datos faltantes.",
     "2vc7TY": "n/a",
-    "3Ts5m8": "close modal button",
+    "4k944r": "close modal",
     "2kqQC3": "Exitoso",
     "3IzWFC": "Error",
     "1pft9x": "Atención",

--- a/src/sx-design/translations/out/no-NO.json
+++ b/src/sx-design/translations/out/no-NO.json
@@ -7,7 +7,7 @@
     "3BjGb7": "open menu",
     "t3fdO": "Unable to load data or missing data.",
     "2vc7TY": "N/A",
-    "3Ts5m8": "close modal button",
+    "4k944r": "close modal",
     "2kqQC3": "Suksess",
     "3IzWFC": "Feil",
     "1pft9x": "Advarsel",

--- a/src/sx-design/translations/out/ru-RU.json
+++ b/src/sx-design/translations/out/ru-RU.json
@@ -7,7 +7,7 @@
     "3BjGb7": "open menu",
     "t3fdO": "Unable to load data or missing data.",
     "2vc7TY": "N/A",
-    "3Ts5m8": "close modal button",
+    "4k944r": "close modal",
     "2kqQC3": "Успех",
     "3IzWFC": "Ошибка",
     "1pft9x": "Предупреждение",

--- a/src/sx-design/translations/out/uk-UA.json
+++ b/src/sx-design/translations/out/uk-UA.json
@@ -7,7 +7,7 @@
     "3BjGb7": "open menu",
     "t3fdO": "Unable to load data or missing data.",
     "2vc7TY": "N/A",
-    "3Ts5m8": "close modal button",
+    "4k944r": "close modal",
     "2kqQC3": "Успішно",
     "3IzWFC": "Помилка",
     "1pft9x": "Увага",

--- a/src/sx-design/translations/source_strings.json
+++ b/src/sx-design/translations/source_strings.json
@@ -100,31 +100,31 @@
   },
   {
    "hashToText": {
-    "STJRzUb9dqzlXD8Ox1HhPA==": "close modal button"
+    "Czh1UqoArscJtPTS7oIQgg==": "close modal"
    },
    "filepath": "src/Modal/ModalDialog.js",
-   "line_beg": 41,
-   "col_beg": 18,
-   "line_end": 41,
-   "col_end": 90,
+   "line_beg": 40,
+   "col_beg": 28,
+   "line_end": 40,
+   "col_end": 93,
    "desc": "close modal button ARIA description",
    "project": "",
    "type": "text",
-   "jsfbt": "close modal button"
+   "jsfbt": "close modal"
   },
   {
    "hashToText": {
-    "STJRzUb9dqzlXD8Ox1HhPA==": "close modal button"
+    "Czh1UqoArscJtPTS7oIQgg==": "close modal"
    },
    "filepath": "src/Modal/ModalDrawer.js",
-   "line_beg": 41,
-   "col_beg": 18,
-   "line_end": 41,
-   "col_end": 90,
+   "line_beg": 40,
+   "col_beg": 28,
+   "line_end": 40,
+   "col_end": 93,
    "desc": "close modal button ARIA description",
    "project": "",
    "type": "text",
-   "jsfbt": "close modal button"
+   "jsfbt": "close modal"
   },
   {
    "hashToText": {


### PR DESCRIPTION
The screen reader announces `aria-label, button`, so it will read out
`close modal button, button`. Which makes the button abundant. Now it will
read `close modal, button` instead.