### PR TITLE
Fixes some edge cases in monorepo-shipit

### DIFF
--- a/src/monorepo-shipit/src/RepoGit.js
+++ b/src/monorepo-shipit/src/RepoGit.js
@@ -258,7 +258,9 @@ export default class RepoGit implements AnyRepo, SourceRepo, DestinationRepo {
     } else {
       const diff = this.renderPatch(changeset);
       try {
-        this._gitCommand('am', '--keep-non-patch', '--keep-cr').setStdin(diff).runSynchronously();
+        this._gitCommand('am', '--keep-non-patch', '--keep-cr', '--committer-date-is-author-date')
+          .setStdin(diff)
+          .runSynchronously();
       } catch (error) {
         this._gitCommand('am', '--show-current-patch').setOutputToScreen().runSynchronously();
         this._gitCommand('am', '--abort').setOutputToScreen().runSynchronously();

--- a/src/monorepo-shipit/src/RepoGitFake.js
+++ b/src/monorepo-shipit/src/RepoGitFake.js
@@ -54,6 +54,13 @@ export default class RepoGitFake extends RepoGit {
     return this.#testRepoPath;
   }
 
+  printTimestamps(): string {
+    return this._gitCommand('log', '--stat', '--pretty=format:AUTHOR:%aD%nCOMMIT:%cD%n')
+      .runSynchronously()
+      .getStdout()
+      .trim();
+  }
+
   printFakeRepoHistory(): string {
     return this._gitCommand('log', '--stat', '--pretty=format:SUBJ: %s%nDESC: %b')
       .runSynchronously()

--- a/src/monorepo-shipit/src/__tests__/RepoGit.commitPatch.test.js
+++ b/src/monorepo-shipit/src/__tests__/RepoGit.commitPatch.test.js
@@ -27,6 +27,20 @@ it('commits changeset with single diff correctly', () => {
   `);
 });
 
+it('commits changeset with the author timestamp the same as commit timestamp', () => {
+  const repo = new RepoGitFake();
+  const changeset = createMockChangeset(1);
+  repo.commitPatch(changeset);
+
+  expect(repo.printTimestamps()).toMatchInlineSnapshot(`
+    "AUTHOR:Tue, 16 Jul 2019 10:55:04 -0100
+    COMMIT:Tue, 16 Jul 2019 10:55:04 -0100
+
+     fakeFile_1.txt | 1 +
+     1 file changed, 1 insertion(+)"
+  `);
+});
+
 it('commits changeset with multiple diffs correctly', () => {
   const repo = new RepoGitFake();
   const changeset = createMockChangeset(3);

--- a/src/monorepo-shipit/src/__tests__/RepoGit.findLastSourceCommit.test.js
+++ b/src/monorepo-shipit/src/__tests__/RepoGit.findLastSourceCommit.test.js
@@ -62,3 +62,33 @@ it('can find last source commit without whitespaces', () => {
   const repo = createGITRepoWithCommit(`${description}  `);
   expect(repo.findLastSourceCommit(new Set())).toBe(fakeCommitID);
 });
+
+it('should return first commit in list', () => {
+  const repo = new RepoGitFake();
+  const firstCommit = repo.commitPatch(
+    new Changeset()
+      .withSubject('test subject')
+      .withDescription('initial-commit')
+      .withAuthor('John Doe <john@doe.com>')
+      .withTimestamp('Mon, 4 Feb 2019 13:29:04 -0600'),
+  );
+
+  const secondCommit = repo.commitPatch(
+    new Changeset()
+      .withSubject('test subject')
+      .withDescription('second-commit')
+      .withAuthor('John Doe <john@doe.com>')
+      .withTimestamp('Mon, 5 Feb 2019 13:29:04 -0600'),
+  );
+
+  const descendants = repo.findDescendantsPath(firstCommit, 'master', new Set([]));
+
+  // It never brings back the first commit (base revision)!
+  // This means any repository that has a first commit _with content_ has its shipit fail.
+  expect(descendants).toEqual([secondCommit]);
+
+  const descendantsFromFirst = repo.findDescendantsPath(firstCommit, 'master', new Set([]), true);
+
+  // By forcing it we can have it picked up.
+  expect(descendantsFromFirst).toEqual([firstCommit, secondCommit]);
+});

--- a/src/monorepo-shipit/src/phases/createSyncPhase.js
+++ b/src/monorepo-shipit/src/phases/createSyncPhase.js
@@ -18,16 +18,20 @@ export default function createSyncPhase(config: ShipitConfig): Phase {
     const destinationRepo = _getDestinationRepo();
     const sourceRepo = _getSourceRepo();
     let initialRevision = destinationRepo.findLastSourceCommit(config.getDestinationRoots());
+    let isNewRepo = false;
     if (initialRevision === null) {
       // Seems like it's a new repo so there is no signed commit.
       // Let's take the first one from our source repo instead.
       initialRevision = sourceRepo.findFirstAvailableCommit();
+      isNewRepo = true;
     }
+
     const sourceChangesets = new Set<Changeset>();
     const descendantsPath = sourceRepo.findDescendantsPath(
       initialRevision,
       config.getSourceBranch(),
       config.getSourceRoots(),
+      isNewRepo,
     );
     if (descendantsPath !== null) {
       descendantsPath.forEach((revision) => {

--- a/src/monorepo-shipit/src/phases/createVerifyRepoPhase.js
+++ b/src/monorepo-shipit/src/phases/createVerifyRepoPhase.js
@@ -82,7 +82,7 @@ export default function createVerifyRepoPhase(config: ShipitConfig): Phase {
       'diff',
       '--stat',
       'HEAD',
-      'shipit_destination/master',
+      `shipit_destination/${config.getDestinationBranch()}`,
     )
       .runSynchronously()
       .getStdout()
@@ -96,7 +96,7 @@ export default function createVerifyRepoPhase(config: ShipitConfig): Phase {
         '--full-index',
         '--binary',
         '--no-color',
-        'shipit_destination/master',
+        `shipit_destination/${config.getDestinationBranch()}`,
         'HEAD',
       )
         .runSynchronously()


### PR DESCRIPTION
This pull request:

- fixes hardcoded branches during the shipit verify step
- includes the first revision commit when running in a new repo
- adds `--committer-date-is-author-date` to `git am` call in `commitPatch` to ensure each commit uses the author datetime, preventing the initial sync forcing every commit to have the same commit timestamp 

With these changes (applied as a patch) I've been able to sync a repo in CI successfully.
