### PR TITLE
Eslint config: improve peer dependencies requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {},
   "devDependencies": {
     "@adeira/babel-preset-adeira": "^4.0.0",
-    "@adeira/eslint-config": "^6.7.0",
+    "@adeira/eslint-config": "^6.7.1",
     "@babel/cli": "^7.15.7",
     "@babel/core": "^7.15.8",
     "@babel/eslint-parser": "^7.15.8",

--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "private": false,
-  "version": "6.7.0",
+  "version": "6.7.1",
   "main": "./index.js",
   "type": "commonjs",
   "sideEffects": false,


### PR DESCRIPTION
We do not support Eslint version 8 quite yet.