### PR TITLE
Jest: run tests with `--randomize`

### DIFF
--- a/src/eslint-plugin-sx/src/rules/__tests__/__snapshots__/no-unused-stylesheet.test.js.snap
+++ b/src/eslint-plugin-sx/src/rules/__tests__/__snapshots__/no-unused-stylesheet.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reports correct lines and columns: SX function "styles" was not used anywhere in the code. 1`] = `
+exports[`reports correct lines and columns: SX function "styles" was not used anywhere in the code. cd1c7998551695468f5a28bc16e77ce4 1`] = `
 "  1 |
   2 | import sx from '@adeira/sx';
 > 3 | const styles = sx.create({
@@ -16,7 +16,7 @@ exports[`reports correct lines and columns: SX function "styles" was not used an
   8 |"
 `;
 
-exports[`reports correct lines and columns: Unknown stylesheet used: bbb (not defined anywhere) 1`] = `
+exports[`reports correct lines and columns: Unknown stylesheet used: bbb (not defined anywhere) c1333fff2a93d48fb0265f41ce127150 1`] = `
 "  2 | import sx from '@adeira/sx';
   3 | export default function TestComponent() {
 > 4 |   return <div className={styles('bbb')} />
@@ -26,7 +26,16 @@ exports[`reports correct lines and columns: Unknown stylesheet used: bbb (not de
   7 |   aaa: { color: blue }"
 `;
 
-exports[`reports correct lines and columns: Unused stylesheet: aaa (defined via "styles" variable) 1`] = `
+exports[`reports correct lines and columns: Unused stylesheet: aaa (defined via "styles" variable) c1333fff2a93d48fb0265f41ce127150 1`] = `
+"  5 | }
+  6 | const styles = sx.create({
+> 7 |   aaa: { color: blue }
+    |   ^^^^^^^^^^^^^^^^^^^^
+  8 | });
+  9 |"
+`;
+
+exports[`reports correct lines and columns: Unused stylesheet: aaa (defined via "styles" variable) cd1c7998551695468f5a28bc16e77ce4 1`] = `
 "  2 | import sx from '@adeira/sx';
   3 | const styles = sx.create({
 > 4 |   aaa: {
@@ -37,13 +46,4 @@ exports[`reports correct lines and columns: Unused stylesheet: aaa (defined via 
     | ^^^^
   7 | });
   8 |"
