### PR TITLE
CI: drop Node.js 16.x

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 19.x]
+        node-version: [18.x, 19.x]
 
     steps:
       # https://github.com/actions/checkout

--- a/.github/workflows/npm-publisher.yml
+++ b/.github/workflows/npm-publisher.yml
@@ -21,10 +21,10 @@ jobs:
           fetch-depth: 0
 
       # Always use the oldest supported Node.js version here:
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Install Yarn dependencies
         run: yarn install --immutable


### PR DESCRIPTION
From now on this repository should support LTS and Current Node.js versions only. See: https://nodejs.org/en/download/