### PR TITLE
Abacus: remove "Maison de Cannelle" from the menu

### DIFF
--- a/src/abacus/server/src/menu/mod.rs
+++ b/src/abacus/server/src/menu/mod.rs
@@ -57,7 +57,6 @@ pub(in crate::menu) async fn get_section(
                     "13296916".to_string(), // Hamara Black Chai
                     "3707225".to_string(),  // Jarabe Tapatío
                     "3707278".to_string(),  // Bésame Mucho
-                    "3707327".to_string(),  // Maison de Cannelle
                 ],
             )
             .await


### PR DESCRIPTION
We are replacing and improving our tea options so there are going to be more changes to this section soon.