### PR TITLE
feat: adds commit message transformer to shipit

### DIFF
--- a/src/monorepo-shipit/ConfigType.flow.js
+++ b/src/monorepo-shipit/ConfigType.flow.js
@@ -10,4 +10,5 @@ export type ConfigType = {
     +source: string,
     +destination: string,
   },
+  +transformCommitMessage?: (message: string) => string,
 };

--- a/src/monorepo-shipit/README.md
+++ b/src/monorepo-shipit/README.md
@@ -98,6 +98,21 @@ module.exports = {
 };
 ```
 
+```js
+export type ConfigType = {
+  +getStaticConfig: () => {
+    +repository: string,
+  },
+  +getPathMappings: () => Map<string, string>,
+  +getStrippedFiles?: () => Set<RegExp>,
+  +getBranchConfig?: () => {
+    +source: string,
+    +destination: string,
+  },
+  +transformCommitMessage?: (message: string) => string,
+};
+```
+
 Read more about available filters and how to use them below.
 
 ## Filters

--- a/src/monorepo-shipit/src/Changeset.js
+++ b/src/monorepo-shipit/src/Changeset.js
@@ -25,6 +25,9 @@ export default class Changeset {
   declare subject: string;
   declare description: string;
   declare diffs: Set<Diff>;
+
+  descriptionTransformer: (msg: string) => string = (msg) => msg;
+
   coAuthorLines: $ReadOnlyArray<string> = [];
   debugMessages: $ReadOnlyArray<string> = [];
 
@@ -73,11 +76,16 @@ export default class Changeset {
   }
 
   getDescription(): string {
-    return this.description;
+    return this.descriptionTransformer(this.description);
   }
 
   withDescription(description: string): Changeset {
     return this.__clone({ description });
+  }
+
+  withDescriptionTransformer(descriptionTransformer: (msg: string) => string): Changeset {
+    this.descriptionTransformer = descriptionTransformer;
+    return this;
   }
 
   getCommitMessage(): string {

--- a/src/monorepo-shipit/src/ShipitConfig.js
+++ b/src/monorepo-shipit/src/ShipitConfig.js
@@ -21,6 +21,7 @@ export default class ShipitConfig {
   exportedRepoURL: string; // TODO: what to do with this?
   directoryMapping: Map<string, string>;
   strippedFiles: Set<RegExp>;
+  transformCommitMessage: (msg: string) => string;
 
   #sourceBranch: string;
   #destinationBranch: string;
@@ -32,6 +33,7 @@ export default class ShipitConfig {
     strippedFiles: Set<RegExp>,
     sourceBranch: string = 'origin/master', // our GitLab CI doesn't have master branch
     destinationBranch: string = 'master',
+    transformCommitMessage: (msg: string) => string = (msg) => msg,
   ) {
     this.sourcePath = sourcePath;
     // This is currently not configurable. We could (should) eventually keep
@@ -40,6 +42,7 @@ export default class ShipitConfig {
     this.exportedRepoURL = exportedRepoURL;
     this.directoryMapping = directoryMapping;
     this.strippedFiles = strippedFiles;
+    this.transformCommitMessage = transformCommitMessage;
     this.#sourceBranch = sourceBranch;
     this.#destinationBranch = destinationBranch;
   }
@@ -66,6 +69,8 @@ export default class ShipitConfig {
    */
   getDefaultShipitFilter(): ChangesetFilter {
     return (changeset: Changeset) => {
+      changeset.withDescriptionTransformer(this.transformCommitMessage);
+
       const ch1 = addTrackingData(changeset);
       const ch2 = stripExceptDirectories(ch1, this.getSourceRoots());
       const ch3 = moveDirectories(ch2, this.directoryMapping);

--- a/src/monorepo-shipit/src/__tests__/Changeset.test.js
+++ b/src/monorepo-shipit/src/__tests__/Changeset.test.js
@@ -23,6 +23,7 @@ test('immutability of the changesets', () => {
     Changeset {
       "coAuthorLines": [],
       "debugMessages": [],
+      "descriptionTransformer": [Function],
     }
   `);
 
