### PR TITLE
Added `no_future_proof_enums` to relay.config.js

### DIFF
--- a/relay.config.js
+++ b/relay.config.js
@@ -40,6 +40,9 @@ module.exports = {
       featureFlags: {
         no_inline: { kind: 'enabled' },
       },
+      flowTypegen: {
+        no_future_proof_enums: false, // enable to remove "%future added value" from enum types
+      },
       ...abacusPersistConfig,
     },
   },


### PR DESCRIPTION
Hi.
I saw your file from https://github.com/facebook/relay/issues/3795#issuecomment-1062350082 so thanks for that at first.
Multi-project config for Relay is not yet documented and I couldn't figure out how to enable the `no_future_proof_enums` flag.
This PR sets `no_future_proof_enums` to it's default value `false` so others will not have to debug relay-compiler to have this.