-`;
-
-exports[`reports correct lines and columns: Unused stylesheet: aaa (defined via "styles" variable) 2`] = `
-"  5 | }
-  6 | const styles = sx.create({
-> 7 |   aaa: { color: blue }
-    |   ^^^^^^^^^^^^^^^^^^^^
-  8 | });
-  9 |"
 `;

--- a/src/eslint-plugin-sx/src/rules/__tests__/no-unused-stylesheet.test.js
+++ b/src/eslint-plugin-sx/src/rules/__tests__/no-unused-stylesheet.test.js
@@ -1,6 +1,7 @@
 // @flow
 
 import path from 'path';
+import crypto from 'crypto';
 import { RuleTester } from 'eslint';
 import { codeFrameColumns } from '@babel/code-frame';
 import testFixtures from '@adeira/eslint-fixtures-tester';
@@ -92,6 +93,8 @@ test.each(invalidTests)('reports correct lines and columns', (test) => {
         start: { line: error.line, column: error.column },
         end: { line: error.endLine, column: error.endColumn },
       }),
-    ).toMatchSnapshot(error.message);
+    ).toMatchSnapshot(
+      `${error.message} ${crypto.createHash('md5').update(test.code).digest('hex')}`,
+    );
   }
 });

--- a/src/fixtures-tester/src/__tests__/__snapshots__/generateTestsFromFixtures.test.js.snap
+++ b/src/fixtures-tester/src/__tests__/__snapshots__/generateTestsFromFixtures.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`matches expected output: aaa.error.txt 1`] = `
+exports[`matches expected output: aaa.error.txt: 0e36b7aaa66fbd8dd6d8cb74d23b12e7 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 aaa error
 
@@ -10,7 +10,7 @@ THROWN EXCEPTION:
 Error: correctly failed
 `;
 
-exports[`matches expected output: aaa.txt 1`] = `
+exports[`matches expected output: aaa.txt: 0c3085de02c3066d7de61f02619755c9 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 aaa
 
@@ -19,7 +19,7 @@ AAA
 
 `;
 
-exports[`matches expected output: aaa.txt 2`] = `
+exports[`matches expected output: aaa.txt: 192f24c0409592a919d79b6e5f4b1b0f 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 aaa
 
@@ -28,7 +28,16 @@ AAA
 
 `;
 
-exports[`matches expected output: aaa.txt 3`] = `
+exports[`matches expected output: aaa.txt: custom snapshot name (no modifications) 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+aaa
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+aaa
+
+`;
+
+exports[`matches expected output: aaa.txt: d53b86044151463c2175e421c25b2af0 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 aaa
 
@@ -49,16 +58,7 @@ aaa
 }
 `;
 
-exports[`matches expected output: aaa.txt: custom snapshot name (no modifications) 1`] = `
-~~~~~~~~~~ INPUT ~~~~~~~~~~
-aaa
-
-~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-aaa
-
-`;
-
-exports[`matches expected output: bbb.txt 1`] = `
+exports[`matches expected output: bbb.txt: 0c3085de02c3066d7de61f02619755c9 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 bbb
 
@@ -67,7 +67,7 @@ BBB
 
 `;
 
-exports[`matches expected output: bbb.txt 2`] = `
+exports[`matches expected output: bbb.txt: 192f24c0409592a919d79b6e5f4b1b0f 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 bbb
 
@@ -76,7 +76,16 @@ BBB
 
 `;
 
-exports[`matches expected output: bbb.txt 3`] = `
+exports[`matches expected output: bbb.txt: custom snapshot name (no modifications) 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+bbb
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+bbb
+
+`;
+
+exports[`matches expected output: bbb.txt: d53b86044151463c2175e421c25b2af0 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 bbb
 
@@ -95,13 +104,4 @@ bbb
     }
   }
 }
-`;
-
-exports[`matches expected output: bbb.txt: custom snapshot name (no modifications) 1`] = `
-~~~~~~~~~~ INPUT ~~~~~~~~~~
-bbb
-
-~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-bbb
-
 `;

--- a/src/flow-config-parser/src/__tests__/__snapshots__/parse.test.js.snap
+++ b/src/flow-config-parser/src/__tests__/__snapshots__/parse.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`matches expected output: .flowconfig.declarations 1`] = `
+exports[`matches expected output: .flowconfig.declarations: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 ; https://flow.org/en/docs/config/declarations/
 
@@ -30,7 +30,7 @@ exports[`matches expected output: .flowconfig.declarations 1`] = `
 }
 `;
 
-exports[`matches expected output: .flowconfig.empty 1`] = `
+exports[`matches expected output: .flowconfig.empty: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
@@ -48,7 +48,7 @@ exports[`matches expected output: .flowconfig.empty 1`] = `
 }
 `;
 
-exports[`matches expected output: .flowconfig.empty-sections 1`] = `
+exports[`matches expected output: .flowconfig.empty-sections: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 [declarations]
 
@@ -83,7 +83,7 @@ exports[`matches expected output: .flowconfig.empty-sections 1`] = `
 }
 `;
 
-exports[`matches expected output: .flowconfig.empty-sections-comments 1`] = `
+exports[`matches expected output: .flowconfig.empty-sections-comments: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 # This is a comment
   # This is a comment
@@ -179,7 +179,7 @@ exports[`matches expected output: .flowconfig.empty-sections-comments 1`] = `
 }
 `;
 
-exports[`matches expected output: .flowconfig.ignore 1`] = `
+exports[`matches expected output: .flowconfig.ignore: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 ; https://flow.org/en/docs/config/ignore/
 
@@ -215,7 +215,7 @@ exports[`matches expected output: .flowconfig.ignore 1`] = `
 }
 `;
 
-exports[`matches expected output: .flowconfig.include 1`] = `
+exports[`matches expected output: .flowconfig.include: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 ; https://flow.org/en/docs/config/include/
 
@@ -245,7 +245,7 @@ exports[`matches expected output: .flowconfig.include 1`] = `
 }
 `;
 
-exports[`matches expected output: .flowconfig.invalid 1`] = `
+exports[`matches expected output: .flowconfig.invalid: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 💩 Purpose of this fixture is to see how it behaves when the config is
 💩 crazy invalid (and potentially improve the behavior).
@@ -299,7 +299,7 @@ exports[`matches expected output: .flowconfig.invalid 1`] = `
 }
 `;
 
-exports[`matches expected output: .flowconfig.options 1`] = `
+exports[`matches expected output: .flowconfig.options: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 ; https://flow.org/en/docs/config/options/
 
@@ -438,7 +438,7 @@ well_formed_exports.includes=<PROJECT_ROOT>/dirB
 }
 `;
 
-exports[`matches expected output: .flowconfig.rollout_duplicate_names 1`] = `
+exports[`matches expected output: .flowconfig.rollout_duplicate_names: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 [rollouts]
 foo=20% on, 80% off
@@ -461,7 +461,7 @@ foo=30% on, 70% off
 }
 `;
 
-exports[`matches expected output: .flowconfig.rollouts-ignore 1`] = `
+exports[`matches expected output: .flowconfig.rollouts-ignore: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 [ignore]
 (ignore_everything=true).*\\.js
@@ -493,7 +493,7 @@ experimental.well_formed_exports=true
 }
 `;
 
-exports[`matches expected output: .flowconfig.rollouts-options 1`] = `
+exports[`matches expected output: .flowconfig.rollouts-options: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 [rollouts]
 formed_exports=80% on, 20% off
@@ -520,7 +520,7 @@ formed_exports=80% on, 20% off
 }
 `;
 
-exports[`matches expected output: .flowconfig.universe 1`] = `
+exports[`matches expected output: .flowconfig.universe: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 ; https://flow.org/en/docs/config/ignore/
 [ignore]
@@ -647,7 +647,7 @@ experimental.const_params=true
 }
 `;
 
-exports[`matches expected output: .flowconfig.untyped 1`] = `
+exports[`matches expected output: .flowconfig.untyped: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 ; https://flow.org/en/docs/config/untyped/
 
@@ -677,7 +677,7 @@ exports[`matches expected output: .flowconfig.untyped 1`] = `
 }
 `;
 
-exports[`matches expected output: .flowconfig.version 1`] = `
+exports[`matches expected output: .flowconfig.version: 515ab48df9e80c22c850f6267da38407 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 ; https://flow.org/en/docs/config/version/
 

--- a/src/monorepo-shipit/src/__tests__/__snapshots__/parsePatch.test.js.snap
+++ b/src/monorepo-shipit/src/__tests__/__snapshots__/parsePatch.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`matches expected output: chmod.patch 1`] = `
+exports[`matches expected output: chmod.patch: fc2e9a4b8e951064d53311a538e6ea9a 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 diff --git a/src/platform/terraform-gitlab-project-cluster/environment_scope.sh b/src/platform/terraform-gitlab-project-cluster/environment_scope.sh
 old mode 100644
@@ -22,7 +22,7 @@ new mode 100755
 
 `;
 
-exports[`matches expected output: diff-in-diff.patch 1`] = `
+exports[`matches expected output: diff-in-diff.patch: fc2e9a4b8e951064d53311a538e6ea9a 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 diff --git a/unicode.txt b/unicode.txt
 index 1f60525b30fedbea3660714fb6198053f3457168..485cb7f13081f005c2f83890e155c0fcf4b16cd6 100644
@@ -88,7 +88,7 @@ index 1f60525b30fedbea3660714fb6198053f3457168..485cb7f13081f005c2f83890e155c0fc
 
 `;
 
-exports[`matches expected output: file-delete.patch 1`] = `
+exports[`matches expected output: file-delete.patch: fc2e9a4b8e951064d53311a538e6ea9a 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 diff --git a/bbb.txt b/bbb.txt
 deleted file mode 100644
@@ -116,7 +116,7 @@ index dbee0265d31298531773537e6e37e4fd1ee71d62..00000000000000000000000000000000
 
 `;
 
-exports[`matches expected output: file-modify-no-eol.patch 1`] = `
+exports[`matches expected output: file-modify-no-eol.patch: fc2e9a4b8e951064d53311a538e6ea9a 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 diff --git a/aaa.txt b/aaa.txt
 index 72943a16fb2c8f38f9dde202b7a70ccc19c52f34..01f02e32ce8a128dd7b1d16a45f2eff66ec23c2d 100644
@@ -144,7 +144,7 @@ index 72943a16fb2c8f38f9dde202b7a70ccc19c52f34..01f02e32ce8a128dd7b1d16a45f2eff6
 
 `;
 
-exports[`matches expected output: file-new.patch 1`] = `
+exports[`matches expected output: file-new.patch: fc2e9a4b8e951064d53311a538e6ea9a 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 diff --git a/aaa.txt b/aaa.txt
 new file mode 100644
@@ -170,7 +170,7 @@ index 0000000000000000000000000000000000000000..72943a16fb2c8f38f9dde202b7a70ccc
 
 `;
 
-exports[`matches expected output: file-rename.patch 1`] = `
+exports[`matches expected output: file-rename.patch: fc2e9a4b8e951064d53311a538e6ea9a 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 diff --git a/aaa.txt b/aaa.txt
 deleted file mode 100644
@@ -217,7 +217,7 @@ index 0000000000000000000000000000000000000000..01f02e32ce8a128dd7b1d16a45f2eff6
 
 `;
 
-exports[`matches expected output: files-modify.patch 1`] = `
+exports[`matches expected output: files-modify.patch: fc2e9a4b8e951064d53311a538e6ea9a 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 diff --git a/bbb.txt b/bbb.txt
 index 01f02e32ce8a128dd7b1d16a45f2eff66ec23c2d..dbee0265d31298531773537e6e37e4fd1ee71d62 100644
@@ -264,7 +264,7 @@ index b2a7546679fdf79ca0eb7bfbee1e1bb342487380..66bde67332bef8dfb2c70698c51bf37b
 
 `;
 
-exports[`matches expected output: lfs-removal.patch 1`] = `
+exports[`matches expected output: lfs-removal.patch: fc2e9a4b8e951064d53311a538e6ea9a 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 diff --git a/.yarn/cache/@adeira-js-0.9.0.tgz b/.yarn/cache/@adeira-js-0.9.0.tgz
 deleted file mode 100644
@@ -294,7 +294,7 @@ index f2572f9c9d2f2ab4f2a61695a09ee50430f8ccbe..00000000000000000000000000000000
 
 `;
 
-exports[`matches expected output: nasty.patch 1`] = `
+exports[`matches expected output: nasty.patch: fc2e9a4b8e951064d53311a538e6ea9a 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 diff --git a/nasty.txt b/nasty.txt
 index 044b936071f4da77efec5b15794785ecde6b6791..e316f565a5386462ecbfd01d245888570a00ca85 100644
@@ -320,7 +320,7 @@ index 044b936071f4da77efec5b15794785ecde6b6791..e316f565a5386462ecbfd01d24588857
 
 `;
 
-exports[`matches expected output: unicode.patch 1`] = `
+exports[`matches expected output: unicode.patch: fc2e9a4b8e951064d53311a538e6ea9a 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 diff --git a/unicode.txt b/unicode.txt
 new file mode 100644

--- a/src/monorepo-shipit/src/__tests__/__snapshots__/parsePatchHeader.test.js.snap
+++ b/src/monorepo-shipit/src/__tests__/__snapshots__/parsePatchHeader.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`matches expected output: co-authored-by.header 1`] = `
+exports[`matches expected output: co-authored-by.header: edbd2b06ce66db276adbf8d3936612a9 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 From 160feaf6d2637b22216987d1f95b96d585a838a6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Martin=20Zl=C3=A1mal?= <mrtnzlml@gmail.com>
@@ -23,7 +23,7 @@ Co-authored-by: Trond Bergquist <trond_bergquist@hotmail.com>
 }
 `;
 
-exports[`matches expected output: co-authored-by-multiple.header 1`] = `
+exports[`matches expected output: co-authored-by-multiple.header: edbd2b06ce66db276adbf8d3936612a9 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 From 160feaf6d2637b22216987d1f95b96d585a838a6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Martin=20Zl=C3=A1mal?= <mrtnzlml@gmail.com>
@@ -48,7 +48,7 @@ Co-authored-by: Patricia Bergquist <patricia_bergquist@hotmail.com>
 }
 `;
 
-exports[`matches expected output: multiline-subject.header 1`] = `
+exports[`matches expected output: multiline-subject.header: edbd2b06ce66db276adbf8d3936612a9 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 From 93ee65de02e77c52eb9d677b859554b40253bafa Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Martin=20Zl=C3=A1mal?= <adeira@example.com>
@@ -68,7 +68,7 @@ Subject: [PATCH] Docs: add Relay and GraphQL related videos from our internal
 }
 `;
 
-exports[`matches expected output: simple.header 1`] = `
+exports[`matches expected output: simple.header: edbd2b06ce66db276adbf8d3936612a9 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 From bf0a8783cf416f796659e60fe735bba98e676e67 Mon Sep 17 00:00:00 2001
 From: Automator <adeira@example.com>
@@ -89,7 +89,7 @@ Formerly known as '@mrtnzlml/relay'
 }
 `;
 
-exports[`matches expected output: unicode.header 1`] = `
+exports[`matches expected output: unicode.header: edbd2b06ce66db276adbf8d3936612a9 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Martin=20Zl=C3=A1mal?= <adeira@example.com>

--- a/src/sx-design/src/Link/__tests__/Link.test.js
+++ b/src/sx-design/src/Link/__tests__/Link.test.js
@@ -10,6 +10,19 @@ import fbt from 'fbt';
 import Link from '../Link';
 import { initFbt, renderWithoutProviders } from '../../test-utils';
 
+function isElementNode(node /*: any */) /*: node is Element */ {
+  // https://developer.mozilla.org/en-US/docs/Web/API/Node
+  // https://developer.mozilla.org/en-US/docs/Web/API/Element
+  return node.nodeType === Node.ELEMENT_NODE;
+}
+
+function getChild(container: HTMLElement): Element {
+  if (isElementNode(container.firstChild)) {
+    return container.firstChild;
+  }
+  throw new Error('Unexpected node type');
+}
+
 beforeEach(() => {
   initFbt();
 });
@@ -23,52 +36,10 @@ it('renders the link as expected - internal link', () => {
     </Link>,
   );
 
-  expect(container).toMatchInlineSnapshot(`
-.f6wvk {
-  color: rgba(var(--sx-link-text-color));
-}
-.T4SJ0 {
-  cursor: pointer;
-}
-.eJqht {
-  text-decoration-color: transparent;
-}
-._4GrjhO {
-  text-decoration-line: underline;
-}
-._2aVmeo {
-  text-decoration-style: solid;
-}
-.WV8t {
-  text-decoration-thickness: 0.05em;
-}
-@media (prefers-reduced-motion: no-preference) {
-  ._2FqB21._2FqB21 {
-    transition: text-decoration-color 300ms;
-  }
-}
-.gy8aG:hover {
-  opacity: 1;
-}
-._39mXIW:hover {
-  text-decoration-color: inherit;
-}
-._4eR9Ri {
-  opacity: 1;
-}
-._1traoH {
-  opacity: 0.9;
-}
-
-<div>
-  <a
-    class="f6wvk T4SJ0 eJqht _4GrjhO _2aVmeo WV8t _2FqB21 gy8aG _39mXIW _1traoH"
-    href="/assets/yadada"
-  >
-    internal link
-  </a>
-</div>
-`);
+  const child = getChild(container);
+  expect(child).toHaveAttribute('href', '/assets/yadada');
+  expect(child).not.toHaveAttribute('rel');
+  expect(child).not.toHaveAttribute('target');
 });
 
 it('renders the link as expected - internal link with target _blank', () => {
@@ -80,15 +51,10 @@ it('renders the link as expected - internal link with target _blank', () => {
     </Link>,
   );
 
-  // $FlowFixMe[prop-missing]: `attributes` is missing in the types but it works
-  expect(container.firstChild?.attributes).toMatchInlineSnapshot(`
-NamedNodeMap {
-  "class": "f6wvk T4SJ0 eJqht _4GrjhO _2aVmeo WV8t _2FqB21 gy8aG _39mXIW _1traoH",
-  "href": "/assets/yadada",
-  "rel": "noreferrer noopener",
-  "target": "_blank",
-}
-`);
+  const child = getChild(container);
+  expect(child).toHaveAttribute('href', '/assets/yadada');
+  expect(child).toHaveAttribute('rel', 'noreferrer noopener');
+  expect(child).toHaveAttribute('target', '_blank');
 });
 
 it('renders the link as expected - external link', () => {
@@ -100,48 +66,8 @@ it('renders the link as expected - external link', () => {
     </Link>,
   );
 
-  expect(container).toMatchInlineSnapshot(`
-.f6wvk {
-  color: rgba(var(--sx-link-text-color));
-}
-.T4SJ0 {
-  cursor: pointer;
-}
-.eJqht {
-  text-decoration-color: transparent;
-}
-._4GrjhO {
-  text-decoration-line: underline;
-}
-._2aVmeo {
-  text-decoration-style: solid;
-}
-.WV8t {
-  text-decoration-thickness: 0.05em;
-}
-@media (prefers-reduced-motion: no-preference) {
-  ._2FqB21._2FqB21 {
-    transition: text-decoration-color 300ms;
-  }
-}
-.gy8aG:hover {
-  opacity: 1;
-}
-._39mXIW:hover {
-  text-decoration-color: inherit;
-}
-._1traoH {
-  opacity: 0.9;
-}
-
-<div>
-  <a
-    class="f6wvk T4SJ0 eJqht _4GrjhO _2aVmeo WV8t _2FqB21 gy8aG _39mXIW _1traoH"
-    href="https://localhost"
-    rel="noreferrer noopener"
-  >
-    external link
-  </a>
-</div>
-`);
+  const child = getChild(container);
+  expect(child).toHaveAttribute('href', 'https://localhost');
+  expect(child).toHaveAttribute('rel', 'noreferrer noopener');
+  expect(child).not.toHaveAttribute('target');
 });

--- a/src/sx-design/src/Modal/__tests__/Modal.test.js
+++ b/src/sx-design/src/Modal/__tests__/Modal.test.js
@@ -14,6 +14,14 @@ beforeEach(() => {
   initFbt();
 });
 
+afterEach(() => {
+  // Jest does not clean the JSDOM document after each test run! It only clears the DOM after all
+  // tests inside an entire file are completed.
+  //
+  // See: https://stackoverflow.com/a/50800473/3135248
+  document.getElementsByTagName('html')[0].innerHTML = '';
+});
+
 function TestingComponent(props: { +onClose?: () => void }) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -39,7 +47,7 @@ function TestingComponent(props: { +onClose?: () => void }) {
 it('renders Modal component without any problems', async () => {
   const { getByText, queryByText } = render(<TestingComponent />);
 
-  // By default the modal is closed and the modal content is not being rendered:
+  // By default, the modal is closed and the modal content is not being rendered:
   expect(queryByText('Modal title')).not.toBeInTheDocument();
   expect(queryByText('modal body')).not.toBeInTheDocument();
 

--- a/src/sx/src/__tests__/keyframes.test.js
+++ b/src/sx/src/__tests__/keyframes.test.js
@@ -34,7 +34,7 @@ it('returns hashed name of the keyframe', () => {
   );
   expect(hashedName).toMatchInlineSnapshot(`"wOIjT"`);
   expect(hashedName2).toMatchInlineSnapshot(`"_1kFWtB"`);
-  spy.mockReset();
+  spy.mockRestore();
 });
 
 it('works with percentages', () => {
@@ -55,7 +55,7 @@ it('works with percentages', () => {
     hashedName,
     '@keyframes _3B4dOq {0% {transform:translateX(-300px);}100% {transform:translateX(0);}75%,80% {transform:translateX(50px);}}',
   );
-  spy.mockReset();
+  spy.mockRestore();
 });
 
 it('generates same hash for similar object', () => {

--- a/src/x/src/executors/tests.rs
+++ b/src/x/src/executors/tests.rs
@@ -7,6 +7,9 @@ pub fn run(trailing_args: &Vec<&str>) -> anyhow::Result<()> {
     execute_command(
         create_command(JEST_BIN)
             .expect("Jest binary doesn't exist")
+            // https://jestjs.io/docs/cli
+            .arg("--workerThreads")
+            .arg("--randomize")
             .arg("--showSeed")
             .arg("--config")
             .arg(JEST_CONFIG)


### PR DESCRIPTION
This arg helps to uncover some leaky tests which I've fixed. It was also necessary to change the logic of some test generators and their snapshots to be stable with `--randomize` (by generating test hash instead of relying just on the snapshot name and ordering).