### PR TITLE
SX Design: improve ICU 72.1 detection

### DIFF
--- a/src/sx-design/package.json
+++ b/src/sx-design/package.json
@@ -60,7 +60,6 @@
     "playwright": "^1.28.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "semver": "^7.3.8",
     "storybook-addon-next-router": "^4.0.1"
   },
   "scripts": {

--- a/src/sx-design/src/DateTime/__tests__/DateTime.test.js
+++ b/src/sx-design/src/DateTime/__tests__/DateTime.test.js
@@ -4,7 +4,6 @@
  */
 
 import React from 'react';
-import semver from 'semver';
 
 import DateTime from '../DateTime';
 import SxDesignProvider from '../../SxDesignProvider';
@@ -54,7 +53,7 @@ it('works correctly for `es-MX` locale', () => {
   );
 
   // Change in ICU 72.1 (https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V19.md#19.1.0)
-  if (semver.gte(process.versions.node, '19.1.0')) {
+  if (Number(process.versions.icu) >= 72.1) {
     expect(getByText('16 abr 2022, 01:00:00')).toBeInTheDocument();
   } else {
     expect(getByText('16 abr 2022 01:00:00')).toBeInTheDocument();
@@ -90,7 +89,7 @@ it('works correctly with additional format options', () => {
   );
 
   // Change in ICU 72.1 (https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V19.md#19.1.0)
-  if (semver.gte(process.versions.node, '19.1.0')) {
+  if (Number(process.versions.icu) >= 72.1) {
     expect(
       getByText('sobota 16. dubna 2022 našeho letopočtu v 1:00:00, koordinovaný světový čas'),
     ).toBeInTheDocument();

--- a/src/sx-design/src/Money/__tests__/Money.test.js
+++ b/src/sx-design/src/Money/__tests__/Money.test.js
@@ -4,7 +4,6 @@
  */
 
 import * as React from 'react';
-import semver from 'semver';
 
 import Money, { MoneyFn } from '../Money';
 import { render } from '../../test-utils';
@@ -68,8 +67,8 @@ test.each`
         priceUnitAmountCurrency: currency,
       }),
     ).toBe(
-      // There is a difference between these Node.js versions:
-      semver.gte(process.versions.node, '19.1.0') ? expectedFnNew : expectedFnOld,
+      // Change in ICU 72.1 (https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V19.md#19.1.0)
+      Number(process.versions.icu) >= 72.1 ? expectedFnNew : expectedFnOld,
     );
   },
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -463,7 +463,6 @@ __metadata:
     react-device-detect: ^2.2.2
     react-dom: ^18.2.0
     react-table: ^7.8.0
-    semver: ^7.3.8
     storybook-addon-next-router: ^4.0.1
   peerDependencies:
     "@adeira/sx": ^0.29.1


### PR DESCRIPTION
Apparently, it's possible to have Node.js 19.1.0 with older ICU version. So we should really be focusing on the ICU version itself, not Node.js version.

I removed `semver` dependency because it doesn't support X.Y version schemas. Simple number comparison should do in this case.