### PR TITLE
Eslint config: release version 7.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@adeira/babel-preset-adeira": "^4.0.0",
-    "@adeira/eslint-config": "^7.6.0",
+    "@adeira/eslint-config": "^7.7.0",
     "@adeira/monorepo-utils": "^0.11.0",
     "@babel/cli": "^7.18.6",
     "@babel/core": "^7.18.6",

--- a/src/eslint-config-adeira/CHANGELOG.md
+++ b/src/eslint-config-adeira/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 7.7.0
+
 - New rule [`@next/next/no-styled-jsx-in-document`](https://nextjs.org/docs/messages/no-styled-jsx-in-document) enabled.
 
 # 7.6.0

--- a/src/eslint-config-adeira/package.json
+++ b/src/eslint-config-adeira/package.json
@@ -9,7 +9,7 @@
     "directory": "src/eslint-config-adeira"
   },
   "license": "MIT",
-  "version": "7.6.0",
+  "version": "7.7.0",
   "main": "./index.js",
   "type": "commonjs",
   "sideEffects": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,7 +121,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@adeira/eslint-config@^7.6.0, @adeira/eslint-config@workspace:src/eslint-config-adeira":
+"@adeira/eslint-config@^7.7.0, @adeira/eslint-config@workspace:src/eslint-config-adeira":
   version: 0.0.0-use.local
   resolution: "@adeira/eslint-config@workspace:src/eslint-config-adeira"
   dependencies:
@@ -16784,7 +16784,7 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@adeira/babel-preset-adeira": ^4.0.0
-    "@adeira/eslint-config": ^7.6.0
+    "@adeira/eslint-config": ^7.7.0
     "@adeira/monorepo-utils": ^0.11.0
     "@babel/cli": ^7.18.6
     "@babel/core": ^7.18.6


### PR DESCRIPTION
Most likely the last 7.x version before releasing `hermes-eslint` version (major).