### PR TITLE
Eslint plugin: add new `sort-imports` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,4 +15,8 @@ module.exports = {
     sourceType: 'module',
     fbt: true,
   },
+  rules: {
+    // TODO: move to `src/eslint-config-adeira/src/presets/base.js` once stable:
+    'adeira/sort-imports': 'error',
+  },
 };

--- a/src/__flowtests__/ReactElement.js
+++ b/src/__flowtests__/ReactElement.js
@@ -2,7 +2,7 @@
 
 /* eslint-disable react/no-multi-comp,import/no-extraneous-dependencies */
 
-import { Component, type Element, type ChildrenArray, type Node } from 'react';
+import { Component, type ChildrenArray, type Element, type Node } from 'react';
 
 class Button extends Component<{ +disabled?: boolean }> {
   render(): Node {

--- a/src/abacus-backoffice/pages/index.js
+++ b/src/abacus-backoffice/pages/index.js
@@ -2,7 +2,7 @@
 
 import sx from '@adeira/sx';
 import { Note } from '@adeira/sx-design';
-import React, { type Node, type Element } from 'react';
+import React, { type Element, type Node } from 'react';
 import { fbt } from 'fbt';
 
 import LayoutApp from '../src/LayoutApp';

--- a/src/abacus-kochka/pages/_document.js
+++ b/src/abacus-kochka/pages/_document.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { type Node, type Element } from 'react';
+import React, { type Element, type Node } from 'react';
 /* $FlowFixMe[missing-export] This comment suppresses an error when migrating
  * to adeira/universe. To see the error delete this comment and run Flow. */
 import Document, { Html, Head, Main, NextScript, type DocumentContext } from 'next/document';

--- a/src/eslint-config-adeira/__tests__/__fixtures__/valid-eslint-examples/react/no-unused-state.js
+++ b/src/eslint-config-adeira/__tests__/__fixtures__/valid-eslint-examples/react/no-unused-state.js
@@ -1,7 +1,7 @@
 // @flow strict
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { createContext, Component, type Node, type Context, type Element } from 'react';
+import { createContext, Component, type Context, type Element, type Node } from 'react';
 
 type Props = {
   +accessToken?: string,

--- a/src/eslint-config-adeira/__tests__/index.test.js
+++ b/src/eslint-config-adeira/__tests__/index.test.js
@@ -49,7 +49,13 @@ test('our rules should contain every Eslint rule to be explicit', () => {
     }
   });
 
-  expect(missing).toEqual(new Set());
+  expect(missing).toEqual(
+    new Set([
+      // We ignore this one rule for now. This should be removed once we make it public
+      // and remove it from `.eslintrc.js`
+      'adeira/sort-imports',
+    ]),
+  );
 });
 
 const prettierRules = prettierConfig.rules;

--- a/src/eslint-plugin-adeira/src/index.js
+++ b/src/eslint-plugin-adeira/src/index.js
@@ -7,5 +7,6 @@ module.exports = {
     'no-invalid-flow-annotations': require('./rules/no-invalid-flow-annotations'),
     'only-nullable-fields': require('./rules/only-nullable-fields'),
     'valid-test-folder': require('./rules/valid-test-folder'),
+    'sort-imports': require('./rules/sort-imports'),
   },
 };

