### PR TITLE
Eslint plugin: fix `no-duplicate-import` rule for side-effect imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {},
   "devDependencies": {
     "@adeira/babel-preset-adeira": "^4.0.0",
-    "@adeira/eslint-config": "^6.7.1",
+    "@adeira/eslint-config": "^6.7.2",
     "@babel/cli": "^7.16.0",
     "@babel/core": "^7.16.0",
     "@babel/eslint-parser": "^7.16.0",

--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -18,7 +18,7 @@
     "@babel/runtime": "^7.16.0",
     "@next/eslint-plugin-next": "^12.0.2",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-adeira": "^0.14.0",
+    "eslint-plugin-adeira": "^0.15.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-fb-flow": "^0.0.4",
     "eslint-plugin-flowtype": "^7.0.0",

--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "private": false,
-  "version": "6.7.1",
+  "version": "6.7.2",
   "main": "./index.js",
   "type": "commonjs",
   "sideEffects": false,

--- a/src/eslint-plugin-adeira/package.json
+++ b/src/eslint-plugin-adeira/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "private": false,
-  "version": "0.14.0",
+  "version": "0.15.0",
   "main": "./src/index.js",
   "type": "commonjs",
   "sideEffects": false,

--- a/src/eslint-plugin-adeira/src/rules/__tests__/no-duplicate-import-type-import.test.js
+++ b/src/eslint-plugin-adeira/src/rules/__tests__/no-duplicate-import-type-import.test.js
@@ -15,17 +15,29 @@ ruleTester.run('no-duplicate-import', rule, {
     },
     {
       code: `import Foo, { type FooLol } from 'foo';
-    import Bar, { type BarLol} from 'bar';
-    import Lol from 'lol';`,
+import Bar, { type BarLol} from 'bar';
+import Lol from 'lol';`,
     },
     {
       // These are handled by imports/no-duplicate
       code: `import { Foo } from 'foo';
-      import { Bar } from 'foo';`,
+import { Bar } from 'foo';`,
     },
     {
       code: `import type { Foo } from 'foo'
-    import type { Bar } from 'foo'`,
+import type { Bar } from 'foo'`,
+    },
+    {
+      // https://github.com/adeira/universe/issues/3410
+      code: `import '@material/mwc-button';
+import '@material/mwc-dialog';
+import '@material/mwc-drawer';
+import '@material/mwc-icon-button';
+import '@material/mwc-list';
+import '@material/mwc-menu';
+import './WebComponents/TopAppBar';
+import './WebComponents/MaterialDrawer';
+import type {Dialog} from "@material/mwc-dialog";`,
     },
   ],
 

--- a/src/eslint-plugin-adeira/src/rules/no-duplicate-import-type-import.js
+++ b/src/eslint-plugin-adeira/src/rules/no-duplicate-import-type-import.js
@@ -1,17 +1,17 @@
 // @flow
 
 /*::
-import type { EslintRule, Node } from '@adeira/flow-types-eslint';
+import type { EslintRule, Node, ImportDeclaration } from '@adeira/flow-types-eslint';
 */
 
-function typeNodeSpecifiersToImport(typeNode) {
+function typeNodeSpecifiersToImport(typeNode /*: ImportDeclaration */) /*: string */ {
   // Build the import string, it will result in a string like: type Node, type ElementRef
   // Then caller wraps this accordingly to match it's specific case.
   // $FlowFixMe[prop-missing] - discovered when creating `@adeira/flow-types-eslint`
   return typeNode.specifiers.map((i) => `type ${i.imported.name}`).join(',');
 }
 
-function autoFix(typeNode, valueNode, fixer) {
+function autoFix(typeNode /*: ImportDeclaration */, valueNode /*: ImportDeclaration */, fixer) {
   // Each import has an array of specifiers, we want to append our typeimport after the last import
   const { type, range } = valueNode.specifiers[valueNode.specifiers.length - 1];
 
@@ -48,6 +48,12 @@ module.exports = ({
     const imports /* : Array<Node> */ = [];
     return {
       ImportDeclaration: (node) => {
+        if (node.specifiers.length === 0) {
+          // Early return because we don't want to take imports with side-effects into account, for example:
+          //    import '@material/mwc-dialog';
+          return;
+        }
+
         // An import like `import React, { type Node } from 'react'` has importKind value
         // An import like `import type { Node } from 'react'` has importKind type;
         const existingNode = imports.find(

--- a/src/flow-types-eslint/src/types/ImportDeclaration.js
+++ b/src/flow-types-eslint/src/types/ImportDeclaration.js
@@ -8,7 +8,10 @@ import type { ImportDefaultSpecifier } from './ImportDefaultSpecifier';
 
 export type ImportDeclaration = $ReadOnly<{
   ...INode<'ImportDeclaration'>,
-  +importKind: string,
+  +importKind: 'value' | 'type',
   +source: Literal,
+
+  // Please note that `specifiers` can be empty in case we are importing with side effects like so:
+  //    import '@material/mwc-dialog';
   +specifiers: $ReadOnlyArray<ImportDefaultSpecifier | ImportNamespaceSpecifier | ImportSpecifier>,
 }>;


### PR DESCRIPTION
I decided to ignore side-effect imports completely because it felt
strange to be enforcing consolidation of side-effects and type imports.

Closes: https://github.com/adeira/universe/issues/3410