### PR TITLE
Rossum SA ext: correctly refine observed nodes

### DIFF
--- a/src/rossum-sa-extension/manifest.json
+++ b/src/rossum-sa-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Rossum SA extension",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Adds additional functionality to Rossum UI for developers (SA).",
   "icons": {
     "16": "icons/16-crunch.png",

--- a/src/rossum-sa-extension/package.json
+++ b/src/rossum-sa-extension/package.json
@@ -10,7 +10,7 @@
     "directory": "src/rossum-sa-extension"
   },
   "license": "MIT",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "commonjs",
   "sideEffects": false
 }

--- a/src/rossum-sa-extension/popup/popup.html
+++ b/src/rossum-sa-extension/popup/popup.html
@@ -23,7 +23,7 @@
       </label>
     </div>
 
-    <div class="info">0.4.0</div>
+    <div class="info">0.4.1</div>
 
     <script src="popup.js"></script>
   </body>

--- a/src/rossum-sa-extension/scripts/annotation-schema-ids.js
+++ b/src/rossum-sa-extension/scripts/annotation-schema-ids.js
@@ -39,9 +39,19 @@ function displaySchemaID(node /*: $FlowFixMe */) {
   node.appendChild(div);
 }
 
-const observer = new MutationObserver((mutations) => {
-  const checkAddedNode = (addedNode /*: $FlowFixMe */) => {
-    if (addedNode?.hasAttribute('data-sa-extension-schema-id')) {
+function isElementNode(node /*: any */) /*: node is Element */ {
+  // https://developer.mozilla.org/en-US/docs/Web/API/Node
+  // https://developer.mozilla.org/en-US/docs/Web/API/Element
+  return node.nodeType === Node.ELEMENT_NODE;
+}
+
+const observer = new MutationObserver((mutations /*: Array<MutationRecord> */) => {
+  const checkAddedNode = (addedNode /*: Node */) => {
+    if (!isElementNode(addedNode)) {
+      return;
+    }
+
+    if (addedNode.hasAttribute('data-sa-extension-schema-id')) {
       displaySchemaID(addedNode);
     }
 


### PR DESCRIPTION
This fixes some internal errors popping up (especially on the `/statistics` page).
