### PR TITLE
Flow: codemod `src/monorepo-shipit` (`annotate-lti-experimental`)

### DIFF
--- a/src/monorepo-shipit/src/__tests__/RepoGit.findFirstAvailableCommit.test.js
+++ b/src/monorepo-shipit/src/__tests__/RepoGit.findFirstAvailableCommit.test.js
@@ -11,7 +11,7 @@ jest.mock('@adeira/shell-command', () => {
   return {
     ShellCommand: class {
       stdout = null;
-      constructor(path, git, noPager, ...commandArray) {
+      constructor(path, git: any, noPager: any, ...commandArray) {
         const command = commandArray.toString();
         if (command === 'rev-list,--max-parents=0,HEAD') {
           this.stdout =

--- a/src/monorepo-shipit/src/__tests__/RepoGit.findLastSourceCommit.test.js
+++ b/src/monorepo-shipit/src/__tests__/RepoGit.findLastSourceCommit.test.js
@@ -4,7 +4,7 @@ import Changeset from '../Changeset';
 import RepoGitFake from '../RepoGitFake';
 import addTrackingData from '../filters/addTrackingData';
 
-function createGITRepoWithCommit(message) {
+function createGITRepoWithCommit(message: string) {
   const repo = new RepoGitFake();
   repo.commitPatch(
     new Changeset()

--- a/src/monorepo-shipit/src/__tests__/parsePatch.test.js
+++ b/src/monorepo-shipit/src/__tests__/parsePatch.test.js
@@ -7,7 +7,7 @@ import parsePatch from '../parsePatch';
 
 generateTestsFromFixtures(path.join(__dirname, 'fixtures', 'diffs'), operation);
 
-function operation(input) {
+function operation(input: string) {
   return new Promise((resolve) => {
     let hunks = '';
     let hunkNumber = 1;

--- a/src/monorepo-shipit/src/filters/moveDirectories.js
+++ b/src/monorepo-shipit/src/filters/moveDirectories.js
@@ -10,7 +10,7 @@ export default function moveDirectories(
   changeset: Changeset,
   mapping: Map<string, string>,
 ): Changeset {
-  const rewriteCallback = (oldPath) => {
+  const rewriteCallback = (oldPath: string) => {
     let newPath = oldPath;
     for (const [src, dest] of mapping.entries()) {
       let matchFound = false;


### PR DESCRIPTION
```
flow codemod annotate-lti-experimental
```