### PR TITLE
Abacus: use the latest `arangodb/arangodb:3.9.3`

### DIFF
--- a/src/abacus-kubernetes/abacus/arangodb.yaml
+++ b/src/abacus-kubernetes/abacus/arangodb.yaml
@@ -5,7 +5,7 @@ metadata:
   name: 'arangodb-single-server'
 spec:
   mode: Single
-  image: 'arangodb/arangodb:3.9.2'
+  image: 'arangodb/arangodb:3.9.3'
   tls:
     caSecretName: None # TODO
   auth:
@@ -48,7 +48,7 @@ spec:
           restartPolicy: OnFailure
           initContainers:
             - name: dump-create
-              image: 'arangodb/arangodb:3.9.2'
+              image: 'arangodb/arangodb:3.9.3'
               imagePullPolicy: Always
               args:
                 - 'arangodump'

--- a/src/abacus-kubernetes/manual-arangodb-restore.yaml
+++ b/src/abacus-kubernetes/manual-arangodb-restore.yaml
@@ -37,7 +37,7 @@ spec:
               mountPath: /tmp/dump
       containers:
         - name: arangorestore
-          image: 'arangodb/arangodb:3.9.2'
+          image: 'arangodb/arangodb:3.9.3'
           imagePullPolicy: Always
           args:
             - 'arangorestore'


### PR DESCRIPTION
See: https://github.com/arangodb/arangodb/blob/v3.9.3/CHANGELOG