@@ -35,6 +36,7 @@ test('immutability of the changesets', () => {
         "DEBUG yadada",
       ],
       "description": "new description",
+      "descriptionTransformer": [Function],
       "diffs": Set {
         {
           "body": "AAA",
@@ -66,6 +68,7 @@ test('immutability of the changesets', () => {
         "DEBUG should be appended",
       ],
       "description": "even newer description",
+      "descriptionTransformer": [Function],
       "diffs": Set {
         {
           "body": "CCC",

--- a/src/monorepo-shipit/src/__tests__/ShipitConfig.test.js
+++ b/src/monorepo-shipit/src/__tests__/ShipitConfig.test.js
@@ -54,3 +54,29 @@ it('creates and runs the default filters with Co-authored-by', () => {
   ]);
   expect(defaultFilter(changeset)).toMatchSnapshot();
 });
+
+it('updates the commit message', () => {
+  const defaultFilter = new Config(
+    'fake monorepo path',
+    'fake exported repo URL',
+    new Map([['/known_path', '/destination_path']]),
+    new Set([/mocked/]),
+    'origin/master',
+    'master',
+    (msg) => msg.replace('Test', 'Hello world'),
+  ).getDefaultShipitFilter();
+
+  const changeset = createMockChangeset(2, '/known_path/').withCoAuthorLines([
+    'Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>',
+    'Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>',
+  ]);
+
+  expect(defaultFilter(changeset).description).toMatchInlineSnapshot(`
+    "Hello world description
+
+    adeira-source-id: 1234567890
+
+    Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>
+    Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>"
+  `);
+});

--- a/src/monorepo-shipit/src/__tests__/__snapshots__/Integration.test.js.snap
+++ b/src/monorepo-shipit/src/__tests__/__snapshots__/Integration.test.js.snap
@@ -18,6 +18,7 @@ updated-dependencies:
 ...
 
 Signed-off-by: dependabot[bot] <support@github.com>",
+  "descriptionTransformer": [Function],
   "diffs": Set {
     {
       "body": "index 33c6b476374a38f54e7aa3a92d4f9aed68c34624..dd10ce35969c86ef2c5bd8c59e58bb1fea865a58 100644
@@ -118,6 +119,7 @@ updated-dependencies:
 Signed-off-by: dependabot[bot] <support@github.com>
 
 adeira-source-id: cc7b3818e06f95c2732f75f165a2b98c6eeab135",
+  "descriptionTransformer": [Function],
   "diffs": Set {
     {
       "body": "index 33c6b476374a38f54e7aa3a92d4f9aed68c34624..dd10ce35969c86ef2c5bd8c59e58bb1fea865a58 100644
@@ -189,6 +191,7 @@ Changeset {
   "coAuthorLines": [],
   "debugMessages": [],
   "description": "",
+  "descriptionTransformer": [Function],
   "diffs": Set {
     {
       "body": "index 23e30baaaa8e3453263fc15c174d4b11ab3a0a6b..5ddd96afcdf20ad5dc36f140d0caa7baaacfb63c 100644
@@ -221,6 +224,7 @@ Changeset {
     "ADD TRACKING DATA: "adeira-source-id: f1cc780d89183b4304ae5c22536baec6ef9736ba"",
   ],
   "description": "adeira-source-id: f1cc780d89183b4304ae5c22536baec6ef9736ba",
+  "descriptionTransformer": [Function],
   "diffs": Set {
     {
       "body": "index 23e30baaaa8e3453263fc15c174d4b11ab3a0a6b..5ddd96afcdf20ad5dc36f140d0caa7baaacfb63c 100644

--- a/src/monorepo-shipit/src/__tests__/__snapshots__/ShipitConfig.test.js.snap
+++ b/src/monorepo-shipit/src/__tests__/__snapshots__/ShipitConfig.test.js.snap
@@ -10,6 +10,7 @@ Changeset {
   "description": "Test description
 
 adeira-source-id: 1234567890",
+  "descriptionTransformer": [Function],
   "diffs": Set {
     {
       "body": "new file mode 100644
@@ -52,6 +53,7 @@ adeira-source-id: 1234567890
 
 Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>
 Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>",
+  "descriptionTransformer": [Function],
   "diffs": Set {
     {
       "body": "new file mode 100644

--- a/src/monorepo-shipit/src/filters/__tests__/__snapshots__/moveDirectories.test.js.snap
+++ b/src/monorepo-shipit/src/filters/__tests__/__snapshots__/moveDirectories.test.js.snap
@@ -5,6 +5,7 @@ Changeset {
   "coAuthorLines": [],
   "debugMessages": [],
   "description": "MOCKED_HEADER",
+  "descriptionTransformer": [Function],
   "diffs": Set {
     {
       "body": "new file mode 100644

--- a/src/monorepo-shipit/src/filters/__tests__/addTrackingData.test.js
+++ b/src/monorepo-shipit/src/filters/__tests__/addTrackingData.test.js
@@ -16,6 +16,7 @@ it('adds tracking data', () => {
       "coAuthorLines": [],
       "debugMessages": [],
       "description": "Commit description",
+      "descriptionTransformer": [Function],
       "id": "MOCK_COMMIT_ID",
       "subject": "Commit subject",
     }
@@ -31,6 +32,7 @@ it('adds tracking data', () => {
       "description": "Commit description
 
     adeira-source-id: MOCK_COMMIT_ID",
+      "descriptionTransformer": [Function],
       "id": "MOCK_COMMIT_ID",
       "subject": "Commit subject",
     }
@@ -57,6 +59,7 @@ it('adds tracking data with Co-authored-by line', () => {
       ],
       "debugMessages": [],
       "description": "Commit description",
+      "descriptionTransformer": [Function],
       "id": "MOCK_COMMIT_ID",
       "subject": "Commit subject",
     }
@@ -78,6 +81,7 @@ it('adds tracking data with Co-authored-by line', () => {
 
     Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>
     Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>",
+      "descriptionTransformer": [Function],
       "id": "MOCK_COMMIT_ID",
       "subject": "Commit subject",
     }

--- a/src/monorepo-shipit/src/filters/__tests__/stripDescriptions.test.js
+++ b/src/monorepo-shipit/src/filters/__tests__/stripDescriptions.test.js
@@ -15,6 +15,7 @@ it('strips commit descriptions correctly', () => {
       "coAuthorLines": [],
       "debugMessages": [],
       "description": "This description should be stripped.",
+      "descriptionTransformer": [Function],
       "subject": "Commit subject",
     }
   `);
@@ -25,6 +26,7 @@ it('strips commit descriptions correctly', () => {
       "coAuthorLines": [],
       "debugMessages": [],
       "description": "",
+      "descriptionTransformer": [Function],
       "subject": "Commit subject",
     }
   `);

--- a/src/monorepo-shipit/src/iterateConfigs.js
+++ b/src/monorepo-shipit/src/iterateConfigs.js
@@ -45,6 +45,7 @@ function iterateConfigsInPath(
       config.getStrippedFiles ? config.getStrippedFiles() : new Set(),
       branches.source,
       branches.destination,
+      config.transformCommitMessage,
     );
 
     // We collect all the errors but we do not stop the iteration. These errors


### PR DESCRIPTION
This pull request:

- adds the `transformCommitMessage` option to shipit config so consumers can optionally transform their commit messages, such as removing github issues and pull requests from messages

For context currently when running ShipIt it doesn't do anything with commit messages. This is a problem when it exposes internal issues & pull requests that don't exist in the public repo! So, hence this feature add. I can remove them on my end.