### PR TITLE
Abacus: make `CatInfo` description optional

### DIFF
--- a/src/abacus/schema.graphql
+++ b/src/abacus/schema.graphql
@@ -1,4 +1,4 @@
-# @generated SignedSource<<4c8c5f0e1f131e8eff19c86fad19eac7>>
+# @generated SignedSource<<3e700b72fd467e3b56f62ca7e9283632>>
 
 enum PriceSortDirection {
   LOW_TO_HIGH
@@ -52,7 +52,7 @@ union PosCheckoutPayloadOrError = PosCheckoutPayload | PosCheckoutError
 type CatInfo {
   id: ID!
   name: String!
-  description: String!
+  description: String
   "Order in which the cat was admitted to KOCHKA Café."
   order: Int!
   "Most of the cats can be adopted but some cannot. This flag distinguishes exactly this."

--- a/src/abacus/server/src/cats/dal.rs
+++ b/src/abacus/server/src/cats/dal.rs
@@ -6,7 +6,7 @@ pub struct CatInfo {
     _id: String,
     _key: String,
     name: String,
-    description: String,
+    description: Option<String>,
     order: i32,
     can_be_adopted: Option<bool>,
     date_adoption: Option<String>,
@@ -29,7 +29,7 @@ impl CatInfo {
         self.name.to_owned()
     }
 
-    fn description(&self) -> String {
+    fn description(&self) -> Option<String> {
         self.description.to_owned()
     }
 


### PR DESCRIPTION
Related issue: https://github.com/adeira/universe/issues/4520