### PR TITLE
Publish monorepo-shipit

### DIFF
--- a/.github/workflows/shipit.yml
+++ b/.github/workflows/shipit.yml
@@ -35,4 +35,4 @@ jobs:
           ssh-keyscan -H 'github.com' >> ~/.ssh/known_hosts
 
       - name: Run Shipit
-        run: yarn monorepo-babel-node src/monorepo-shipit/bin/shipit.js
+        run: yarn monorepo-babel-node src/monorepo-shipit/bin/shipit.js --config-dir src/monorepo-shipit/config --committer-name adeira-github-bot --committer-email mrtnzlml+adeira-github-bot@gmail.com

--- a/scripts/publishedPackages.json
+++ b/scripts/publishedPackages.json
@@ -11,6 +11,7 @@
   "@adeira/icons",
   "@adeira/js",
   "@adeira/monorepo-npm-publisher",
+  "@adeira/monorepo-shipit",
   "@adeira/monorepo-utils",
   "@adeira/murmur-hash",
   "@adeira/qr-code-reader",

--- a/src/monorepo-shipit/.npmignore
+++ b/src/monorepo-shipit/.npmignore
@@ -1,0 +1,2 @@
+__flowtests__
+__tests__

--- a/src/monorepo-shipit/README.md
+++ b/src/monorepo-shipit/README.md
@@ -1,7 +1,5 @@
 Monorepo Shipit takes care of exporting and importing our projects from GitHub monorepo into any other Git repository. It can export even from our monorepo to another monorepo. In theory, it can export even to different VCS, not just Git. We use it open-source some of our code to our [Adeira](https://github.com/adeira) GitHub organization.
 
-_Are you interested in using Shipit for your own monorepo? Get in touch and we can discuss necessary changes._
-
 - [Shipit part](#shipit-part)
   - [Configuration](#configuration)
   - [Filters](#filters)
@@ -16,7 +14,18 @@ _Are you interested in using Shipit for your own monorepo? Get in touch and we c
 
 # Shipit part
 
-Shipit part is responsible for exporting code from our monorepo somewhere else.
+Shipit part is responsible for exporting code from a monorepo to somewhere else.
+
+```
+npx @adeira/monorepo-shipit
+```
+
+| Option                    | Description                                                            | Default value |
+| ------------------------- | ---------------------------------------------------------------------- | ------------- |
+| --committer-name <name>   | Name to use for the commit, usually a bot account.                     |               |
+| --committer-email <email> | Email to use for the commit, usually a bot account.                    |               |
+| --config-filter           | Filters the configs to only run a subset, useful for testing purposes. | `"./*.js`     |
+| --config-dir              | Directory to look for the shipit configs.                              | `"./.shipit"` |
 
 Here is how it works. First, we try to extract relevant commits of each project we want to export. Each commit is converted into so called _changeset_ which is an immutable structure representing one commit and doesn't depend on Git or any other VCS. Each changeset can contain many diffs describing changes in each individual file.
 

--- a/src/monorepo-shipit/bin/importit.js
+++ b/src/monorepo-shipit/bin/importit.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
-// @flow strict-local
+// @flow
 
 import { invariant } from '@adeira/js';
+import commandLineArgs from 'command-line-args';
 
 import iterateConfigs from '../src/iterateConfigs';
 import createClonePhase from '../src/phases/createClonePhase';
@@ -14,29 +15,65 @@ import type { Phase } from '../types.flow';
 // TODO: check we can actually import this package (whether we have config for it)
 // yarn monorepo-babel-node src/monorepo-shipit/bin/importit.js git@github.com:adeira/fetch.git 1
 
-const argv = process.argv.splice(2); // TODO: better CLI
-invariant(argv.length === 2, 'Importit expects two arguments: git URL and PR number.');
-
-const exportedRepoURL = argv[0]; // git@github.com:adeira/fetch.git
-const pullRequestNumber = argv[1];
-
 const gitRegex = /^git@github.com:(?<packageName>.+)\.git$/;
+
+const options = commandLineArgs(
+  [
+    {
+      name: 'config-filter',
+      type: String,
+      defaultValue: '/*.js',
+    },
+    {
+      name: 'config-dir',
+      type: String,
+      defaultValue: './.shipit',
+    },
+    {
+      name: 'committer-name',
+      type: String,
+    },
+    {
+      name: 'committer-email',
+      type: String,
+    },
+    {
+      name: 'pull-request-id',
+      type: Number,
+    },
+    {
+      name: 'repo-url',
+      type: Number,
+    },
+  ],
+  { camelCase: true },
+);
+
+invariant(options.committerName, 'committer-name is required');
+invariant(options.committerEmail, 'committer-email is required');
+invariant(options.repoUrl, 'repo-url is required');
+invariant(options.pullRequestId, 'pull-request-id is required');
+
+process.env.SHIPIT_COMMITTER_EMAIL = options.committerName;
+process.env.SHIPIT_COMMITTER_NAME = options.committerEmail;
+
 invariant(
-  gitRegex.test(exportedRepoURL),
+  gitRegex.test(options.repoUrl),
   'We currently support imports only from GitHub.com - please open an issue to add additional services.',
 );
 
-const match = exportedRepoURL.match(gitRegex);
+const match = options.repoUrl.match(gitRegex);
 const packageName = match?.groups?.packageName;
-invariant(packageName != null, 'Cannot figure out package name from: %s', exportedRepoURL);
 
-iterateConfigs('/*.js', (config) => {
-  if (config.exportedRepoURL === exportedRepoURL) {
+invariant(packageName != null, 'Cannot figure out package name from: %s', options.repoUrl);
+
+iterateConfigs(options, (config) => {
+  if (config.exportedRepoURL === options.repoUrl) {
     new Set<Phase>([
       createClonePhase(config.exportedRepoURL, config.destinationPath),
       createCheckCorruptedRepoPhase(config.destinationPath),
       createCleanPhase(config.destinationPath),
-      createImportSyncPhase(config, packageName, pullRequestNumber),
+      createImportSyncPhase(config, packageName, options.pullRequestId),
     ]).forEach((phase) => phase());
   }
 });

--- a/src/monorepo-shipit/package.json
+++ b/src/monorepo-shipit/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@adeira/monorepo-shipit",
-  "private": true,
   "license": "MIT",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "bin": {
     "monorepo-importit": "bin/importit.js",
     "monorepo-importit-reversed": "bin/importit-reversed.js",
@@ -14,6 +13,7 @@
     "@adeira/js": "^2.1.1",
     "@adeira/monorepo-utils": "^0.11.0",
     "@adeira/shell-command": "^0.1.0",
+    "@babel/runtime": "^7.21.5",
     "chalk": "^4.1.2",
     "command-line-args": "^5.2.1",
     "fast-levenshtein": "^3.0.0"

--- a/src/monorepo-shipit/package.json
+++ b/src/monorepo-shipit/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@adeira/monorepo-shipit",
+  "description": "Monorepo → many repos (Git) exporter.",
+  "homepage": "https://github.com/adeira/monorepo-shipit",
+  "bugs": "https://github.com/adeira/universe/issues",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:adeira/universe.git",
+    "directory": "src/monorepo-shipit"
+  },
   "license": "MIT",
   "version": "0.1.0",
+  "type": "commonjs",
   "bin": {
     "monorepo-importit": "bin/importit.js",
     "monorepo-shipit": "bin/shipit.js"

--- a/src/monorepo-shipit/package.json
+++ b/src/monorepo-shipit/package.json
@@ -4,7 +4,6 @@
   "version": "0.1.0",
   "bin": {
     "monorepo-importit": "bin/importit.js",
-    "monorepo-importit-reversed": "bin/importit-reversed.js",
     "monorepo-shipit": "bin/shipit.js"
   },
   "sideEffects": false,

--- a/src/monorepo-shipit/src/RepoGit.js
+++ b/src/monorepo-shipit/src/RepoGit.js
@@ -9,7 +9,6 @@ import parsePatch from './parsePatch';
 import parsePatchHeader from './parsePatchHeader';
 import splitHead from './splitHead';
 import Changeset, { type Diff } from './Changeset';
-import accounts from './accounts';
 
 /**
  * This is our monorepo part - source of exports.
@@ -74,10 +73,9 @@ export default class RepoGit implements AnyRepo, SourceRepo, DestinationRepo {
   };
 
   configure: () => void = () => {
-    const username = 'adeira-github-bot';
     for (const [key, value] of Object.entries({
-      'user.email': accounts.get(username),
-      'user.name': username,
+      'user.email': process.env.SHIPIT_COMMITTER_EMAIL,
+      'user.name': process.env.SHIPIT_COMMITTER_NAME,
     })) {
       // $FlowIssue[incompatible-call]: https://github.com/facebook/flow/issues/2174
       this._gitCommand('config', key, value).runSynchronously();

--- a/src/monorepo-shipit/src/RepoGitFake.js
+++ b/src/monorepo-shipit/src/RepoGitFake.js
@@ -17,10 +17,9 @@ export default class RepoGitFake extends RepoGit {
     testRepoPath: string = fs.mkdtempSync(path.join(os.tmpdir(), 'adeira-shipit-tests-')),
   ) {
     new ShellCommand(testRepoPath, 'git', 'init').runSynchronously();
-    const username = 'adeira-shipit-tests';
     for (const [key, value] of Object.entries({
       'user.email': 'shipit-tests@adeira.dev',
-      'user.name': username,
+      'user.name': 'adeira-shipit-tests',
     })) {
       new ShellCommand(
         testRepoPath,

--- a/src/monorepo-shipit/src/RepoGitFake.js
+++ b/src/monorepo-shipit/src/RepoGitFake.js
@@ -5,7 +5,6 @@ import os from 'os';
 import path from 'path';
 import { ShellCommand } from '@adeira/shell-command';
 
-import accounts from './accounts';
 import RepoGit from './RepoGit';
 
 /* $FlowFixMe[incompatible-extend] This comment suppresses an error when
@@ -20,7 +19,7 @@ export default class RepoGitFake extends RepoGit {
     new ShellCommand(testRepoPath, 'git', 'init').runSynchronously();
     const username = 'adeira-shipit-tests';
     for (const [key, value] of Object.entries({
-      'user.email': accounts.get(username),
+      'user.email': 'shipit-tests@adeira.dev',
       'user.name': username,
     })) {
       new ShellCommand(

--- a/src/monorepo-shipit/src/accounts.js
+++ b/src/monorepo-shipit/src/accounts.js
@@ -1,8 +1,0 @@
-// @flow strict
-
-const availableAccounts: $ReadOnlyMap<string, string> = new Map([
-  ['adeira-github-bot', 'mrtnzlml+adeira-github-bot@gmail.com'],
-  ['adeira-shipit-tests', 'shipit-tests@adeira.dev'],
-]);
-
-export default availableAccounts;

--- a/src/monorepo-shipit/src/iterateConfigs.js
+++ b/src/monorepo-shipit/src/iterateConfigs.js
@@ -7,11 +7,14 @@ import requireAndValidateConfig from './requireAndValidateConfig';
 import ShipitConfig from './ShipitConfig';
 
 function iterateConfigsInPath(
-  globPattern: string,
+  options: {
+    configFilter: string,
+    configDir: string,
+  },
   rootPath: string,
   callback: (ShipitConfig) => void,
 ): void {
-  const configFiles = globSync(globPattern, {
+  const configFiles = globSync(options.configFilter, {
     root: rootPath,
     ignore: [
       '**/node_modules/**',
@@ -64,8 +67,11 @@ function iterateConfigsInPath(
 }
 
 export default function iterateConfigs(
-  globPattern: string,
+  options: {
+    configFilter: string,
+    configDir: string,
+  },
   callback: (ShipitConfig) => void,
 ): void {
-  iterateConfigsInPath(globPattern, path.join(__dirname, '..', 'config'), callback);
+  iterateConfigsInPath(options, path.join(process.cwd(), options.configDir), callback);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -298,12 +298,12 @@ __metadata:
     "@adeira/js": ^2.1.1
     "@adeira/monorepo-utils": ^0.11.0
     "@adeira/shell-command": ^0.1.0
+    "@babel/runtime": ^7.21.5
     chalk: ^4.1.2
     command-line-args: ^5.2.1
     fast-levenshtein: ^3.0.0
   bin:
     monorepo-importit: bin/importit.js
-    monorepo-importit-reversed: bin/importit-reversed.js
     monorepo-shipit: bin/shipit.js
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This pull request updates monorepo-shipit to be able to be published to NPM and used by anyone. It:

- introduces new command line args
- removes hardcoded accounts
- updates internal workflow runs to use the new args

There is an opportunity in a follow up to replace the command line library with something like commanderjs so there is an easier way to look for available args, etc.

Related to #6096. Need to test it end-to-end before closing the issue.