### PR TITLE
Shellcheck: disable SC2312

### DIFF
--- a/x
+++ b/x
@@ -42,6 +42,8 @@
 # ```
 
 if ! command -v rustup &> /dev/null ; then
+  # https://www.shellcheck.net/wiki/SC2312
+  # shellcheck disable=SC2312
   curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- -y
 fi
 


### PR DESCRIPTION
See: https://www.shellcheck.net/wiki/SC2312

Fixes the following error:

```
In ./x line 45:
  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- -y
  ^-- SC2312 (info): Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore).
```