### PR TITLE
Abacus BO: fix project dependencies

### DIFF
--- a/src/abacus-backoffice/package.json
+++ b/src/abacus-backoffice/package.json
@@ -19,11 +19,13 @@
     "@adeira/relay": "^4.0.0",
     "@adeira/sx": "^0.28.0",
     "@adeira/sx-design": "^0.20.0",
+    "@next/bundle-analyzer": "^11.1.2",
     "d3": "^7.1.1",
     "fbt": "^0.16.6",
     "graphql": "^15.6.1",
     "immutable": "^4.0.0",
     "next": "^11.1.2",
+    "next-compose-plugins": "^2.2.1",
     "next-plugin-custom-babel-config": "^1.0.5",
     "next-transpile-modules": "^8.0.0",
     "react": "^17.0.2",
@@ -34,11 +36,9 @@
   "devDependencies": {
     "@adeira/babel-preset-adeira": "^4.0.0",
     "@fbtjs/default-collection-transform": "^0.0.3",
-    "@next/bundle-analyzer": "^11.1.2",
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^7.0.2",
     "babel-plugin-fbt": "^0.20.3",
-    "babel-plugin-fbt-runtime": "^0.9.18",
-    "next-compose-plugins": "^2.2.1"
+    "babel-plugin-fbt-runtime": "^0.9.18"
   }
 }


### PR DESCRIPTION
To fix the following error in K8S:

```text
next start --port=5001
ready - started server on 0.0.0.0:5001, url: http://localhost:5001
Error: failed to load next.config.js, see more info here https://nextjs.org/docs/messages/next-config-error
Error: Cannot find module 'next-compose-plugins'
Require stack:
- /app/next.config.js
- /app/node_modules/next/dist/server/config.js
- /app/node_modules/next/dist/server/next.js
- /app/node_modules/next/dist/server/lib/start-server.js
- /app/node_modules/next/dist/cli/next-start.js
- /app/node_modules/next/dist/bin/next
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.mod._resolveFilename (/app/node_modules/next/dist/build/webpack/require-hook.js:96:28)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/app/next.config.js:6:21)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/app/next.config.js',
    '/app/node_modules/next/dist/server/config.js',
    '/app/node_modules/next/dist/server/next.js',
    '/app/node_modules/next/dist/server/lib/start-server.js',
    '/app/node_modules/next/dist/cli/next-start.js',
    '/app/node_modules/next/dist/bin/next'
  ]
}
error Command failed with exit code 1.
```