### PR TITLE
Partially revert 2c9f9f683d21e53e95e914a9edaebb07b4afa6ba

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -4,11 +4,6 @@ on:
   merge_group:
     types:
       - checks_requested
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
   push:
     branches-ignore:
       # We do not run tests on master as the changes were already tested when opening a PR,

--- a/.github/workflows/continuous-integration-rust.yml
+++ b/.github/workflows/continuous-integration-rust.yml
@@ -4,11 +4,6 @@ on:
   merge_group:
     types:
       - checks_requested
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
   push:
     branches-ignore:
       # We do not run tests on master as the changes were already tested when opening a PR,

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,11 +4,6 @@ on:
   merge_group:
     types:
       - checks_requested
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
   push:
     branches-ignore:
       # We do not run tests on master as the changes were already tested when opening a PR,

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,11 +4,6 @@ on:
   merge_group:
     types:
       - checks_requested
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
   push:
     branches-ignore:
       # We do not run tests on master as the changes were already tested when opening a PR,


### PR DESCRIPTION
Seems like `pull_request` and `push` and duplicate in this context and create twice as CI runs as needed. We should probably use one or the other.