### PR TITLE
Renovate: do not automerge dev dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,11 +17,6 @@
     'strip-ansi',
   ],
   packageRules: [
-    {
-      matchDepTypes: ['devDependencies'],
-      matchUpdateTypes: ['patch'],
-      addLabels: ['automerge'],
-    },
     // Group dependencies by pattern:
     {
       groupName: 'SVGR packages (JavaScript)',


### PR DESCRIPTION
This approach is not compatible with the new GitHub merge queue I am currently testing.