### PR TITLE
Abacus KO: enable failing tests

### DIFF
--- a/src/abacus-kochka/src/__tests__/LanguageTag.test.js
+++ b/src/abacus-kochka/src/__tests__/LanguageTag.test.js
@@ -2,9 +2,7 @@
 
 import LanguageTag from '../LanguageTag';
 
-// https://github.com/babel/babel/issues/13462
-// eslint-disable-next-line jest/no-disabled-tests
-it.skip('returns default language as expected', () => {
+it('returns default language as expected', () => {
   expect(LanguageTag.getDefaultLanguageTag()).toMatchInlineSnapshot(`
     Object {
       "bcp47": "es-MX",
@@ -14,9 +12,7 @@ it.skip('returns default language as expected', () => {
   `);
 });
 
-// https://github.com/babel/babel/issues/13462
-// eslint-disable-next-line jest/no-disabled-tests
-test.skip.each`
+test.each`
   languageTag | expectedBCP47 | expectedURL | expectedGraphQL
   ${'en-US'}  | ${'en-US'}    | ${'en-us'}  | ${'en_US'}
   ${'en-us'}  | ${'en-US'}    | ${'en-us'}  | ${'en_US'}
@@ -34,9 +30,7 @@ test.skip.each`
   },
 );
 
-// https://github.com/babel/babel/issues/13462
-// eslint-disable-next-line jest/no-disabled-tests
-test.skip.each`
+test.each`
   languageTag | expected
   ${'en-US'}  | ${false}
   ${'abc'}    | ${true}

--- a/src/abacus-kochka/src/__tests__/Layout.test.js
+++ b/src/abacus-kochka/src/__tests__/Layout.test.js
@@ -7,9 +7,7 @@ import { render } from '@testing-library/react';
 
 import Layout from '../Layout';
 
-// https://github.com/babel/babel/issues/13462
-// eslint-disable-next-line jest/no-disabled-tests
-it.skip('disallows hidden title when the title is specified', () => {
+it('disallows hidden title when the title is specified', () => {
   const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
   expect(() =>
@@ -25,9 +23,7 @@ it.skip('disallows hidden title when the title is specified', () => {
   consoleSpy.mockRestore();
 });
 
-// https://github.com/babel/babel/issues/13462
-// eslint-disable-next-line jest/no-disabled-tests
-it.skip('disallows hidden title when the subtitle is specified', () => {
+it('disallows hidden title when the subtitle is specified', () => {
   const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
   expect(() =>


### PR DESCRIPTION
Let's see if something changed and it works now (https://github.com/babel/babel/issues/13462).

Reverts: https://github.com/adeira/universe/pull/2550