### PR TITLE
Dependabot: disable `chalk` dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,9 @@ updates:
       # Pure ESM, see: https://github.com/adeira/universe/issues/2341
       - dependency-name: 'refractor'
         versions: ['4.x']
+      # Pure ESM, see: https://github.com/adeira/universe/issues/2341
+      - dependency-name: 'chalk'
+        versions: ['5.x']
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
It's a pure ESM package, see: https://github.com/adeira/universe/issues/2341