### PR TITLE
Eslint plugin: sort all import specifiers alphabetically

### DIFF
--- a/src/eslint-plugin-adeira/src/rules/__tests__/sort-imports.test.js
+++ b/src/eslint-plugin-adeira/src/rules/__tests__/sort-imports.test.js
@@ -15,13 +15,17 @@ ruleTester.run('sort-imports', rule, {
       import b from 'b.js';
       import c from 'c.js';
     `,
+    `import { A, B } from 'x.js';`,
+    `import { A as C, B } from 'x.js';`,
     `import { type A, type B } from 'x.js';`,
     `import type { A, B } from 'x.js';`,
+    `import * as React from 'react';`,
     `import React, { Component } from 'react';`,
+    `import { createEnvironment, createNetworkFetcher, RelayEnvironmentProvider } from '@adeira/relay';`,
 
     // TODO: the following examples are incorrect but currently not implemented
-    `import { B, A } from 'x.js';`,
-    `import type { B, A } from 'x.js';`,
+    `import { type A, B } from 'x.js';`,
+    `import { useContext, type Node, useRef } from 'react';`,
     `
       import c from 'c.js';
       import b from 'b.js';
@@ -29,6 +33,35 @@ ruleTester.run('sort-imports', rule, {
     `,
   ],
   invalid: [
+    // sortImportsAlphabetically
+    {
+      code: `import { B, A } from 'x.js';`,
+      output: `import { A, B } from 'x.js';`,
+      errors: [
+        {
+          messageId: 'sortImportsAlphabetically',
+          data: {
+            firstUnsortedImport: 'A',
+            beforeFirstUnsortedImport: 'B',
+          },
+        },
+      ],
+    },
+    {
+      code: `import type { B, A } from 'x.js';`,
+      output: `import type { A, B } from 'x.js';`,
+      errors: [
+        {
+          messageId: 'sortImportsAlphabetically',
+          data: {
+            firstUnsortedImport: 'A',
+            beforeFirstUnsortedImport: 'B',
+          },
+        },
+      ],
+    },
+
+    // sortTypeImportsAlphabetically
     {
       code: `import { type B, type A } from 'x.js';`,
       output: `import { type A, type B } from 'x.js';`,
@@ -45,8 +78,8 @@ ruleTester.run('sort-imports', rule, {
     {
       code: `
         import {
-          Network,
           Environment as RelayEnvironment,
+          Network,
           type OperationLoader,
           type LogFunction,
           type Environment,
@@ -54,8 +87,8 @@ ruleTester.run('sort-imports', rule, {
       `,
       output: `
         import {
-          Network,
           Environment as RelayEnvironment,
+          Network,
           type Environment,
           type LogFunction,
           type OperationLoader,

--- a/src/eslint-plugin-adeira/src/rules/sort-imports.js
+++ b/src/eslint-plugin-adeira/src/rules/sort-imports.js
@@ -11,6 +11,8 @@ module.exports = {
     ],
     fixable: 'code',
     messages: {
+      sortImportsAlphabetically:
+        "Import '{{firstUnsortedImport}}' should be before '{{beforeFirstUnsortedImport}}'.",
       sortTypeImportsAlphabetically:
         "Import 'type {{firstUnsortedImport}}' should be before 'type {{beforeFirstUnsortedImport}}'.",
     },
@@ -19,62 +21,83 @@ module.exports = {
   create(context /*: $FlowFixMe */) /*: $FlowFixMe */ {
     const sourceCode = context.getSourceCode();
 
+    const fixImportSpecifiers = (fixer, importSpecifiers) => {
+      if (
+        importSpecifiers.some(
+          (specifier) =>
+            sourceCode.getCommentsBefore(specifier).length ||
+            sourceCode.getCommentsAfter(specifier).length,
+        )
+      ) {
+        // If there are comments in the ImportSpecifier list, don't rearrange the specifiers.
+        return null;
+      }
+
+      return fixer.replaceTextRange(
+        [importSpecifiers[0].range[0], importSpecifiers[importSpecifiers.length - 1].range[1]],
+        importSpecifiers
+          .slice() // clone the `importSpecifiers` array to avoid mutating it
+          .sort((specifierA, specifierB) => {
+            // sort the array into the desired order
+            return specifierA.imported.name.toLowerCase() > specifierB.imported.name.toLowerCase()
+              ? 1
+              : -1;
+          })
+          .reduce((sourceText, specifier, index) => {
+            // build a string out of the sorted list of import specifiers and the text
+            // between the originals
+            const textAfterSpecifier =
+              index === importSpecifiers.length - 1
+                ? ''
+                : sourceCode
+                    .getText()
+                    .slice(importSpecifiers[index].range[1], importSpecifiers[index + 1].range[0]);
+            return sourceText + sourceCode.getText(specifier) + textAfterSpecifier;
+          }, ''),
+      );
+    };
+
     return {
       ImportDeclaration(node) {
         const importSpecifiers = node.specifiers.filter(
+          (specifier) => specifier.type === 'ImportSpecifier' && specifier.importKind == null,
+        );
+        const importTypeSpecifiers = node.specifiers.filter(
           (specifier) => specifier.type === 'ImportSpecifier' && specifier.importKind === 'type',
         );
 
         const firstUnsortedIndex = importSpecifiers
-          .map((specifier) => specifier.local.name)
+          .map((specifier) => specifier.imported.name.toLowerCase())
+          .findIndex((name, index, array) => array[index - 1] > name);
+        const firstTypeUnsortedIndex = importTypeSpecifiers
+          .map((specifier) => specifier.imported.name.toLowerCase())
           .findIndex((name, index, array) => array[index - 1] > name);
 
         if (firstUnsortedIndex !== -1) {
           context.report({
             node: importSpecifiers[firstUnsortedIndex],
-            messageId: 'sortTypeImportsAlphabetically',
+            messageId: 'sortImportsAlphabetically',
             data: {
-              firstUnsortedImport: importSpecifiers[firstUnsortedIndex].local.name,
-              beforeFirstUnsortedImport: importSpecifiers[firstUnsortedIndex - 1].local.name,
+              firstUnsortedImport: importSpecifiers[firstUnsortedIndex].imported.name,
+              beforeFirstUnsortedImport: importSpecifiers[firstUnsortedIndex - 1].imported.name,
             },
             fix(fixer) {
-              if (
-                importSpecifiers.some(
-                  (specifier) =>
-                    sourceCode.getCommentsBefore(specifier).length ||
-                    sourceCode.getCommentsAfter(specifier).length,
-                )
-              ) {
-                // If there are comments in the ImportSpecifier list, don't rearrange the specifiers.
-                return null;
-              }
+              return fixImportSpecifiers(fixer, importSpecifiers);
+            },
+          });
+        }
 
-              return fixer.replaceTextRange(
-                [
-                  importSpecifiers[0].range[0],
-                  importSpecifiers[importSpecifiers.length - 1].range[1],
-                ],
-                importSpecifiers
-                  .slice() // clone the `importSpecifiers` array to avoid mutating it
-                  .sort((specifierA, specifierB) => {
-                    // sort the array into the desired order
-                    return specifierA.local.name > specifierB.local.name ? 1 : -1;
-                  })
-                  .reduce((sourceText, specifier, index) => {
-                    // build a string out of the sorted list of import specifiers and the text
-                    // between the originals
-                    const textAfterSpecifier =
-                      index === importSpecifiers.length - 1
-                        ? ''
-                        : sourceCode
-                            .getText()
-                            .slice(
-                              importSpecifiers[index].range[1],
-                              importSpecifiers[index + 1].range[0],
-                            );
-                    return sourceText + sourceCode.getText(specifier) + textAfterSpecifier;
-                  }, ''),
-              );
+        if (firstTypeUnsortedIndex !== -1) {
+          context.report({
+            node: importTypeSpecifiers[firstTypeUnsortedIndex],
+            messageId: 'sortTypeImportsAlphabetically',
+            data: {
+              firstUnsortedImport: importTypeSpecifiers[firstTypeUnsortedIndex].imported.name,
+              beforeFirstUnsortedImport:
+                importTypeSpecifiers[firstTypeUnsortedIndex - 1].imported.name,
+            },
+            fix(fixer) {
+              return fixImportSpecifiers(fixer, importTypeSpecifiers);
             },
           });
         }


### PR DESCRIPTION
_Note: this implementation is WIP and is currently incorrect (it allows mixed order of `type` and regular imports; `type` imports should always be last in the group)._