### PR TITLE
Abacus docs: install `@babel/core`

### DIFF
--- a/src/abacus-docs/package.json
+++ b/src/abacus-docs/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
+    "@babel/core": "^7.18.2",
     "@babel/preset-flow": "^7.17.12"
   }
 }

--- a/src/abacus-docs/pages/docs/security.md
+++ b/src/abacus-docs/pages/docs/security.md
@@ -32,4 +32,4 @@ The previous links leads to:
 
 ![Phishing link destination example](/images/docs/security/phishing_2.png)
 
-Notice the URL address. That's certainly not Facebook website. So where does the login go?
+Notice the URL address. That's certainly not Facebook website. So where does the login go? Well, to the attacker!

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@abacus/docs@workspace:src/abacus-docs"
   dependencies:
+    "@babel/core": ^7.18.2
     "@babel/preset-flow": ^7.17.12
     "@markdoc/markdoc": ^0.1.2
     "@markdoc/next.js": ^0.1.4


### PR DESCRIPTION
This seems to be one of the required `@babel/preset-flow` peer dependencies.