### PR TITLE
Revert "Renovate: set custom changelog URL for `amazon/aws-cli`"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,11 +50,6 @@
     {
       groupName: 'Sentry packages (Rust)',
       matchSourceUrlPrefixes: ['https://github.com/getsentry/sentry-rust'],
-    },
-    // Custom changelog URLs:
-    {
-      matchPackageNames: ['amazon/aws-cli'],
-      customChangelogUrl: 'https://github.com/aws/aws-cli/tree/v2',
-    },
+    }
   ],
 }


### PR DESCRIPTION
This reverts commit 7d7b232552bb0f2d7bb2f7fa4c62c5ef764501fb.

Seems like it doesn't work (maybe because the changelog is in `rst` format?)