### PR TITLE
Relay: release version 6.2.0

### DIFF
--- a/src/abacus-backoffice/package.json
+++ b/src/abacus-backoffice/package.json
@@ -19,7 +19,7 @@
     "@adeira/icons": "^2.0.0",
     "@adeira/js": "^2.1.1",
     "@adeira/react-auth": "^0.1.0",
-    "@adeira/relay": "^6.1.0",
+    "@adeira/relay": "^6.2.0",
     "@adeira/sx": "^0.29.1",
     "@adeira/sx-design": "^0.29.0",
     "@next/bundle-analyzer": "^12.2.3",

--- a/src/abacus-kochka/package.json
+++ b/src/abacus-kochka/package.json
@@ -18,7 +18,7 @@
     "@adeira/hooks": "^0.3.0",
     "@adeira/icons": "^2.0.0",
     "@adeira/js": "^2.1.1",
-    "@adeira/relay": "^6.1.0",
+    "@adeira/relay": "^6.2.0",
     "@adeira/sx": "^0.29.1",
     "@adeira/sx-design": "^0.29.0",
     "@adeira/sx-design-nextjs": "^0.3.2",

--- a/src/forms/package.json
+++ b/src/forms/package.json
@@ -27,7 +27,7 @@
     "babel-plugin-fbt-runtime": "^1.0.0"
   },
   "peerDependencies": {
-    "@adeira/relay": "^6.1.0",
+    "@adeira/relay": "^6.2.0",
     "react": "^18.2.0"
   },
   "scripts": {

--- a/src/relay/CHANGELOG.md
+++ b/src/relay/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 6.2.0
+
+- Relay 14.1.0, see: https://github.com/facebook/relay/releases/tag/v14.1.0
+
 # 6.1.0
 
 - The network layer now takes `QueryResponseCache` into account.

--- a/src/relay/package.json
+++ b/src/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adeira/relay",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "main": "./src/index.js",
   "bin": {
     "adeira-relay-compiler": "./bin/compiler.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@ __metadata:
     "@adeira/icons": ^2.0.0
     "@adeira/js": ^2.1.1
     "@adeira/react-auth": ^0.1.0
-    "@adeira/relay": ^6.1.0
+    "@adeira/relay": ^6.2.0
     "@adeira/sx": ^0.29.1
     "@adeira/sx-design": ^0.29.0
     "@fbtjs/default-collection-transform": ^1.0.0
@@ -69,7 +69,7 @@ __metadata:
     "@adeira/hooks": ^0.3.0
     "@adeira/icons": ^2.0.0
     "@adeira/js": ^2.1.1
-    "@adeira/relay": ^6.1.0
+    "@adeira/relay": ^6.2.0
     "@adeira/sx": ^0.29.1
     "@adeira/sx-design": ^0.29.0
     "@adeira/sx-design-nextjs": ^0.3.2
@@ -222,7 +222,7 @@ __metadata:
     babel-plugin-fbt-runtime: ^1.0.0
     fbt: ^1.0.0
   peerDependencies:
-    "@adeira/relay": ^6.1.0
+    "@adeira/relay": ^6.2.0
     react: ^18.2.0
   languageName: unknown
   linkType: soft
@@ -344,7 +344,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@adeira/relay@^6.1.0, @adeira/relay@workspace:src/relay":
+"@adeira/relay@^6.2.0, @adeira/relay@workspace:src/relay":
   version: 0.0.0-use.local
   resolution: "@adeira/relay@workspace:src/relay"
   dependencies:


### PR DESCRIPTION
Includes Relay 14.1.0, see: https://github.com/facebook/relay/releases/tag/v14.1.0