### PR TITLE
Renovate: use rebase when conflicted

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
     'replacements:all',
     'workarounds:all',
   ],
+  rebaseWhen: 'conflicted',
   prHourlyLimit: 0,
   prConcurrentLimit: 0,
   dependencyDashboard: true,


### PR DESCRIPTION
Just a test to see whether this setting would work together with merge queues and whether it would reduce the load on our CI.