### PR TITLE
Yarn add `package.json` and `yarn.lock` into `changesetIgnorePatterns`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,3 +10,5 @@ yarnPath: .yarn/releases/yarn-3.2.0.cjs
 
 changesetIgnorePatterns:
   - "**/*.test.js"
+  - "**/package.json"
+  - "**/yarn.lock"


### PR DESCRIPTION
We are receiving many dependency upgrades and this can get very annoying. Let's skip these files for now even though it might be important for the releases.