### PR TITLE
SX Design: patch `build-storybook` script

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -76,6 +76,7 @@ jobs:
         run: yarn workspace ${{ matrix.repository }} playwright test
         env:
           # See: https://github.com/storybookjs/storybook/issues/16555
+          # TODO: remove when no longer needed
           NODE_OPTIONS: --openssl-legacy-provider
 
       # https://github.com/actions/upload-artifact

--- a/src/sx-design/package.json
+++ b/src/sx-design/package.json
@@ -64,7 +64,7 @@
   },
   "scripts": {
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
+    "build-storybook": "NODE_OPTIONS=--openssl-legacy-provider build-storybook",
     "fbt:manifest": "fbt-manifest --src=src --enum-manifest=translations/enum_manifest.json --src-manifest=translations/src_manifest.json",
     "fbt:collect": "fbt-collect --options=__self --pretty --manifest < translations/src_manifest.json > translations/source_strings.json",
     "fbt:translate": "fbt-translate --source-strings=translations/source_strings.json --pretty --translations translations/in/*.json --output-dir=translations/out --jenkins",


### PR DESCRIPTION
Annoyingly, there is currently an issue with Storybook (see: https://github.com/storybookjs/storybook/issues/16555). We already have to do this in CI to make Playwright work, and it also affects Vercel deployments (and builds on Node.js 18).