### PR TITLE
CI: enable Node.js version 19

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 19.x]
 
     steps:
       # https://github.com/actions/checkout


### PR DESCRIPTION
See: https://nodejs.org/en/blog/announcements/v19-release-announce/

TODO:

- [x] make this version **required** on CI