### PR TITLE
X: allow hyphen values

### DIFF
--- a/src/x/src/main.rs
+++ b/src/x/src/main.rs
@@ -5,11 +5,14 @@ mod executors;
 /// Creates a subcommand that allows any trailing arguments and is later able to forward them to
 /// the executed process.
 fn clap_fallthrough_subcommand(subcommand_name: &str) -> Command {
-    Command::new(subcommand_name).trailing_var_arg(true).arg(
-        Arg::new("trailing_args")
-            .takes_value(true)
-            .multiple_values(true),
-    )
+    Command::new(subcommand_name)
+        .trailing_var_arg(true)
+        .allow_hyphen_values(true)
+        .arg(
+            Arg::new("trailing_args")
+                .takes_value(true)
+                .multiple_values(true),
+        )
 }
 
 fn collect_trailing_args(matches: &ArgMatches) -> Vec<&str> {


### PR DESCRIPTION
This way we can run `./x t --watch` instead of `./x t -- --watch`