### PR TITLE
Abacus Tools ext: use `font-variant-numeric: tabular-nums`

### DIFF
--- a/src/abacus-tools/src/components/Jumbo.js
+++ b/src/abacus-tools/src/components/Jumbo.js
@@ -10,6 +10,7 @@ export default function Jumbo(props: { +children: string }): Node {
           font-size: 8em;
           font-weight: bold;
           transition: all 0.5s ease-in-out;
+          font-variant-numeric: tabular-nums;
         }
       `}</style>
 


### PR DESCRIPTION
This is to prevent the time font horizontal jumping.