### PR TITLE
Shipit: correctly propagate PATH to `ShellCommand`

### DIFF
--- a/src/monorepo-utils/src/Git.js
+++ b/src/monorepo-utils/src/Git.js
@@ -3,20 +3,30 @@
 import os from 'os';
 import { ShellCommand } from '@adeira/shell-command';
 
+/*::
+
+import type { EnvironmentVariables } from '@adeira/shell-command';
+
+*/
+
 function __parseRows(changes /*: string */) /*: $ReadOnlyArray<string> */ {
   return changes.split(os.EOL).filter((row) => row !== '');
 }
 
 function git(...args /*: $ReadOnlyArray<string> */): string {
   // TODO: unify with Git implementation from Shipit (?)
+  const environmentVariables /*: EnvironmentVariables */ = {
+    // https://git-scm.com/docs/git#_environment_variables
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_TERMINAL_PROMPT: '0',
+  };
+
+  if (process.env.PATH != null) {
+    environmentVariables.PATH = process.env.PATH;
+  }
+
   return new ShellCommand(null, 'git', '--no-pager', ...args)
-    .setEnvironmentVariables(
-      new Map([
-        // https://git-scm.com/docs/git#_environment_variables
-        ['GIT_CONFIG_NOSYSTEM', '1'],
-        ['GIT_TERMINAL_PROMPT', '0'],
-      ]),
-    )
+    .setEnvironmentVariables(environmentVariables)
     .runSynchronously()
     .getStdout();
 }

--- a/src/shell-command/index.js
+++ b/src/shell-command/index.js
@@ -2,3 +2,5 @@
 
 export { default as ShellCommand } from './src/ShellCommand';
 export { default as ShellCommandResult } from './src/ShellCommandResult';
+
+export type { EnvironmentVariables } from './src/ShellCommand';

--- a/src/shell-command/src/__tests__/ShellCommand.test.js
+++ b/src/shell-command/src/__tests__/ShellCommand.test.js
@@ -84,6 +84,7 @@ it('executes the underlying child process correctly -- output to screen', () => 
     signal: null,
     status: 0, // success
   }));
+
   new ShellCommand(
     null,
     'some_command',
@@ -95,6 +96,7 @@ it('executes the underlying child process correctly -- output to screen', () => 
   )
     .setOutputToScreen()
     .runSynchronously();
+
   expect(spy).toHaveBeenCalledWith('some_command', ['-x', '-x', '--abc', 'string'], {
     cwd: expect.any(String),
     input: undefined,
@@ -110,7 +112,9 @@ it('executes the underlying child process correctly -- returns output with stdin
     signal: null,
     status: 0, // success
   }));
+
   new ShellCommand(null, 'some_command').setStdin('custom playload').runSynchronously();
+
   expect(spy).toHaveBeenCalledWith('some_command', [], {
     cwd: expect.any(String),
     input: 'custom playload',
@@ -126,12 +130,14 @@ it('executes the underlying child process correctly -- with environment variable
     signal: null,
     status: 0, // success
   }));
+
   new ShellCommand(null, 'some_command')
-    .setEnvironmentVariables(new Map([['GIT_CONFIG_NOSYSTEM', '1']]))
+    .setEnvironmentVariables({ GIT_CONFIG_NOSYSTEM: '1' })
     .runSynchronously();
+
   expect(spy).toHaveBeenCalledWith('some_command', [], {
     cwd: expect.any(String),
-    env: new Map([['GIT_CONFIG_NOSYSTEM', '1']]),
+    env: { GIT_CONFIG_NOSYSTEM: '1' },
     stdio: ['inherit', 'pipe', 'pipe'],
     maxBuffer: Infinity,
   });


### PR DESCRIPTION
This change started with investigating why `src/monorepo-shipit/src/__tests__/RepoGit.findLastSourceCommit.test.js` fails on some machines. Here is an example of such failure:

```
  ● can find last source commit

    expect(received).toBe(expected) // Object.is equality

    Expected: "636abcdef012345840"
    Received: null

      27 |   const description = addTrackingData(new Changeset().withID(fakeCommitID)).getDescription();
      28 |   const repo = createGITRepoWithCommit(description);
    > 29 |   expect(repo.findLastSourceCommit(new Set())).toBe(fakeCommitID);
         |                                                ^
      30 | });
      31 |
      32 | it('can find last source commit with Co-authored-by', () => {

      at Object.toBe (src/__tests__/RepoGit.findLastSourceCommit.test.js:29:48)
```

Interestingly, this doesn't happen on CI. It happens only on some macOS machines (but doesn't fail using `macos-latest` on CI either). I've discovered that this is a problem of Git after reading the 2.40.0 changelog:

> Newer regex library macOS stopped enabling GNU-like enhanced BRE, where '\(A\|B\)' works as alternation, unless explicitly asked with the REG_ENHANCED flag.  "git grep" now can be compiled to do so, to retain the old behaviour.

Source: https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.40.0.txt

This lead me to the fix - install the latest Git version instead of using the broken one on macOS:

```
brew install git
```

This still however didn't work becuase Shipit was incorrectly working with PATH. Internally the Homebrew version was still being ignored.

The fix was to update the usage of `ShellCommand` because apparently when overwriting the envs, `ShellCommand` defaults to ignoring the PATH variable and therefore the incorrect Git version is used.

This change should fix the problem.