### PR TITLE
Babel preset: remove experimental support for throw expressions

### DIFF
--- a/src/babel-preset-adeira/CHANGELOG.md
+++ b/src/babel-preset-adeira/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Remove experimental support for throw expressions (https://github.com/tc39/proposal-throw-expressions)
+
 # 4.0.0
 
 Breaking changes ahead!

--- a/src/babel-preset-adeira/package.json
+++ b/src/babel-preset-adeira/package.json
@@ -14,7 +14,6 @@
   "type": "commonjs",
   "sideEffects": false,
   "dependencies": {
-    "@babel/plugin-proposal-throw-expressions": "^7.23.3",
     "@babel/plugin-transform-flow-strip-types": "^7.23.3",
     "@babel/plugin-transform-runtime": "^7.23.4",
     "@babel/preset-env": "^7.23.5",

--- a/src/babel-preset-adeira/src/__tests__/__fixtures__/features/throw-expressions.js
+++ b/src/babel-preset-adeira/src/__tests__/__fixtures__/features/throw-expressions.js
@@ -1,3 +1,0 @@
-/* eslint-disable */
-
-() => throw new Error('');

--- a/src/babel-preset-adeira/src/__tests__/__snapshots__/configs.test.js.snap
+++ b/src/babel-preset-adeira/src/__tests__/__snapshots__/configs.test.js.snap
@@ -16,8 +16,7 @@ exports[`emits correct config for target 'flow' and environment '{"browsers":["l
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": true
@@ -40,8 +39,7 @@ exports[`emits correct config for target 'flow' and environment '{"browsers":["l
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": true
@@ -64,8 +62,7 @@ exports[`emits correct config for target 'flow' and environment '{"node":"curren
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": true
@@ -88,8 +85,7 @@ exports[`emits correct config for target 'flow' and environment '{"node":"curren
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": true
@@ -112,8 +108,7 @@ exports[`emits correct config for target 'flow' and environment 'undefined' and 
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": true
@@ -136,8 +131,7 @@ exports[`emits correct config for target 'flow' and environment 'undefined' and 
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": true
@@ -180,7 +174,6 @@ exports[`emits correct config for target 'js' and environment '{"browsers":["las
         "allowDeclareFields": true
       }
     ],
-    "@babel/plugin-proposal-throw-expressions",
     [
       "@babel/plugin-transform-runtime",
       {
@@ -197,8 +190,7 @@ exports[`emits correct config for target 'js' and environment '{"browsers":["las
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": false
@@ -241,7 +233,6 @@ exports[`emits correct config for target 'js' and environment '{"browsers":["las
         "allowDeclareFields": true
       }
     ],
-    "@babel/plugin-proposal-throw-expressions",
     [
       "@babel/plugin-transform-runtime",
       {
@@ -258,8 +249,7 @@ exports[`emits correct config for target 'js' and environment '{"browsers":["las
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": false
@@ -299,7 +289,6 @@ exports[`emits correct config for target 'js' and environment '{"node":"current"
         "allowDeclareFields": true
       }
     ],
-    "@babel/plugin-proposal-throw-expressions",
     [
       "@babel/plugin-transform-runtime",
       {
@@ -316,8 +305,7 @@ exports[`emits correct config for target 'js' and environment '{"node":"current"
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": false
@@ -357,7 +345,6 @@ exports[`emits correct config for target 'js' and environment '{"node":"current"
         "allowDeclareFields": true
       }
     ],
-    "@babel/plugin-proposal-throw-expressions",
     [
       "@babel/plugin-transform-runtime",
       {
@@ -374,8 +361,7 @@ exports[`emits correct config for target 'js' and environment '{"node":"current"
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": false
@@ -415,7 +401,6 @@ exports[`emits correct config for target 'js' and environment 'undefined' and re
         "allowDeclareFields": true
       }
     ],
-    "@babel/plugin-proposal-throw-expressions",
     [
       "@babel/plugin-transform-runtime",
       {
@@ -432,8 +417,7 @@ exports[`emits correct config for target 'js' and environment 'undefined' and re
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": false
@@ -473,7 +457,6 @@ exports[`emits correct config for target 'js' and environment 'undefined' and re
         "allowDeclareFields": true
       }
     ],
-    "@babel/plugin-proposal-throw-expressions",
     [
       "@babel/plugin-transform-runtime",
       {
@@ -490,8 +473,7 @@ exports[`emits correct config for target 'js' and environment 'undefined' and re
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": false
@@ -534,7 +516,6 @@ exports[`emits correct config for target 'js-esm' and environment '{"browsers":[
         "allowDeclareFields": true
       }
     ],
-    "@babel/plugin-proposal-throw-expressions",
     [
       "@babel/plugin-transform-runtime",
       {
@@ -551,8 +532,7 @@ exports[`emits correct config for target 'js-esm' and environment '{"browsers":[
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": false
@@ -595,7 +575,6 @@ exports[`emits correct config for target 'js-esm' and environment '{"browsers":[
         "allowDeclareFields": true
       }
     ],
-    "@babel/plugin-proposal-throw-expressions",
     [
       "@babel/plugin-transform-runtime",
       {
@@ -612,8 +591,7 @@ exports[`emits correct config for target 'js-esm' and environment '{"browsers":[
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": false
@@ -653,7 +631,6 @@ exports[`emits correct config for target 'js-esm' and environment '{"node":"curr
         "allowDeclareFields": true
       }
     ],
-    "@babel/plugin-proposal-throw-expressions",
     [
       "@babel/plugin-transform-runtime",
       {
@@ -670,8 +647,7 @@ exports[`emits correct config for target 'js-esm' and environment '{"node":"curr
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": false
@@ -711,7 +687,6 @@ exports[`emits correct config for target 'js-esm' and environment '{"node":"curr
         "allowDeclareFields": true
       }
     ],
-    "@babel/plugin-proposal-throw-expressions",
     [
       "@babel/plugin-transform-runtime",
       {
@@ -728,8 +703,7 @@ exports[`emits correct config for target 'js-esm' and environment '{"node":"curr
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": false
@@ -769,7 +743,6 @@ exports[`emits correct config for target 'js-esm' and environment 'undefined' an
         "allowDeclareFields": true
       }
     ],
-    "@babel/plugin-proposal-throw-expressions",
     [
       "@babel/plugin-transform-runtime",
       {
@@ -786,8 +759,7 @@ exports[`emits correct config for target 'js-esm' and environment 'undefined' an
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": false
@@ -827,7 +799,6 @@ exports[`emits correct config for target 'js-esm' and environment 'undefined' an
         "allowDeclareFields": true
       }
     ],
-    "@babel/plugin-proposal-throw-expressions",
     [
       "@babel/plugin-transform-runtime",
       {
@@ -844,8 +815,7 @@ exports[`emits correct config for target 'js-esm' and environment 'undefined' an
           "enums": true
         }
       ],
-      "flowComments",
-      "throwExpressions"
+      "flowComments"
     ]
   },
   "retainLines": false

--- a/src/babel-preset-adeira/src/__tests__/__snapshots__/transformations.test.js.snap
+++ b/src/babel-preset-adeira/src/__tests__/__snapshots__/transformations.test.js.snap
@@ -730,18 +730,6 @@ module.exports = function (a: AnyObject, ...rest: Array<any>): AnyObject {
 };
 `;
 
-exports[`matches expected output: throw-expressions.js: flow 1`] = `
-~~~~~~~~~~ INPUT ~~~~~~~~~~
-/* eslint-disable */
-
-() => throw new Error('');
-
-~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-/* eslint-disable */
-
-() => throw new Error('');
-`;
-
 exports[`matches expected output: warning-global.js: flow 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 /* eslint-disable */

--- a/src/babel-preset-adeira/src/index.js
+++ b/src/babel-preset-adeira/src/index.js
@@ -54,7 +54,6 @@ module.exports = (
     'jsx',
     ['flow', { enums: true }],
     'flowComments',
-    'throwExpressions', // https://github.com/tc39/proposal-throw-expressions
   ];
   let retainLines = false;
 
@@ -95,7 +94,6 @@ module.exports = (
           allowDeclareFields: true,
         },
       ],
-      '@babel/plugin-proposal-throw-expressions',
       // Transform runtime plugin turns common chunks of code into imports. However, this
       // requires `@babel/runtime` dependency thus we are requiring it as well.
       // See: https://babeljs.io/docs/en/babel-plugin-transform-runtime

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,7 +110,6 @@ __metadata:
   dependencies:
     "@adeira/fixtures-tester": "npm:^1.1.1"
     "@adeira/monorepo-utils": "npm:^0.12.0"
-    "@babel/plugin-proposal-throw-expressions": "npm:^7.23.3"
     "@babel/plugin-transform-flow-strip-types": "npm:^7.23.3"
     "@babel/plugin-transform-runtime": "npm:^7.23.4"
     "@babel/preset-env": "npm:^7.23.5"
@@ -1311,18 +1310,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-throw-expressions@npm:^7.23.3":
-  version: 7.23.3
-  resolution: "@babel/plugin-proposal-throw-expressions@npm:7.23.3"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.22.5"
-    "@babel/plugin-syntax-throw-expressions": "npm:^7.23.3"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 4d9cfef05c69e1f9e8be54fd437aec1c285c457b5c48fd7ccfb4bf070da522e402b30d647f76cd3b6d37b5feed37cf02cd17bca3c99e2153371f06968b8b567f
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-syntax-async-generators@npm:^7.8.4":
   version: 7.8.4
   resolution: "@babel/plugin-syntax-async-generators@npm:7.8.4"
@@ -1562,17 +1549,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 69822772561706c87f0a65bc92d0772cea74d6bc0911537904a676d5ff496a6d3ac4e05a166d8125fce4a16605bace141afc3611074e170a994e66e5397787f3
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-throw-expressions@npm:^7.23.3":
-  version: 7.23.3
-  resolution: "@babel/plugin-syntax-throw-expressions@npm:7.23.3"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.22.5"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: f18e914e422c30dec3f6a6551636b07da2ec8da534e2cde70bb29b6f66c2edcacb6884025b651fbcbcb332de93034220e375213b7dcae54317fd1850ae57c7f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
See: https://github.com/tc39/proposal-throw-expressions