### PR TITLE
Abacus: use ArangoDB Kubernetes Operator version 1.2.3

### DIFF
--- a/src/abacus/kubernetes/third_party/arangodb/arango-crd.yaml
+++ b/src/abacus/kubernetes/third_party/arangodb/arango-crd.yaml
@@ -7,7 +7,7 @@ metadata:
   name: arangobackuppolicies.backup.arangodb.com
   labels:
     app.kubernetes.io/name: kube-arangodb-crd
-    helm.sh/chart: kube-arangodb-crd-1.1.9
+    helm.sh/chart: kube-arangodb-crd-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: crd
     release: crd
@@ -78,7 +78,7 @@ metadata:
   name: arangobackups.backup.arangodb.com
   labels:
     app.kubernetes.io/name: kube-arangodb-crd
-    helm.sh/chart: kube-arangodb-crd-1.1.9
+    helm.sh/chart: kube-arangodb-crd-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: crd
     release: crd
@@ -190,7 +190,7 @@ metadata:
   name: arangodeploymentreplications.replication.database.arangodb.com
   labels:
     app.kubernetes.io/name: kube-arangodb-crd
-    helm.sh/chart: kube-arangodb-crd-1.1.9
+    helm.sh/chart: kube-arangodb-crd-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: crd
     release: crd
@@ -237,7 +237,7 @@ metadata:
   name: arangodeployments.database.arangodb.com
   labels:
     app.kubernetes.io/name: kube-arangodb-crd
-    helm.sh/chart: kube-arangodb-crd-1.1.9
+    helm.sh/chart: kube-arangodb-crd-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: crd
     release: crd
@@ -284,7 +284,7 @@ metadata:
   name: arangomembers.database.arangodb.com
   labels:
     app.kubernetes.io/name: kube-arangodb-crd
-    helm.sh/chart: kube-arangodb-crd-1.1.9
+    helm.sh/chart: kube-arangodb-crd-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: crd
     release: crd

--- a/src/abacus/kubernetes/third_party/arangodb/arango-deployment.yaml
+++ b/src/abacus/kubernetes/third_party/arangodb/arango-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: deployment
     release: deployment
@@ -20,7 +20,7 @@ metadata:
   name: arango-deployment-operator-rbac-deployment
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: deployment
     release: deployment
@@ -39,7 +39,7 @@ metadata:
   name: arango-deployment-operator-rbac-deployment
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: deployment
     release: deployment
@@ -60,7 +60,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: deployment
     release: deployment
@@ -77,7 +77,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: deployment
     release: deployment
@@ -119,7 +119,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: deployment
     release: deployment
@@ -140,7 +140,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: deployment
     release: deployment
@@ -161,7 +161,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: deployment
     release: deployment
@@ -188,7 +188,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: deployment
     release: deployment
@@ -207,7 +207,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-arangodb
-        helm.sh/chart: kube-arangodb-1.1.9
+        helm.sh/chart: kube-arangodb-1.2.3
         app.kubernetes.io/managed-by: Tiller
         app.kubernetes.io/instance: deployment
         release: deployment
@@ -246,7 +246,7 @@ spec:
       containers:
         - name: operator
           imagePullPolicy: Always
-          image: arangodb/kube-arangodb:1.1.9
+          image: arangodb/kube-arangodb:1.2.3
           args:
             - --scope=legacy
             - --operator.deployment

--- a/src/abacus/kubernetes/third_party/arangodb/arango-storage.yaml
+++ b/src/abacus/kubernetes/third_party/arangodb/arango-storage.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: storage
     release: storage
@@ -20,7 +20,7 @@ metadata:
   name: arangolocalstorages.storage.arangodb.com
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: storage
     release: storage
@@ -43,7 +43,7 @@ metadata:
   name: arango-storage-operator-rbac-storage
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: storage
     release: storage
@@ -71,7 +71,7 @@ metadata:
   name: arango-storage-operator-rbac-storage
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: storage
     release: storage
@@ -92,7 +92,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: storage
     release: storage
@@ -118,7 +118,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: storage
     release: storage
@@ -139,7 +139,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: storage
     release: storage
@@ -166,7 +166,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.1.9
+    helm.sh/chart: kube-arangodb-1.2.3
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/instance: storage
     release: storage
@@ -185,7 +185,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-arangodb
-        helm.sh/chart: kube-arangodb-1.1.9
+        helm.sh/chart: kube-arangodb-1.2.3
         app.kubernetes.io/managed-by: Tiller
         app.kubernetes.io/instance: storage
         release: storage
@@ -224,7 +224,7 @@ spec:
       containers:
         - name: operator
           imagePullPolicy: Always
-          image: arangodb/kube-arangodb:1.1.9
+          image: arangodb/kube-arangodb:1.2.3
           args:
             - --scope=legacy
             - --operator.storage


### PR DESCRIPTION
Already applied in the cluster.