--- a/src/eslint-plugin-adeira/src/rules/__tests__/sort-imports.test.js
+++ b/src/eslint-plugin-adeira/src/rules/__tests__/sort-imports.test.js
@@ -1,0 +1,127 @@
+// @flow
+
+const RuleTester = require('eslint').RuleTester;
+
+const rule = require('../sort-imports');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('hermes-eslint'),
+});
+
+ruleTester.run('sort-imports', rule, {
+  valid: [
+    `
+      import a from 'a.js';
+      import b from 'b.js';
+      import c from 'c.js';
+    `,
+    `import { type A, type B } from 'x.js';`,
+    `import type { A, B } from 'x.js';`,
+    `import React, { Component } from 'react';`,
+
+    // TODO: the following examples are incorrect but currently not implemented
+    `import { B, A } from 'x.js';`,
+    `import type { B, A } from 'x.js';`,
+    `
+      import c from 'c.js';
+      import b from 'b.js';
+      import a from 'a.js';
+    `,
+  ],
+  invalid: [
+    {
+      code: `import { type B, type A } from 'x.js';`,
+      output: `import { type A, type B } from 'x.js';`,
+      errors: [
+        {
+          messageId: 'sortTypeImportsAlphabetically',
+          data: {
+            firstUnsortedImport: 'A',
+            beforeFirstUnsortedImport: 'B',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        import {
+          Network,
+          Environment as RelayEnvironment,
+          type OperationLoader,
+          type LogFunction,
+          type Environment,
+        } from 'relay-runtime';
+      `,
+      output: `
+        import {
+          Network,
+          Environment as RelayEnvironment,
+          type Environment,
+          type LogFunction,
+          type OperationLoader,
+        } from 'relay-runtime';
+      `,
+      errors: [
+        {
+          messageId: 'sortTypeImportsAlphabetically',
+          data: {
+            firstUnsortedImport: 'LogFunction',
+            beforeFirstUnsortedImport: 'OperationLoader',
+          },
+        },
+      ],
+    },
+    {
+      code: `import { /* comment */ type B, type A } from 'x.js';`,
+      output: null, // not fixed due to comment
+      errors: [
+        {
+          messageId: 'sortTypeImportsAlphabetically',
+          data: {
+            firstUnsortedImport: 'A',
+            beforeFirstUnsortedImport: 'B',
+          },
+        },
+      ],
+    },
+    {
+      code: `import { type B /* comment */, type A } from 'x.js';`,
+      output: null, // not fixed due to comment
+      errors: [
+        {
+          messageId: 'sortTypeImportsAlphabetically',
+          data: {
+            firstUnsortedImport: 'A',
+            beforeFirstUnsortedImport: 'B',
+          },
+        },
+      ],
+    },
+    {
+      code: `import { type B, /* comment */ type A } from 'x.js';`,
+      output: null, // not fixed due to comment
+      errors: [
+        {
+          messageId: 'sortTypeImportsAlphabetically',
+          data: {
+            firstUnsortedImport: 'A',
+            beforeFirstUnsortedImport: 'B',
+          },
+        },
+      ],
+    },
+    {
+      code: `import { type B, type A /* comment */ } from 'x.js';`,
+      output: null, // not fixed due to comment
+      errors: [
+        {
+          messageId: 'sortTypeImportsAlphabetically',
+          data: {
+            firstUnsortedImport: 'A',
+            beforeFirstUnsortedImport: 'B',
+          },
+        },
+      ],
+    },
+  ],
+});

--- a/src/eslint-plugin-adeira/src/rules/sort-imports.js
+++ b/src/eslint-plugin-adeira/src/rules/sort-imports.js
@@ -1,0 +1,84 @@
+// @flow
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+      },
+    ],
+    fixable: 'code',
+    messages: {
+      sortTypeImportsAlphabetically:
+        "Import 'type {{firstUnsortedImport}}' should be before 'type {{beforeFirstUnsortedImport}}'.",
+    },
+  },
+
+  create(context /*: $FlowFixMe */) /*: $FlowFixMe */ {
+    const sourceCode = context.getSourceCode();
+
+    return {
+      ImportDeclaration(node) {
+        const importSpecifiers = node.specifiers.filter(
+          (specifier) => specifier.type === 'ImportSpecifier' && specifier.importKind === 'type',
+        );
+
+        const firstUnsortedIndex = importSpecifiers
+          .map((specifier) => specifier.local.name)
+          .findIndex((name, index, array) => array[index - 1] > name);
+
+        if (firstUnsortedIndex !== -1) {
+          context.report({
+            node: importSpecifiers[firstUnsortedIndex],
+            messageId: 'sortTypeImportsAlphabetically',
+            data: {
+              firstUnsortedImport: importSpecifiers[firstUnsortedIndex].local.name,
+              beforeFirstUnsortedImport: importSpecifiers[firstUnsortedIndex - 1].local.name,
+            },
+            fix(fixer) {
+              if (
+                importSpecifiers.some(
+                  (specifier) =>
+                    sourceCode.getCommentsBefore(specifier).length ||
+                    sourceCode.getCommentsAfter(specifier).length,
+                )
+              ) {
+                // If there are comments in the ImportSpecifier list, don't rearrange the specifiers.
+                return null;
+              }
+
+              return fixer.replaceTextRange(
+                [
+                  importSpecifiers[0].range[0],
+                  importSpecifiers[importSpecifiers.length - 1].range[1],
+                ],
+                importSpecifiers
+                  .slice() // clone the `importSpecifiers` array to avoid mutating it
+                  .sort((specifierA, specifierB) => {
+                    // sort the array into the desired order
+                    return specifierA.local.name > specifierB.local.name ? 1 : -1;
+                  })
+                  .reduce((sourceText, specifier, index) => {
+                    // build a string out of the sorted list of import specifiers and the text
+                    // between the originals
+                    const textAfterSpecifier =
+                      index === importSpecifiers.length - 1
+                        ? ''
+                        : sourceCode
+                            .getText()
+                            .slice(
+                              importSpecifiers[index].range[1],
+                              importSpecifiers[index + 1].range[0],
+                            );
+                    return sourceText + sourceCode.getText(specifier) + textAfterSpecifier;
+                  }, ''),
+              );
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/src/forms/src/FormMultiSelect.js
+++ b/src/forms/src/FormMultiSelect.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { type Node, type ChildrenArray } from 'react';
+import { type ChildrenArray, type Node } from 'react';
 
 import FormSelectOption from './FormSelectOption';
 import BaseSelect from './private/BaseSelect';

--- a/src/forms/src/FormSelect.js
+++ b/src/forms/src/FormSelect.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { fbt } from 'fbt';
-import React, { type Node, type ChildrenArray } from 'react';
+import React, { type ChildrenArray, type Node } from 'react';
 
 import FormSelectOption from './FormSelectOption';
 import BaseSelect from './private/BaseSelect';

--- a/src/forms/src/private/BaseSelect.js
+++ b/src/forms/src/private/BaseSelect.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { useRef, type Node, type ChildrenArray } from 'react';
+import { useRef, type ChildrenArray, type Node } from 'react';
 import sx from '@adeira/sx';
 
 import FormSelectOption from '../FormSelectOption';

--- a/src/monorepo-shipit/src/phases/createImportSyncPhase.js
+++ b/src/monorepo-shipit/src/phases/createImportSyncPhase.js
@@ -2,7 +2,7 @@
 
 import { ShellCommand } from '@adeira/shell-command';
 
-import RepoGit, { type SourceRepo, type DestinationRepo } from '../RepoGit';
+import RepoGit, { type DestinationRepo, type SourceRepo } from '../RepoGit';
 import Changeset from '../Changeset';
 import ShipitConfig from '../ShipitConfig';
 

--- a/src/monorepo-shipit/src/phases/createSyncPhase.js
+++ b/src/monorepo-shipit/src/phases/createSyncPhase.js
@@ -1,6 +1,6 @@
 // @flow strict-local
 
-import RepoGit, { type SourceRepo, type DestinationRepo } from '../RepoGit';
+import RepoGit, { type DestinationRepo, type SourceRepo } from '../RepoGit';
 import Changeset from '../Changeset';
 import ShipitConfig from '../ShipitConfig';
 

--- a/src/relay/src/__flowtests__/Environment.js
+++ b/src/relay/src/__flowtests__/Environment.js
@@ -10,8 +10,8 @@ import {
   createEnvironment,
   type Disposable,
   type RelayPaginationProp,
-  type RelayRefetchProp,
   type RelayProp,
+  type RelayRefetchProp,
 } from '../index';
 
 type PropsA = { +relay: RelayProp };

--- a/src/sx-design/__flowtests__/Button.js
+++ b/src/sx-design/__flowtests__/Button.js
@@ -1,7 +1,7 @@
 // @flow
 
 import Icon from '@adeira/icons';
-import { type Node, type Element } from 'react';
+import { type Element, type Node } from 'react';
 import fbt from 'fbt';
 
 import { Button } from '../index';

--- a/src/sx-design/__flowtests__/Entity.js
+++ b/src/sx-design/__flowtests__/Entity.js
@@ -1,7 +1,7 @@
 // @flow
 
 import Icon from '@adeira/icons';
-import { type Node, type Element } from 'react';
+import { type Element, type Node } from 'react';
 
 import { Entity, EntityField } from '../index';
 

--- a/src/sx-design/__flowtests__/LinkButton.js
+++ b/src/sx-design/__flowtests__/LinkButton.js
@@ -2,7 +2,7 @@
 
 import Icon from '@adeira/icons';
 import NextLink from 'next/link';
-import { type Node, type Element } from 'react';
+import { type Element, type Node } from 'react';
 import fbt from 'fbt';
 
 import { LinkButton, Money } from '../index';

--- a/src/sx-design/__flowtests__/Text.js
+++ b/src/sx-design/__flowtests__/Text.js
@@ -1,7 +1,7 @@
 // @flow
 
 import NextLink from 'next/link';
-import { type Node, type Element } from 'react';
+import { type Element, type Node } from 'react';
 import fbt from 'fbt';
 
 import { Link, Text } from '../index';

--- a/src/sx-design/src/Entity/EntityField.js
+++ b/src/sx-design/src/Entity/EntityField.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { invariant } from '@adeira/js';
-import React, { type Node, type Element } from 'react';
+import React, { type Element, type Node } from 'react';
 import sx from '@adeira/sx';
 
 type RestrictedReactNode = number | Fbt | Element<any> | null;

--- a/src/sx-design/src/Loader/Loader.js
+++ b/src/sx-design/src/Loader/Loader.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { type Node, type Element } from 'react';
+import React, { type Element, type Node } from 'react';
 import sx from '@adeira/sx';
 import fbt from 'fbt';
 

--- a/src/sx-design/src/SxDesignPortal.js
+++ b/src/sx-design/src/SxDesignPortal.js
@@ -2,7 +2,7 @@
 
 import ReactDOM from 'react-dom';
 import { invariant } from '@adeira/js';
-import { useEffect, useState, useRef, type Portal, type Node } from 'react';
+import { useEffect, useState, useRef, type Node, type Portal } from 'react';
 
 type Props = {
   +children: Node,

--- a/src/sx-design/src/Text/Text.js
+++ b/src/sx-design/src/Text/Text.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { type Node, type Element } from 'react';
+import React, { type Element, type Node } from 'react';
 import sx from '@adeira/sx';
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/font-size


### PR DESCRIPTION
Not yet enabled for the public. This new rule is basically a fork of the official `sort-imports` but without any additional features and tailored specifically for Adeira needs.

It currently supports only type imports. Support for additional imports will be added later once decided how to.