### PR TITLE
Abacus: fix `payment_intent.requires_action` Stripe event parsing

### DIFF
--- a/src/abacus/server/src/stripe/fixtures/payment_intent.requires_action.json
+++ b/src/abacus/server/src/stripe/fixtures/payment_intent.requires_action.json
@@ -1,0 +1,170 @@
+{
+  "id": "evt_REDACTED",
+  "object": "event",
+  "api_version": "2020-08-27",
+  "created": 1662673235,
+  "data": {
+    "object": {
+      "id": "pi_REDACTED",
+      "object": "payment_intent",
+      "amount": 20000,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": {}
+      },
+      "amount_received": 0,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {
+        "object": "list",
+        "data": [
+          {
+            "id": "ch_REDACTED",
+            "object": "charge",
+            "amount": 20000,
+            "amount_captured": 0,
+            "amount_refunded": 0,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": "MX",
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": "REDACTED",
+              "name": "REDACTED",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "KOCHKA.COM.MX",
+            "captured": false,
+            "created": 1662673203,
+            "currency": "mxn",
+            "customer": "cus_REDACTED",
+            "description": null,
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_balance_transaction": null,
+            "failure_code": "card_declined",
+            "failure_message": "Your card was declined.",
+            "fraud_details": {},
+            "invoice": null,
+            "livemode": true,
+            "metadata": {},
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "declined_by_network",
+              "reason": "do_not_honor",
+              "risk_level": "normal",
+              "seller_message": "The bank returned the decline code `do_not_honor`.",
+              "type": "issuer_declined"
+            },
+            "paid": false,
+            "payment_intent": "pi_REDACTED",
+            "payment_method": "pm_REDACTED",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "unavailable"
+                },
+                "country": "MX",
+                "exp_month": 11,
+                "exp_year": 2025,
+                "fingerprint": "REDACTED",
+                "funding": "debit",
+                "installments": null,
+                "last4": "REDACTED",
+                "mandate": null,
+                "network": "visa",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": "REDACTED",
+            "receipt_number": null,
+            "receipt_url": null,
+            "refunded": false,
+            "refunds": {
+              "object": "list",
+              "data": [],
+              "has_more": false,
+              "total_count": 0,
+              "url": "/v1/charges/ch_REDACTED/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": null,
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "failed",
+            "transfer_data": null,
+            "transfer_group": null
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/charges?payment_intent=pi_REDACTED"
+      },
+      "client_secret": "pi_REDACTED",
+      "confirmation_method": "automatic",
+      "created": 1662673202,
+      "currency": "mxn",
+      "customer": "cus_REDACTED",
+      "description": null,
+      "invoice": null,
+      "last_payment_error": null,
+      "livemode": true,
+      "metadata": {},
+      "next_action": {
+        "oxxo_display_details": {
+          "expires_after": 1662958799,
+          "hosted_voucher_url": "https://payments.stripe.com/oxxo/voucher/live_REDACTED",
+          "number": "REDACTED"
+        },
+        "type": "oxxo_display_details"
+      },
+      "on_behalf_of": null,
+      "payment_method": "pm_REDACTED",
+      "payment_method_options": {
+        "oxxo": {
+          "expires_after_days": 3
+        }
+      },
+      "payment_method_types": ["oxxo"],
+      "processing": null,
+      "receipt_email": "REDACTED",
+      "review": null,
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "requires_action",
+      "transfer_data": null,
+      "transfer_group": null
+    }
+  },
+  "livemode": true,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_REDACTED",
+    "idempotency_key": "44dbd9a0-41fa-4e8e-91a1-6cccb05b51ea"
+  },
+  "type": "payment_intent.requires_action"
+}

--- a/src/abacus/server/src/stripe/tests.rs
+++ b/src/abacus/server/src/stripe/tests.rs
@@ -50,3 +50,16 @@ fn test_invoice_paid() {
         StripeWebhookType::InvoicePaid { .. }
     ));
 }
+
+#[test]
+fn test_payment_intent_requires_action() {
+    let webhook_payload = serde_json::from_str::<StripeWebhookPayload>(include_str!(
+        "fixtures/payment_intent.requires_action.json"
+    ))
+    .unwrap();
+
+    assert!(matches!(
+        webhook_payload.r#type,
+        StripeWebhookType::PaymentIntentRequiresAction { .. }
+    ));
+}

--- a/src/abacus/server/src/stripe/webhook.rs
+++ b/src/abacus/server/src/stripe/webhook.rs
@@ -150,6 +150,12 @@ pub enum StripeWebhookType {
     IssuingCardCreated,
     #[serde(rename = "issuing_cardholder.created")]
     IssuingCardholderCreated,
+
+    /// Occurs when a PaymentIntent has funds to be captured. Check the `amount_capturable` property
+    /// on the PaymentIntent to determine the amount that can be captured. You may capture the
+    /// PaymentIntent with an `amount_to_capture` value up to the specified amount.
+    ///
+    /// More info: https://stripe.com/docs/api/payment_intents/capture
     #[serde(rename = "payment_intent.amount_capturable_updated")]
     PaymentIntentAmountCapturableUpdated,
 
@@ -161,9 +167,22 @@ pub enum StripeWebhookType {
     #[serde(rename = "payment_intent.created")]
     PaymentIntentCreated,
 
+    /// Occurs when funds are applied to a `customer_balance` PaymentIntent and the
+    /// `amount_remaining` changes.
+    #[serde(rename = "payment_intent.partially_funded")]
+    PaymentIntentPartiallyFunded,
+
     /// Occurs when a PaymentIntent has failed the attempt to create a payment method or a payment.
     #[serde(rename = "payment_intent.payment_failed")]
     PaymentIntentPaymentFailed,
+
+    /// Occurs when a PaymentIntent has started processing.
+    #[serde(rename = "payment_intent.processing")]
+    PaymentIntentProcessing,
+
+    /// Occurs when a PaymentIntent transitions to requires_action state.
+    #[serde(rename = "payment_intent.requires_action")]
+    PaymentIntentRequiresAction,
 
     /// Occurs when a PaymentIntent has successfully completed payment.
     #[serde(rename = "payment_intent.succeeded")]


### PR DESCRIPTION
This also adds some other missing `payment_intent.*` Stripe events.