### PR TITLE
Dockerfile builder: remove `abacus-docs`

### DIFF
--- a/.github/workflows/dockerfile-builder.yml
+++ b/.github/workflows/dockerfile-builder.yml
@@ -25,7 +25,6 @@ jobs:
         project:
           - 'abacus'
           - 'abacus-backoffice'
-          - 'abacus-docs'
           - 'abacus-kochka'
           - 'abacus-tools'
           - 'mrtnzlml-meta'
@@ -38,10 +37,6 @@ jobs:
             projectPath: './src/abacus-backoffice'
             projectDockerfile: './src/abacus-backoffice/Dockerfile'
             projectImageName: 'adeira/abacus-backoffice'
-          - project: abacus-docs
-            projectPath: './src/abacus-docs'
-            projectDockerfile: './src/abacus-docs/Dockerfile'
-            projectImageName: 'adeira/abacus-docs'
           - project: abacus-kochka
             projectPath: './src/abacus-kochka'
             projectDockerfile: './src/abacus-kochka/Dockerfile'


### PR DESCRIPTION
No longer exists.