### PR TITLE
Homebrew: add `rossum-dmv2-analyze` formula

### DIFF
--- a/src/homebrew-universe/Formula/rossum-dmv2-analyze.rb
+++ b/src/homebrew-universe/Formula/rossum-dmv2-analyze.rb
@@ -1,0 +1,32 @@
+# Documentation: https://docs.brew.sh/Formula-Cookbook
+#                https://rubydoc.brew.sh/Formula
+class Adeira/Universe/RossumDmv2Analyze < Formula
+  desc ""
+  homepage ""
+  url "https://github.com/adeira/universe/releases/download/rossum-dmv2-analyze%2F0.1.0/aarch64-apple-darwin"
+  sha256 "768c6133125bf59dab23e6585b8f03544c66470891c08c0cc8ae53ae14aa385c"
+  license ""
+
+  # depends_on "cmake" => :build
+
+  def install
+    # ENV.deparallelize  # if your formula fails when building in parallel
+    # Remove unrecognized options if warned by configure
+    # https://rubydoc.brew.sh/Formula.html#std_configure_args-instance_method
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+    # system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+  end
+
+  test do
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! For Homebrew/homebrew-core
+    # this will need to be a test that verifies the functionality of the
+    # software. Run the test with `brew test adeira/universe/rossum-dmv2-analyze`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "false"
+  end
+end

--- a/src/homebrew-universe/README.md
+++ b/src/homebrew-universe/README.md
@@ -4,6 +4,10 @@
 
 Or `brew tap adeira/universe` and then `brew install <formula>`.
 
+Available formulae:
+
+- `brew install adeira/universe/rossum-dmv2-analyze`
+
 ## Documentation
 
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).


### PR DESCRIPTION
It's most likely broken, just an init commit.