### PR TITLE
SX Design: allow `Money` component as a `LinkButton` children

### DIFF
--- a/src/sx-design/__flowtests__/LinkButton.js
+++ b/src/sx-design/__flowtests__/LinkButton.js
@@ -1,0 +1,58 @@
+// @flow
+
+import Icon from '@adeira/icons';
+import { type Node, type Element } from 'react';
+import fbt from 'fbt';
+
+import { LinkButton, Money } from '../index';
+
+export const testStringChildren = (): Element<typeof LinkButton> => {
+  // $FlowExpectedError[incompatible-type]: we do not allow string children
+  return <LinkButton href="#">test string</LinkButton>;
+};
+
+export const testFbtChildren = (): Element<typeof LinkButton> => {
+  return (
+    <LinkButton href="#">
+      <fbt desc="test" doNotExtract={true}>
+        test fbt <fbt:param name="parameter">parameter</fbt:param>
+      </fbt>
+    </LinkButton>
+  );
+};
+
+export const testMoney = (): Element<typeof LinkButton> => {
+  return (
+    <LinkButton href="#">
+      <Money priceUnitAmount={42} priceUnitAmountCurrency="USD" />
+    </LinkButton>
+  );
+};
+
+export const testValidProperties = (): Node => {
+  return (
+    <LinkButton
+      href="#"
+      onClick={() => {}}
+      isDisabled={true}
+      data-testid="test-button-id"
+      prefix={<Icon name="duplicate" />}
+      suffix={<Icon name="postcard" />}
+    >
+      <fbt desc="…" doNotExtract={true}>
+        …
+      </fbt>
+    </LinkButton>
+  );
+};
+
+export const testMissingHref = (): Element<typeof LinkButton> => {
+  return (
+    // $FlowExpectedError[prop-missing]: property href is missing
+    <LinkButton>
+      <fbt desc="missing href" doNotExtract={true}>
+        missing href
+      </fbt>
+    </LinkButton>
+  );
+};

--- a/src/sx-design/src/Link/LinkButton.js
+++ b/src/sx-design/src/Link/LinkButton.js
@@ -6,10 +6,11 @@ import sx from '@adeira/sx';
 
 import Link from './Link';
 import sharedButtonStyles from '../Button/styles';
+import Money from '../Money/Money';
 
 type Props = {
   +'href': string,
-  +'children': FbtWithoutString,
+  +'children': FbtWithoutString | RestrictedElement<typeof Money>,
   +'target'?: string,
   +'isActive'?: boolean,
   +'tint'?: 'default' | 'secondary' | 'error' | 'success' | 'warning',


### PR DESCRIPTION
Also, add some basic Flow tests for `LinkButton`.