### PR TITLE
Flow: cleanup deprecated predicates `%checks`

### DIFF
--- a/src/flow-config-parser/src/utils.js
+++ b/src/flow-config-parser/src/utils.js
@@ -1,7 +1,7 @@
 // @flow strict
 
 // https://github.com/facebook/flow/issues/6904
-export function isListSection(sectionName: string | null): boolean %checks {
+export function isListSection(sectionName: string | null): boolean {
   return (
     sectionName === 'declarations' ||
     sectionName === 'ignore' ||

--- a/src/js/src/isNumeric.js
+++ b/src/js/src/isNumeric.js
@@ -1,5 +1,5 @@
 // @flow strict
 
-export default function isNumeric(value: mixed): boolean %checks {
+export default function isNumeric(value: mixed): boolean {
   return !isNaN(parseFloat(value)) && isFinite(value);
 }

--- a/src/js/src/isObjectEmpty.js
+++ b/src/js/src/isObjectEmpty.js
@@ -2,7 +2,7 @@
 
 import isObject from './isObject';
 
-export default function isObjectEmpty(obj: mixed): boolean %checks {
+export default function isObjectEmpty(obj: mixed): boolean {
   // https://stackoverflow.com/a/32108184/3135248
 
   return (

--- a/src/monorepo-scanner/src/isValidLicense.js
+++ b/src/monorepo-scanner/src/isValidLicense.js
@@ -1,7 +1,7 @@
 // @flow strict
 
 // This function makes sure we use the correct licence formats without any unexpected modifications.
-export default function isValidLicense(license: string): boolean %checks {
+export default function isValidLicense(license: string): boolean {
   return mitLicenseRegexp.test(license) || unlicenseRegexp.test(license);
 }
 

--- a/src/monorepo-utils/src/glob.js
+++ b/src/monorepo-utils/src/glob.js
@@ -37,11 +37,11 @@ type GlobOptions = $ReadOnly<{
   absolute?: boolean,
 }>;
 
-function isWindowsPath(globPattern: GlobPattern): boolean %checks {
+function isWindowsPath(globPattern: GlobPattern): boolean {
   return /^[a-z]:\\/i.test(globPattern);
 }
 
-function isValidRoot(globPattern: GlobPattern, options?: GlobOptions): boolean %checks {
+function isValidRoot(globPattern: GlobPattern, options?: GlobOptions): boolean {
   return !(globPattern.startsWith('/') && options?.root === undefined);
 }
 

--- a/src/relay/src/internal/helpers.js
+++ b/src/relay/src/internal/helpers.js
@@ -2,18 +2,15 @@
 
 import type { UploadableMap, Variables } from 'relay-runtime';
 
-export const isMutation = (request: $FlowFixMe): boolean %checks => {
+export const isMutation = (request: $FlowFixMe): boolean => {
   return request.operationKind === 'mutation';
 };
 
-export const isQuery = (request: $FlowFixMe): boolean %checks => {
+export const isQuery = (request: $FlowFixMe): boolean => {
   return request.operationKind === 'query';
 };
 
-export const forceFetch = (cacheConfig: { +force?: ?boolean }): boolean %checks => {
-  /* $FlowFixMe[sketchy-null-bool] This comment suppresses an error when
-   * upgrading Flow to version 0.174.0. To see the error delete this comment
-   * and run Flow. */
+export const forceFetch = (cacheConfig: { +force?: ?boolean }): boolean => {
   return !!(cacheConfig && cacheConfig.force);
 };
 


### PR DESCRIPTION
See: https://flow.org/en/docs/types/type-guards/