### PR TITLE
Renovate: remove `npm:unpublishSafe` preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,11 +1,5 @@
 {
-  extends: [
-    ':ignoreModulesAndTests',
-    'npm:unpublishSafe',
-    'group:monorepos',
-    'group:recommended',
-    'workarounds:all',
-  ],
+  extends: [':ignoreModulesAndTests', 'group:monorepos', 'group:recommended', 'workarounds:all'],
   prHourlyLimit: 0,
   prConcurrentLimit: 0,
   dependencyDashboard: true,


### PR DESCRIPTION
It doesn't work correctly: it waits for opening the PR 3 days, but then it can update Yarn lock file with a newly released patch version that is much younger (and this version could be yanked anytime).