### PR TITLE
CI: run Relay check

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -30,19 +30,22 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
 
+      # Command `yarn install --frozen-lockfile` doesn't always fail if `yarn.lock` is modified
+      # (see: https://github.com/yarnpkg/yarn/issues/5840). Instead, we are installing the
+      # dependencies as usual and checking that nothing changed.
       - name: Install Yarn dependencies
-        # Command `yarn install --frozen-lockfile` doesn't always fail if `yarn.lock` is modified (https://github.com/yarnpkg/yarn/issues/5840).
-        # Instead, we are installing the dependencies as usual and checking that nothing changed.
         run: |
           yarn install
           git diff --exit-code
 
-      - name: Run Flow checks
+      # We are purposefully expecting zero warnings in the output to make sure flowtests are
+      # working as expected (Flow returns warnings for unused suppression comments).
+      - name: Run Flow check
         run: |
           yarn flow version --binary
           yarn run flow --max-warnings=0
 
-      - name: Run Eslint
+      - name: Run Eslint check
         run: yarn run lint
 
       - name: Run Jest tests
@@ -50,3 +53,10 @@ jobs:
 
       - name: Run monorepo scanner
         run: yarn run scanner
+
+      # Runs the Relay Compiler for the whole monorepo and exit if there are new changes
+      # (meaning the generated files are not up-to-date).
+      - name: Run Relay check
+        run: |
+          ./node_modules/.bin/relay-compiler
+          git diff --exit-code


### PR DESCRIPTION
This makes sure that our generated files are always up-to-date. This
check works for the whole monorepo regardless of the projects inside
(all Relay projects will be checked).