### PR TITLE
SX Design: fix `Money` and `MoneyFn` rendering

### DIFF
--- a/src/sx-design/src/Money/Money.js
+++ b/src/sx-design/src/Money/Money.js
@@ -56,7 +56,7 @@ type IntlNumberFormatOptions = {
   maximumFractionDigits?: number,
   minimumSignificantDigits?: number,
   maximumSignificantDigits?: number,
-  numberingSystem?: 'arab' | 'cyrl',
+  numberingSystem?: 'arab' | 'cyrl' | 'latn',
 };
 
 // This function does essentially the same like the React <Money /> component except it can be
@@ -69,12 +69,13 @@ export function MoneyFn(props: MoneyFnProps): string {
   };
 
   if (props.locale === 'ar-AR') {
-    // We use "Cyrillic numerals" for Arabic as it is very common around the web. However, we allow
-    // to explicitly specify custom numbering system via the locale string. For example, locale
-    // `ar-AR-u-nu-arab` explicitly uses `arab` numbering system.
+    // We use "Latin numerals" (0123456789) for Arabic by default as it is very common around the
+    // web. However, we allow to explicitly specify custom numbering system via the locale string.
+    // For example, locale `ar-AR-u-nu-arab` explicitly uses `arab` numbering system.
+    //
     // See: https://www.unicode.org/reports/tr35/#u_Extension
     // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem
-    intlOptions.numberingSystem = 'cyrl';
+    intlOptions.numberingSystem = 'latn';
   }
 
   return new Intl.NumberFormat(props.locale, intlOptions).format(props.priceUnitAmount);


### PR DESCRIPTION
Something changed between Node.js 17.1 and 17.2 and our previous
implementation stopped working. Regardless of this fact, it seems like
we should've used numbering system `latn` in a first place.

This commit fixes the issue and unblocks all pending pull requests.