### PR TITLE
CI: add `workflow_dispatch` event to the daily Rust Cargo workflow

### DIFF
--- a/.github/workflows/daily-rust-cargo-update.yml
+++ b/.github/workflows/daily-rust-cargo-update.yml
@@ -1,6 +1,7 @@
 name: Daily Rust Cargo update
 
 on:
+  workflow_dispatch:
   schedule:
     # daily (https://crontab.guru/#0_7_*_*_*)
     - cron: '0 7 * * *'


### PR DESCRIPTION
See: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow