### PR TITLE
Shipit: improve CLI interface

### DIFF
--- a/src/monorepo-shipit/bin/shipit.js
+++ b/src/monorepo-shipit/bin/shipit.js
@@ -3,8 +3,7 @@
 // @flow
 
 import chalk from 'chalk';
-import commandLineArgs from 'command-line-args';
-import { invariant } from '@adeira/js';
+import { program as commander } from 'commander';
 
 import iterateConfigs from '../src/iterateConfigs';
 import createClonePhase from '../src/phases/createClonePhase';
@@ -15,44 +14,26 @@ import createVerifyRepoPhase from '../src/phases/createVerifyRepoPhase';
 import createPushPhase from '../src/phases/createPushPhase';
 import type { Phase } from '../types.flow';
 
-// yarn monorepo-babel-node src/monorepo-shipit/bin/shipit.js
-// yarn monorepo-babel-node src/monorepo-shipit/bin/shipit.js --config-filter="/abacus.js"
+// yarn monorepo-babel-node src/monorepo-shipit/bin/shipit.js --help
+// yarn monorepo-babel-node src/monorepo-shipit/bin/shipit.js --committer-name=A --committer-email=B
 
 type ShipitCLIType = {
   +configFilter: string,
   +configDir: string,
-  +committerName?: string,
-  +committerEmail?: string,
+  +committerName: string,
+  +committerEmail: string,
 };
 
-const options: ShipitCLIType = commandLineArgs(
-  [
-    {
-      // This option allows us to grep subset of config files. Especially useful when running the
-      // Shipit binary locally for testing purposes.
-      name: 'config-filter',
-      type: String,
-      defaultValue: '/*.js',
-    },
-    {
-      name: 'config-dir',
-      type: String,
-      defaultValue: './.shipit',
-    },
-    {
-      name: 'committer-name',
-      type: String,
-    },
-    {
-      name: 'committer-email',
-      type: String,
-    },
-  ],
-  { camelCase: true },
-);
+commander
+  .version(require('./../package.json').version)
+  .description('Export a monorepo to multiple git repositories')
+  .requiredOption('--config-filter <glob>', 'Glob pattern to filter config files', '/*.js')
+  .requiredOption('--config-dir <path>', 'Path to the directory with config files', './.shipit')
+  .requiredOption('--committer-name <name>', 'Name of the committer')
+  .requiredOption('--committer-email <email>', 'Email of the committer');
 
-invariant(options.committerName != null, 'committer-name is required');
-invariant(options.committerEmail != null, 'committer-email is required');
+commander.parse();
+const options: ShipitCLIType = commander.opts();
 
 process.env.SHIPIT_COMMITTER_EMAIL = options.committerEmail;
 process.env.SHIPIT_COMMITTER_NAME = options.committerName;

--- a/src/monorepo-shipit/package.json
+++ b/src/monorepo-shipit/package.json
@@ -22,7 +22,7 @@
     "@adeira/shell-command": "^0.1.0",
     "@babel/runtime": "^7.22.3",
     "chalk": "^4.1.2",
-    "command-line-args": "^5.2.1",
+    "commander": "^10.0.1",
     "fast-levenshtein": "^3.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,7 +297,7 @@ __metadata:
     "@adeira/shell-command": ^0.1.0
     "@babel/runtime": ^7.22.3
     chalk: ^4.1.2
-    command-line-args: ^5.2.1
+    commander: ^10.0.1
     fast-levenshtein: ^3.0.0
   bin:
     monorepo-importit: bin/importit.js
@@ -7568,13 +7568,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-back@npm:^3.0.1, array-back@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "array-back@npm:3.1.0"
-  checksum: 7205004fcd0f9edd926db921af901b083094608d5b265738d0290092f9822f73accb468e677db74c7c94ef432d39e5ed75a7b1786701e182efb25bbba9734209
-  languageName: node
-  linkType: hard
-
 "array-find-index@npm:^1.0.1":
   version: 1.0.2
   resolution: "array-find-index@npm:1.0.2"
@@ -9374,22 +9367,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"command-line-args@npm:^5.2.1":
-  version: 5.2.1
-  resolution: "command-line-args@npm:5.2.1"
-  dependencies:
-    array-back: ^3.1.0
-    find-replace: ^3.0.0
-    lodash.camelcase: ^4.3.0
-    typical: ^4.0.0
-  checksum: e759519087be3cf2e86af8b9a97d3058b4910cd11ee852495be881a067b72891f6a32718fb685ee6d41531ab76b2b7bfb6602f79f882cd4b7587ff1e827982c7
-  languageName: node
-  linkType: hard
-
 "commander@npm:7, commander@npm:^7.2.0":
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
   checksum: 53501cbeee61d5157546c0bef0fedb6cdfc763a882136284bed9a07225f09a14b82d2a84e7637edfd1a679fb35ed9502fd58ef1d091e6287f60d790147f68ddc
+  languageName: node
+  linkType: hard
+
+"commander@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "commander@npm:10.0.1"
+  checksum: 436901d64a818295803c1996cd856621a74f30b9f9e28a588e726b2b1670665bccd7c1a77007ebf328729f0139838a88a19265858a0fa7a8728c4656796db948
   languageName: node
   linkType: hard
 
@@ -12601,15 +12589,6 @@ __metadata:
     make-dir: ^3.0.2
     pkg-dir: ^4.1.0
   checksum: 1e61c2e64f5c0b1c535bd85939ae73b0e5773142713273818cc0b393ee3555fb0fd44e1a5b161b8b6c3e03e98c2fcc9c227d784850a13a90a8ab576869576817
-  languageName: node
-  linkType: hard
-
-"find-replace@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "find-replace@npm:3.0.0"
-  dependencies:
-    array-back: ^3.0.1
-  checksum: 6b04bcfd79027f5b84aa1dfe100e3295da989bdac4b4de6b277f4d063e78f5c9e92ebc8a1fec6dd3b448c924ba404ee051cc759e14a3ee3e825fa1361025df08
   languageName: node
   linkType: hard
 
@@ -16513,13 +16492,6 @@ __metadata:
   dependencies:
     p-locate: ^5.0.0
   checksum: 72eb661788a0368c099a184c59d2fee760b3831c9c1c33955e8a19ae4a21b4116e53fa736dc086cdeb9fce9f7cc508f2f92d2d3aae516f133e16a2bb59a39f5a
-  languageName: node
-  linkType: hard
-
-"lodash.camelcase@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "lodash.camelcase@npm:4.3.0"
-  checksum: cb9227612f71b83e42de93eccf1232feeb25e705bdb19ba26c04f91e885bfd3dd5c517c4a97137658190581d3493ea3973072ca010aab7e301046d90740393d1
   languageName: node
   linkType: hard
 
@@ -23317,13 +23289,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
-  languageName: node
-  linkType: hard
-
-"typical@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "typical@npm:4.0.0"
-  checksum: a242081956825328f535e6195a924240b34daf6e7fdb573a1809a42b9f37fb8114fa99c7ab89a695e0cdb419d4149d067f6723e4b95855ffd39c6c4ca378efb3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The previous solution was good enough when the tool was used internally but now I see the need to have a better CLI interface. This not only provides better out-of-the box validations but also supports `--help` option.

I've also improved the Importit interface to support `--pull-request` option (instead of repo URL and PR number). I believe it's more natural to just copy the PR URL and use it.