### PR TITLE
CI: drop support for Node.js 19

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -25,8 +25,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # We support only Node.js versions with "LTS" and "Current" status.
         # See: https://nodejs.dev/en/about/releases/
-        node-version: [18.x, 19.x, 20.x]
+        # See: https://github.com/nodejs/Release
+        node-version: [18.x, 20.x]
 
     steps:
       # https://github.com/actions/checkout


### PR DESCRIPTION
See: https://github.com/nodejs/Release