### PR TITLE
CI: do not automerge daily Cargo update

### DIFF
--- a/.github/workflows/daily-rust-cargo-update.yml
+++ b/.github/workflows/daily-rust-cargo-update.yml
@@ -35,5 +35,4 @@ jobs:
           delete-branch: true
           branch-suffix: random
           labels: |
-            automerge
             dependencies


### PR DESCRIPTION
This approach is not compatible with the new GitHub merge queue I am currently testing.