### PR TITLE
Abacus: forbid `clippy::missing_panics_doc`

### DIFF
--- a/src/abacus/server/src/main.rs
+++ b/src/abacus/server/src/main.rs
@@ -1,5 +1,6 @@
-#![deny(unused_must_use)]
+#![forbid(clippy::missing_panics_doc)]
 #![forbid(unsafe_code)]
+#![forbid(unused_must_use)]
 
 #[macro_use]
 mod global_macros;


### PR DESCRIPTION
See: https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc