### PR TITLE
Rossum hooks: add new `fetchRossumAPI` function

### DIFF
--- a/src/rossum-hooks/src/sync-queues/index.js
+++ b/src/rossum-hooks/src/sync-queues/index.js
@@ -1,74 +1,17 @@
 // @flow
 
-// TODO: use `node:https` when supported (https://github.com/facebook/flow/issues/9028)
-import https from 'https';
-// TODO: use `node:url` when supported (https://github.com/facebook/flow/issues/9028)
-import { URL } from 'url'; // eslint-disable-line n/prefer-global/url
-
+import createMessage from '../utils/createMessage';
+import fetchRossumAPI from '../utils/fetchRossumAPI';
 import type { WebhookResponse } from '../types';
-
-type ParsedBaseUrl = {
-  +protocol: string,
-  +hostname: string,
-  +basePath: string,
-};
-
-function parseBaseUrl(baseUrl: string): ParsedBaseUrl {
-  const url = new URL(baseUrl);
-  const basePath = url.pathname === '/' ? '/api/v1' : url.pathname;
-  return {
-    protocol: url.protocol,
-    hostname: url.hostname,
-    basePath: basePath,
-  };
-}
-
-function httpRequest(options: $FlowFixMe, data: $FlowFixMe = null): Promise<$FlowFixMe> {
-  return new Promise((resolve, reject) => {
-    const req = https.request(options, (res) => {
-      let body = '';
-      res.on('data', (chunk) => {
-        body += chunk;
-      });
-      res.on('end', () => {
-        if (res.statusCode >= 200 && res.statusCode < 300) {
-          resolve(JSON.parse(body));
-        } else {
-          reject(
-            new Error(`Request failed with status code ${res.statusCode}: ${res.statusMessage}`),
-          );
-        }
-      });
-    });
-
-    req.on('error', (error) => {
-      reject(error);
-    });
-
-    if (data) {
-      req.write(data);
-    }
-
-    req.end();
-  });
-}
 
 function fetchQueue(
   authToken: string,
   queueId: string | number,
-  parsedBaseUrl: ParsedBaseUrl,
+  baseUrl: string,
 ): Promise<$FlowFixMe> {
-  const options = {
-    protocol: parsedBaseUrl.protocol,
-    hostname: parsedBaseUrl.hostname,
-    path: `${parsedBaseUrl.basePath}/queues/${queueId}`,
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${authToken}`,
-    },
-  };
-
-  return httpRequest(options);
+  return fetchRossumAPI<$FlowFixMe>(`${baseUrl}/queues/${queueId}`, {
+    headers: { Authorization: `Bearer ${authToken}` },
+  });
 }
 
 function extractSchemaUrl(queue: $FlowFixMe): string {
@@ -76,63 +19,46 @@ function extractSchemaUrl(queue: $FlowFixMe): string {
 }
 
 export async function rossum_hook_request_handler({
-  rossum_authorization_token,
-  base_url,
+  rossum_authorization_token: rossumAuthorizationToken,
+  base_url: baseUrl,
 }: $FlowFixMe): Promise<WebhookResponse> {
-  const parsedBaseUrl = parseBaseUrl(base_url);
-
   const fetchQueueId = 693393; // TODO: make configurable
   const updateQueueIds = [
     824803, // TODO: make configurable
-    824948, // TODO: make configurable
+    825096, // TODO: make configurable
   ];
 
   // Fetch the fetchQueue and extract its schema URL
-  const fetchedQueue = await fetchQueue(rossum_authorization_token, fetchQueueId, parsedBaseUrl);
+  const fetchedQueue = await fetchQueue(rossumAuthorizationToken, fetchQueueId, baseUrl);
   const fetchSchemaUrl = extractSchemaUrl(fetchedQueue);
 
   // Fetch the schema
-  const fetchSchemaOptions = {
-    protocol: parsedBaseUrl.protocol,
-    hostname: parsedBaseUrl.hostname,
-    path: `${parsedBaseUrl.basePath}/schemas/${fetchSchemaUrl.split('/').pop()}`,
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${rossum_authorization_token}`,
-    },
-  };
-  const fetchedSchema = await httpRequest(fetchSchemaOptions);
+  const fetchedSchema: $FlowFixMe = await fetchRossumAPI(
+    `${baseUrl}/schemas/${fetchSchemaUrl.split('/').pop()}`,
+    { headers: { Authorization: `Bearer ${rossumAuthorizationToken}` } },
+  );
 
   // Fetch the updateQueues and extract their schema URLs
   const updateQueues = await Promise.all(
-    updateQueueIds.map((queueId) => fetchQueue(rossum_authorization_token, queueId, parsedBaseUrl)),
+    updateQueueIds.map((queueId) => fetchQueue(rossumAuthorizationToken, queueId, baseUrl)),
   );
   const updateSchemaUrls = updateQueues.map(extractSchemaUrl);
 
   // Update the other schemas
   const updatePromises = updateSchemaUrls.map((schemaUrl) => {
-    const updateSchemaOptions = {
-      protocol: parsedBaseUrl.protocol,
-      hostname: parsedBaseUrl.hostname,
-      path: `${parsedBaseUrl.basePath}/schemas/${schemaUrl.split('/').pop()}`,
+    return fetchRossumAPI(`${baseUrl}/schemas/${schemaUrl.split('/').pop()}`, {
       method: 'PUT',
-      headers: {
-        'Authorization': `Bearer ${rossum_authorization_token}`,
-        'Content-Type': 'application/json',
-      },
-    };
-
-    const updateData = JSON.stringify({
-      name: fetchedSchema.name,
-      content: fetchedSchema.content,
+      headers: { Authorization: `Bearer ${rossumAuthorizationToken}` },
+      body: JSON.stringify({
+        name: fetchedSchema.name,
+        content: fetchedSchema.content,
+      }),
     });
-
-    return httpRequest(updateSchemaOptions, updateData);
   });
 
   await Promise.all(updatePromises);
 
   return {
-    messages: [],
+    messages: [createMessage('info', 'Queues were updated successfully.')],
   };
 }

--- a/src/rossum-hooks/src/utils/fetchRossumAPI.js
+++ b/src/rossum-hooks/src/utils/fetchRossumAPI.js
@@ -1,0 +1,74 @@
+// @flow
+
+// TODO: use `node:https` when supported (https://github.com/facebook/flow/issues/9028)
+import https from 'https';
+
+type FetchOptions = {
+  body?: string,
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
+  headers?: FetchOptionsHeaders,
+};
+
+type FetchOptionsHeaders = {
+  +'Authorization'?: string,
+  +'Content-Length'?: string,
+  +'Content-Type'?: string,
+};
+
+// Technically, this function is similar to `fetch` but there are two main differences:
+//
+// 1) it uses `https` module from Node.js under the hood (which is required by Rossum API)
+// 2) it doesn't return a promise that resolves to a `Response` object but rather to a JSON object (for convenience)
+export default function fetchRossumAPI<Response = { ... }>(
+  url: string,
+  options: FetchOptions = {},
+): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      url,
+      {
+        ...options,
+        headers: {
+          'Content-Type': 'application/json',
+          ...options.headers,
+        },
+      },
+      (res) => {
+        let body = '';
+
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+
+        res.on('end', () => {
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            // resolve({
+            //   ok: true,
+            //   status: res.statusCode,
+            //   statusText: res.statusMessage,
+            //   json: () => Promise.resolve(JSON.parse(body)),
+            //   text: () => Promise.resolve(body),
+            // });
+            resolve(JSON.parse(body));
+          } else {
+            reject(
+              new Error(
+                `Request to ${url} failed with status code ${res.statusCode}: ${res.statusMessage} (${body})`,
+              ),
+            );
+          }
+        });
+      },
+    );
+
+    req.on('error', (error) => {
+      reject(error);
+    });
+
+    if (options.body != null) {
+      req.write(options.body);
+    }
+
+    req.end();
+  });
+}


### PR DESCRIPTION
The purpose is to mimic `fetch` API instead of using `https` module from Node.js directly (which doesn't have such friendly interface).

This change also includes `sync-queues` hook migration to use this new function.