### PR TITLE
Abacus: set DB backup `concurrencyPolicy` to `Allow`

### DIFF
--- a/src/abacus/kubernetes/README.md
+++ b/src/abacus/kubernetes/README.md
@@ -97,7 +97,7 @@ EOF
 
 Automatic database backups are performed periodically **every two hours** and stored into standard S3 bucket. Format of the backups in S3 is `YYYY-MM-DDTHH:MM:SS` (for example `2021-06-06T20:37:42`) and the following S3 lifecycle rules are applied:
 
-- Old backups are automatically removed after 7 days
+- Old backups are automatically removed after 30 days
 - Incomplete multipart uploads are deleted after 1 day
 
 ## Restoring backups

--- a/src/abacus/kubernetes/abacus.yaml
+++ b/src/abacus/kubernetes/abacus.yaml
@@ -41,7 +41,7 @@ spec:
   #          │  │  │ │ │
   #          │  │  │ │ │
   schedule: '0 */2 * * *' # https://crontab.guru/every-two-hours
-  concurrencyPolicy: Forbid
+  concurrencyPolicy: Allow
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3
   jobTemplate:


### PR DESCRIPTION
> If startingDeadlineSeconds is set to a large value or left unset (the default) and if concurrencyPolicy is set to Allow, the jobs will always run at least once.

See: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-job-limitations