### PR TITLE
Relay: expose experimental `compiler` bin wrapper

### DIFF
--- a/src/abacus-backoffice/package.json
+++ b/src/abacus-backoffice/package.json
@@ -18,7 +18,7 @@
     "@adeira/icons": "^1.1.0",
     "@adeira/js": "^2.1.1",
     "@adeira/react-auth": "^0.1.0",
-    "@adeira/relay": "^5.2.0",
+    "@adeira/relay": "^5.2.1",
     "@adeira/sx": "^0.29.1",
     "@adeira/sx-design": "^0.27.0",
     "@next/bundle-analyzer": "^12.1.6",

--- a/src/abacus-kochka/package.json
+++ b/src/abacus-kochka/package.json
@@ -18,7 +18,7 @@
     "@adeira/hooks": "^0.2.0",
     "@adeira/icons": "^1.1.0",
     "@adeira/js": "^2.1.1",
-    "@adeira/relay": "^5.2.0",
+    "@adeira/relay": "^5.2.1",
     "@adeira/sx": "^0.29.1",
     "@adeira/sx-design": "^0.27.0",
     "@adeira/sx-design-nextjs": "^0.3.2",

--- a/src/example-relay/package.json
+++ b/src/example-relay/package.json
@@ -9,7 +9,7 @@
     "@adeira/graphql-relay": "^0.3.0",
     "@adeira/icons": "^1.1.0",
     "@adeira/js": "^2.1.1",
-    "@adeira/relay": "^5.2.0",
+    "@adeira/relay": "^5.2.1",
     "@adeira/sx": "^0.29.1",
     "@adeira/sx-design": "^0.27.0",
     "apollo-server-micro": "^3.8.1",

--- a/src/relay/bin/compiler.js
+++ b/src/relay/bin/compiler.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-var,ft-flow/require-valid-file-annotation */
+
+var bin = require('relay-compiler');
+var spawn = require('child_process').spawn;
+
+var input = process.argv.slice(2);
+
+spawn(bin, input, { stdio: 'inherit' }).on('exit', process.exit);

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -1,7 +1,10 @@
 {
   "name": "@adeira/relay",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "main": "./src/index.js",
+  "bin": {
+    "adeira-relay-compiler": "./bin/compiler.js"
+  },
   "type": "commonjs",
   "sideEffects": false,
   "homepage": "https://github.com/adeira/relay",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@ __metadata:
     "@adeira/icons": ^1.1.0
     "@adeira/js": ^2.1.1
     "@adeira/react-auth": ^0.1.0
-    "@adeira/relay": ^5.2.0
+    "@adeira/relay": ^5.2.1
     "@adeira/sx": ^0.29.1
     "@adeira/sx-design": ^0.27.0
     "@fbtjs/default-collection-transform": ^1.0.0
@@ -63,7 +63,7 @@ __metadata:
     "@adeira/hooks": ^0.2.0
     "@adeira/icons": ^1.1.0
     "@adeira/js": ^2.1.1
-    "@adeira/relay": ^5.2.0
+    "@adeira/relay": ^5.2.1
     "@adeira/sx": ^0.29.1
     "@adeira/sx-design": ^0.27.0
     "@adeira/sx-design-nextjs": ^0.3.2
@@ -172,7 +172,7 @@ __metadata:
     "@adeira/graphql-relay": ^0.3.0
     "@adeira/icons": ^1.1.0
     "@adeira/js": ^2.1.1
-    "@adeira/relay": ^5.2.0
+    "@adeira/relay": ^5.2.1
     "@adeira/sx": ^0.29.1
     "@adeira/sx-design": ^0.27.0
     "@testing-library/jest-dom": ^5.16.4
@@ -387,7 +387,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@adeira/relay@^5.2.0, @adeira/relay@workspace:src/relay":
+"@adeira/relay@^5.2.1, @adeira/relay@workspace:src/relay":
   version: 0.0.0-use.local
   resolution: "@adeira/relay@workspace:src/relay"
   dependencies:
@@ -404,6 +404,8 @@ __metadata:
   peerDependencies:
     graphql: ^16.5.0
     react: ^17.0.2
+  bin:
+    adeira-relay-compiler: ./bin/compiler.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Yarn Berry doesn't allow accessing bins from nested dependencies, so we have to expose our own binary (wrapping the original one).