### PR TITLE
CI: use Node.js version 17

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 17.x]
 
     steps:
       # https://github.com/actions/checkout


### PR DESCRIPTION
See: https://nodejs.org/en/blog/release/v17.0.0/

TODO:

- [x] make it a required check in GH settings (once approved)
- [x] run `yarn test-only --all`