### PR TITLE
Abacus Tools ext: replace `Inter` font with `Arial`

### DIFF
--- a/src/abacus-tools/pages/_app.css
+++ b/src/abacus-tools/pages/_app.css
@@ -1,12 +1,9 @@
-/* https://github.com/rsms/inter */
-@import url('https://rsms.me/inter/inter.css');
-
 * {
   box-sizing: border-box;
 }
 
 :root {
-  font-family: 'Inter', sans-serif;
+  font-family: Arial, sans-serif;
 }
 
 body {


### PR DESCRIPTION
This is to make the loading as fast as possible. No need for custom font.