### PR TITLE
CI: run JS tests on `macos-latest`

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   javascript-test:
     name: JavaScript test
-    runs-on: ubuntu-latest
+    runs-on: macos-13
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
I suspect that one test is broken on macOS. This is just a test. DO NOT MERGE.