### PR TITLE
NPM Publisher: add `collectFilenames` test

### DIFF
--- a/src/monorepo-npm-publisher/src/__tests__/collectFilenames.test.js
+++ b/src/monorepo-npm-publisher/src/__tests__/collectFilenames.test.js
@@ -1,0 +1,24 @@
+// @flow
+
+import path from 'path';
+
+import { collectFilenames } from '../collectFilenames';
+
+it('correctly resolves the relevant files to be published to NPM', async () => {
+  // It is a bit strange to be relying on the package folder structure, but at the same time
+  // it's a good way to test that everything works as it should:
+
+  await expect(collectFilenames(path.join(__dirname, '../..'))).resolves.toMatchInlineSnapshot(`
+    [
+      "LICENSE",
+      "src/collectFilenames.js",
+      "src/index.js",
+      "src/log.js",
+      "src/NPM.js",
+      "src/transformFileVariants.js",
+      "package.json",
+      "CHANGELOG.md",
+      "README.md",
+    ]
+  `);
+});

--- a/src/monorepo-npm-publisher/src/collectFilenames.js
+++ b/src/monorepo-npm-publisher/src/collectFilenames.js
@@ -1,0 +1,10 @@
+// @flow
+
+import Arborist from '@npmcli/arborist';
+import packlist from 'npm-packlist';
+
+export async function collectFilenames(packageFolderPath: string): Promise<$ReadOnlyArray<string>> {
+  const arborist = new Arborist({ path: packageFolderPath });
+  const arboristTree = await arborist.loadActual();
+  return packlist(arboristTree);
+}

--- a/src/monorepo-npm-publisher/src/index.js
+++ b/src/monorepo-npm-publisher/src/index.js
@@ -6,15 +6,14 @@ import path from 'path';
 import util from 'util';
 import semver from 'semver';
 import rimraf from 'rimraf';
-import packlist from 'npm-packlist';
 import { Workspaces } from '@adeira/monorepo-utils';
 import isCI from 'is-ci';
 import chalk from 'chalk';
-import Arborist from '@npmcli/arborist';
 
 import log from './log';
 import NPM from './NPM';
 import transformFileVariants from './transformFileVariants';
+import { collectFilenames } from './collectFilenames';
 
 type Options = {
   +dryRun: boolean,
@@ -65,9 +64,7 @@ export default async function publish(options: Options) {
         } else {
           log('🚀 Preparing %s for release (latest: %s)', chalkPackageName, latest);
 
-          const arborist = new Arborist({ path: packageFolderPath });
-          const arboristTree = await arborist.loadActual();
-          const filenames = await packlist(arboristTree);
+          const filenames = await collectFilenames(packageFolderPath);
           for (const filename of filenames) {
             const destinationFileName = path.join(options.buildCache, packageFolderName, filename);
 


### PR DESCRIPTION
This is mostly to make sure that our future dependency upgrades won't break this package.