### PR TITLE
CI: run checks for 3rd party contributions

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -4,11 +4,13 @@ on:
   merge_group:
     types:
       - checks_requested
-  push:
-    branches-ignore:
-      # We do not run tests on master as the changes were already tested when opening a PR,
-      # and we require every PR to be up-to-date before merging it to master.
-      - master
+  pull_request:
+    # We do not run tests on master as the changes were already tested when opening a PR,
+    # and we require every PR to be up-to-date before merging it to master.
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 env:
   CI: true

--- a/.github/workflows/continuous-integration-rust.yml
+++ b/.github/workflows/continuous-integration-rust.yml
@@ -4,11 +4,13 @@ on:
   merge_group:
     types:
       - checks_requested
-  push:
-    branches-ignore:
-      # We do not run tests on master as the changes were already tested when opening a PR,
-      # and we require every PR to be up-to-date before merging it to master.
-      - master
+  pull_request:
+    # We do not run tests on master as the changes were already tested when opening a PR,
+    # and we require every PR to be up-to-date before merging it to master.
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   rust-test:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,11 +4,13 @@ on:
   merge_group:
     types:
       - checks_requested
-  push:
-    branches-ignore:
-      # We do not run tests on master as the changes were already tested when opening a PR,
-      # and we require every PR to be up-to-date before merging it to master.
-      - master
+  pull_request:
+    # We do not run tests on master as the changes were already tested when opening a PR,
+    # and we require every PR to be up-to-date before merging it to master.
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 env:
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,11 +4,13 @@ on:
   merge_group:
     types:
       - checks_requested
-  push:
-    branches-ignore:
-      # We do not run tests on master as the changes were already tested when opening a PR,
-      # and we require every PR to be up-to-date before merging it to master.
-      - master
+  pull_request:
+    # We do not run tests on master as the changes were already tested when opening a PR,
+    # and we require every PR to be up-to-date before merging it to master.
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   shellcheck:


### PR DESCRIPTION
Replaces generic `push` event with more appropriate `pull_request` event.

See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request

Note: previously, there was an issue with the CI jobs running twice (see: https://github.com/adeira/universe/commit/ccf3dec7e98acc5c994280c07dc14ba26dabd9c3). This change should fix it.

Closes: https://github.com/adeira/universe/issues/6110